### PR TITLE
Feature/distinctiveness centrality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ logs
 /src/main/scala/com/raphtory/dev/algorithms/test.scala
 
 testupdates.txt
+
+# local files
+src/main/scala/com/raphtory/lotr

--- a/src/main/scala/com/raphtory/algorithms/Distinctiveness.scala
+++ b/src/main/scala/com/raphtory/algorithms/Distinctiveness.scala
@@ -1,0 +1,105 @@
+package com.raphtory.algorithms
+
+import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row}
+import com.raphtory.core.model.graph.visitor.Vertex
+
+/**
+Description
+  Distinctiveness centrality measures importance of a node through how it
+  bridges different parts of the graph, approximating this by connections to
+  low degree nodes. For more info read ref https://journals.plos.org/plosone/article/file?id=10.1371/journal.pone.0233276&type=printable
+
+Parameters
+  path String : output folder path location
+  alpha Double : tuning exponent, default value is 1.0
+
+Returns
+  ID (Long) : This is the ID of the vertex
+  D1 - D5 (Double) : centrality value according to each version of distinctiveness centrality
+
+Notes
+  Edges here are treated as undirected, weight treated as number of edge occurrences if not supplied
+
+  **/
+
+import scala.math.{log10, pow}
+
+class Distinctiveness(path:String, alpha:Double=1.0) extends GraphAlgorithm{
+
+  override def algorithm(graph: GraphPerspective): Unit = {
+    val N = graph.nodeCount().toDouble
+    graph.step({
+      vertex =>
+        val edges = vertex.getEdges()
+        val degree = edges.size
+        val weight = edges.map(e => pow(e.getPropertyOrElse("weight", e.history().size), alpha)).sum
+        val nodeWeight = edges.map(e => e.getPropertyOrElse("weight",e.history().size).toDouble).sum
+        vertex.messageAllNeighbours(vertex.ID(), degree, weight, nodeWeight)
+    })
+      .select({
+        vertex =>
+          val messages = vertex.messageQueue[(Long, Int, Double, Double)]
+          val D1c = D1(vertex, messages, N, alpha)
+          val D2c = D2(vertex, messages, N, alpha)
+          val D3c = D3(vertex, messages, N, alpha)
+          val D4c = D4(vertex, messages, N, alpha)
+          val D5c = D5(vertex, messages, N, alpha)
+          Row(vertex.getPropertyOrElse("name",vertex.ID()),D1c, D2c, D3c, D4c, D5c)
+      })
+      .writeTo(path)
+  }
+
+  def D1(vertex: Vertex, messages:List[(Long, Int, Double, Double)], noNodes:Double, alpha:Double): Double = {
+    messages.map({
+      msg =>
+        val edge = vertex.getEdge(msg._1).head
+        val edgeWeight = edge.getPropertyOrElse("weight",edge.history().size).toDouble
+        val degree = msg._2.toDouble
+//        val nodeWeight = msg._3
+        edgeWeight*(log10(noNodes-1) - alpha*log10(degree))
+    }).sum
+  }
+
+  def D2(vertex: Vertex, messages:List[(Long, Int, Double, Double)], noNodes:Double, alpha:Double): Double = {
+    messages.map({
+      msg =>
+        val degree = msg._2
+        (log10(noNodes-1) - alpha*log10(degree))
+    }).sum
+  }
+
+  def D3(vertex: Vertex, messages:List[(Long, Int, Double, Double)], noNodes:Double, alpha:Double): Double = {
+    messages.map({
+      msg =>
+        val edge = vertex.getEdge(msg._1).head
+        val edgeWeight = edge.getPropertyOrElse("weight",edge.history().size).toDouble
+        val nodePowerWeight = msg._3
+        val nodeSumWeight = msg._4
+        edgeWeight * (log10(nodeSumWeight/2.0) - log10(nodePowerWeight - pow(edgeWeight,alpha)+1))
+    }).sum
+  }
+
+  def D4(vertex: Vertex, messages:List[(Long, Int, Double, Double)], noNodes:Double, alpha:Double): Double = {
+    messages.map({
+      msg =>
+        val edge = vertex.getEdge(msg._1).head
+        val edgeWeight = edge.getPropertyOrElse("weight",edge.history().size)
+        val degree = msg._2
+        val nodeWeight = msg._3
+        pow(edgeWeight,alpha + 1)/nodeWeight
+    }).sum
+  }
+
+  def D5(vertex: Vertex, messages:List[(Long, Int, Double, Double)], noNodes:Double, alpha:Double): Double = {
+    messages.map({
+      msg =>
+        val degree = msg._2
+        pow(degree,-1*alpha)
+    }).sum
+  }
+
+}
+
+object Distinctiveness {
+  def apply(path:String, alpha:Double=1.0) = new Distinctiveness(path,alpha)
+}

--- a/src/main/scala/com/raphtory/core/implementations/pojograph/entities/external/PojoExVertex.scala
+++ b/src/main/scala/com/raphtory/core/implementations/pojograph/entities/external/PojoExVertex.scala
@@ -45,6 +45,8 @@ class PojoExVertex(private val v: PojoVertex,
   def getOutEdge(id: Long,after:Long=0L,before:Long=Long.MaxValue): Option[Edge] = individualEdge(internalOutgoingEdges,after,before,id)
   //In edges individual
   def getInEdge(id: Long,after:Long=0L,before:Long=Long.MaxValue): Option[Edge]  = individualEdge(internalIncomingEdges,after,before,id)
+  // edge individual
+  def getEdge(id: Long,after:Long=0L,before:Long=Long.MaxValue): Option[Edge]  = individualEdge(internalIncomingEdges++internalOutgoingEdges,after,before,id)
 
 
   override def explodeEdges(after: Long, before: Long): List[ExplodedEdge] = getEdges(after, before).flatMap(_.explode())

--- a/src/main/scala/com/raphtory/core/model/graph/visitor/Vertex.scala
+++ b/src/main/scala/com/raphtory/core/model/graph/visitor/Vertex.scala
@@ -34,6 +34,8 @@ trait Vertex extends EntityVisitor {
   def getOutEdge(id: Long,after:Long=0L,before:Long=Long.MaxValue): Option[Edge]
   //individual in edge
   def getInEdge(id: Long,after:Long=0L,before:Long=Long.MaxValue): Option[Edge]
+  //individual in edge
+  def getEdge(id: Long,after:Long=0L,before:Long=Long.MaxValue): Option[Edge]
 
   //all edges
   def explodeEdges(after:Long=0L,before:Long=Long.MaxValue): List[ExplodedEdge]


### PR DESCRIPTION
Implemented Distinctiveness Centrality and checked that this produces correct results.

I have been using doubles here since just a single messaging step occurs and the mathematical functions like math.pow and math.log10 use doubles, is it cool to send doubles over the wire? (seem to remember that floats are preferred but this is not messaging heavy as an algo).

Finally, as part of this I added a getEdge() fn in the PojoExVertex class, it seems fine but I am nervous of editing the I N T E R N A L S