### PR TITLE
Feature/temporal descendants

### DIFF
--- a/src/main/scala/com/raphtory/algorithms/Ancestors.scala
+++ b/src/main/scala/com/raphtory/algorithms/Ancestors.scala
@@ -1,0 +1,49 @@
+package com.raphtory.algorithms
+
+import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row}
+
+class Ancestors(path:String,
+                seed:String,
+                time:Long,
+                delta:Long=Long.MaxValue,
+                directed:Boolean=true)
+  extends GraphAlgorithm{
+
+  override def algorithm(graph: GraphPerspective): Unit = {
+    graph.step({
+      vertex =>
+        if (vertex.ID() == checkID(seed)) {
+          val edges = (if (directed) vertex.getInEdges() else vertex.getEdges())
+            .filter(e => e.earliestActivity().time < time)
+            .filter(e=> e.lastActivityBefore(time).time > time - delta)
+          edges.foreach({
+            e =>
+              vertex.messageNeighbour(e.ID(), e.lastActivityBefore(time).time)
+          })
+          vertex.setState("ancestor",false)
+        }
+    })
+      .iterate({
+        vertex =>
+          val latestTime = vertex.messageQueue[Long]
+            .max
+          vertex.setState("ancestor",true)
+          val inEdges = (if (directed) vertex.getInEdges() else vertex.getEdges())
+            .filter(e => e.earliestActivity().time < latestTime)
+            .filter(e=> e.lastActivityBefore(time).time > latestTime - delta)
+          inEdges.foreach({
+            e =>
+              vertex.messageNeighbour(e.ID(), e.lastActivityBefore(latestTime).time)
+          })
+      },executeMessagedOnly = true, iterations = 100)
+      .select(vertex => Row(vertex.getPropertyOrElse("name",vertex.ID()), vertex.getStateOrElse[Boolean]("ancestor",false)))
+      .writeTo(path)
+  }
+}
+object Ancestors {
+  def apply(path:String, seed:String,
+            time:Long,
+            delta:Long=Long.MaxValue,
+            directed:Boolean=true)
+  = new Ancestors(path, seed, time, delta, directed)
+}

--- a/src/main/scala/com/raphtory/algorithms/Descendants.scala
+++ b/src/main/scala/com/raphtory/algorithms/Descendants.scala
@@ -27,7 +27,6 @@ class Descendants(path:String, seed:String, time:Long, delta:Long=Long.MaxValue,
           .filter(e => e.firstActivityAfter(earliestTime).time < earliestTime + delta)
           outEdges.foreach({
             e =>
-              println(earliestTime,e.history())
               vertex.messageNeighbour(e.ID(), e.firstActivityAfter(earliestTime).time)
           })
       },executeMessagedOnly = true, iterations = 100)

--- a/src/main/scala/com/raphtory/algorithms/Descendants.scala
+++ b/src/main/scala/com/raphtory/algorithms/Descendants.scala
@@ -2,7 +2,13 @@ package com.raphtory.algorithms
 
 import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row}
 
-class Descendants(path:String, seed:String, time:Long, delta:Long=Long.MaxValue, directed:Boolean=true) extends GraphAlgorithm{
+class Descendants(path:String,
+                  seed:String,
+                  time:Long,
+                  delta:Long=Long.MaxValue,
+                  directed:Boolean=true)
+  extends GraphAlgorithm{
+
   override def algorithm(graph: GraphPerspective): Unit = {
     graph.step({
       vertex =>
@@ -36,5 +42,10 @@ class Descendants(path:String, seed:String, time:Long, delta:Long=Long.MaxValue,
 }
 
 object Descendants {
-  def apply(path:String, seed:String, time:Long, delta:Long=Long.MaxValue, directed:Boolean=true) = new Descendants(path, seed, time, delta, directed)
+  def apply(path:String,
+            seed:String,
+            time:Long,
+            delta:Long=Long.MaxValue,
+            directed:Boolean=true)
+  = new Descendants(path, seed, time, delta, directed)
 }

--- a/src/main/scala/com/raphtory/algorithms/Descendants.scala
+++ b/src/main/scala/com/raphtory/algorithms/Descendants.scala
@@ -1,0 +1,41 @@
+package com.raphtory.algorithms
+
+import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row}
+
+class Descendants(path:String, seed:String, time:Long, delta:Long=Long.MaxValue, directed:Boolean=true) extends GraphAlgorithm{
+  override def algorithm(graph: GraphPerspective): Unit = {
+    graph.step({
+      vertex =>
+        if (vertex.ID() == checkID(seed)) {
+          val edges = (if (directed) vertex.getOutEdges() else vertex.getEdges())
+            .filter(e => e.latestActivity().time > time)
+            .filter(e => e.firstActivityAfter(time).time < time + delta)
+          edges.foreach({
+            e =>
+              vertex.messageNeighbour(e.ID(), e.firstActivityAfter(time).time)
+          })
+          vertex.setState("descendant",false)
+        }
+    })
+      .iterate({
+        vertex =>
+          val earliestTime = vertex.messageQueue[Long]
+            .min
+          vertex.setState("descendant",true)
+          val outEdges = (if (directed) vertex.getOutEdges() else vertex.getEdges())
+            .filter(e => e.latestActivity().time > earliestTime)
+          .filter(e => e.firstActivityAfter(earliestTime).time < earliestTime + delta)
+          outEdges.foreach({
+            e =>
+              println(earliestTime,e.history())
+              vertex.messageNeighbour(e.ID(), e.firstActivityAfter(earliestTime).time)
+          })
+      },executeMessagedOnly = true, iterations = 100)
+      .select(vertex => Row(vertex.getPropertyOrElse("name",vertex.ID()), vertex.getStateOrElse[Boolean]("descendant",false)))
+      .writeTo(path)
+  }
+}
+
+object Descendants {
+  def apply(path:String, seed:String, time:Long, delta:Long=Long.MaxValue, directed:Boolean=true) = new Descendants(path, seed, time, delta, directed)
+}

--- a/src/main/scala/com/raphtory/core/implementations/pojograph/entities/external/PojoExEntity.scala
+++ b/src/main/scala/com/raphtory/core/implementations/pojograph/entities/external/PojoExEntity.scala
@@ -10,6 +10,7 @@ abstract class PojoExEntity(entity: PojoEntity, view: PojoGraphLens) extends Ent
   def Type() = entity.getType
 
   def firstActivityAfter(time: Long) = history.filter(k => k.time >= time).minBy(x => x.time)
+  def lastActivityBefore(time: Long) = history.filter(k => k.time <= time).maxBy(x => x.time)
   def latestActivity()               = history.head
   def earliestActivity()             = history.minBy(k => k.time)
 

--- a/src/main/scala/com/raphtory/core/model/graph/visitor/EntityVisitor.scala
+++ b/src/main/scala/com/raphtory/core/model/graph/visitor/EntityVisitor.scala
@@ -7,6 +7,7 @@ abstract class EntityVisitor {
   def Type()
 
   def firstActivityAfter(time: Long):HistoricEvent
+  def lastActivityBefore(time: Long):HistoricEvent
   def latestActivity():HistoricEvent
   def earliestActivity():HistoricEvent
 


### PR DESCRIPTION
Added lastActivityBefore() function for entity visitors which is the counterpart to firstActivityAfter()
Added "Descendants" algorithm which starting from a node and a point in time, goes out along time-respecting out edges to find nodes which could have been influenced by starting node
"Ancestors" which goes in the opposite direction

Would anyone with some scala/java experience know if there's a nicer way of writing this which avoids all the if/else options? Factory pattern seems an overkill but I feel like I'm repeating code with the two classes... @Alnaimi @BenSteer @imanehaf maybe?