### PR TITLE
Make Algorithm API composable

### DIFF
--- a/src/main/scala/com/raphtory/algorithms/Ancestors.scala
+++ b/src/main/scala/com/raphtory/algorithms/Ancestors.scala
@@ -9,7 +9,7 @@ class Ancestors(path:String,
                 directed:Boolean=true)
   extends GraphAlgorithm{
 
-  override def algorithm(graph: GraphPerspective): GraphPerspective = {
+  override def apply(graph: GraphPerspective): GraphPerspective = {
     graph.step({
       vertex =>
         if (vertex.ID() == checkID(seed)) {

--- a/src/main/scala/com/raphtory/algorithms/Ancestors.scala
+++ b/src/main/scala/com/raphtory/algorithms/Ancestors.scala
@@ -1,6 +1,6 @@
 package com.raphtory.algorithms
 
-import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row}
+import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row, Table}
 
 class Ancestors(path:String,
                 seed:String,
@@ -9,37 +9,44 @@ class Ancestors(path:String,
                 directed:Boolean=true)
   extends GraphAlgorithm{
 
-  override def algorithm(graph: GraphPerspective): Unit = {
+  override def graphStage(graph: GraphPerspective): GraphPerspective = {
     graph.step({
       vertex =>
         if (vertex.ID() == checkID(seed)) {
           val edges = (if (directed) vertex.getInEdges() else vertex.getEdges())
             .filter(e => e.earliestActivity().time < time)
-            .filter(e=> e.lastActivityBefore(time).time > time - delta)
+            .filter(e => e.lastActivityBefore(time).time > time - delta)
           edges.foreach({
             e =>
               vertex.messageNeighbour(e.ID(), e.lastActivityBefore(time).time)
           })
-          vertex.setState("ancestor",false)
+          vertex.setState("ancestor", false)
         }
     })
       .iterate({
         vertex =>
           val latestTime = vertex.messageQueue[Long]
             .max
-          vertex.setState("ancestor",true)
+          vertex.setState("ancestor", true)
           val inEdges = (if (directed) vertex.getInEdges() else vertex.getEdges())
             .filter(e => e.earliestActivity().time < latestTime)
-            .filter(e=> e.lastActivityBefore(time).time > latestTime - delta)
+            .filter(e => e.lastActivityBefore(time).time > latestTime - delta)
           inEdges.foreach({
             e =>
               vertex.messageNeighbour(e.ID(), e.lastActivityBefore(latestTime).time)
           })
-      },executeMessagedOnly = true, iterations = 100)
-      .select(vertex => Row(vertex.getPropertyOrElse("name",vertex.ID()), vertex.getStateOrElse[Boolean]("ancestor",false)))
-      .writeTo(path)
+      }, executeMessagedOnly = true, iterations = 100)
+  }
+
+  override def tableStage(graph: GraphPerspective): Table = {
+    graph.select(vertex => Row(vertex.getPropertyOrElse("name", vertex.ID()), vertex.getStateOrElse[Boolean]("ancestor", false)))
+  }
+
+  override def write(table: Table): Unit = {
+    table.writeTo(path)
   }
 }
+
 object Ancestors {
   def apply(path:String, seed:String,
             time:Long,

--- a/src/main/scala/com/raphtory/algorithms/Ancestors.scala
+++ b/src/main/scala/com/raphtory/algorithms/Ancestors.scala
@@ -9,7 +9,7 @@ class Ancestors(path:String,
                 directed:Boolean=true)
   extends GraphAlgorithm{
 
-  override def graphStage(graph: GraphPerspective): GraphPerspective = {
+  override def algorithm(graph: GraphPerspective): GraphPerspective = {
     graph.step({
       vertex =>
         if (vertex.ID() == checkID(seed)) {
@@ -38,7 +38,7 @@ class Ancestors(path:String,
       }, executeMessagedOnly = true, iterations = 100)
   }
 
-  override def tableStage(graph: GraphPerspective): Table = {
+  override def tabularise(graph: GraphPerspective): Table = {
     graph.select(vertex => Row(vertex.getPropertyOrElse("name", vertex.ID()), vertex.getStateOrElse[Boolean]("ancestor", false)))
   }
 

--- a/src/main/scala/com/raphtory/algorithms/BinaryDiffusion.scala
+++ b/src/main/scala/com/raphtory/algorithms/BinaryDiffusion.scala
@@ -1,11 +1,11 @@
 package com.raphtory.algorithms
 
-import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row}
+import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row, Table}
 
 import scala.util.Random
 
 class BinaryDiffusion(infectedNode:Long, seed:Long, outputFolder:String) extends GraphAlgorithm {
-  override def algorithm(graph: GraphPerspective): Unit = {
+  override def graphStage(graph: GraphPerspective): GraphPerspective = {
     val randomiser = if (seed != -1) new Random(seed) else new Random()
     val infectedStatus = "infected"
     graph
@@ -27,10 +27,16 @@ class BinaryDiffusion(infectedNode:Long, seed:Long, outputFolder:String) extends
               edge => if (randomiser.nextBoolean()) edge.send(infectedStatus)
             }
           }
-      }, 100,true)
-      .select(vertex => Row(vertex.ID(), vertex.getStateOrElse("infected", false)))
+      }, 100, true)
+  }
+
+  override def tableStage(graph: GraphPerspective): Table = {
+    graph.select(vertex => Row(vertex.ID(), vertex.getStateOrElse("infected", false)))
       .filter(row => row.get(1) == true)
-      .writeTo(outputFolder)
+  }
+
+  override def write(table: Table): Unit = {
+    table.writeTo(outputFolder)
   }
 }
 

--- a/src/main/scala/com/raphtory/algorithms/BinaryDiffusion.scala
+++ b/src/main/scala/com/raphtory/algorithms/BinaryDiffusion.scala
@@ -5,7 +5,7 @@ import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row,
 import scala.util.Random
 
 class BinaryDiffusion(infectedNode:Long, seed:Long, outputFolder:String) extends GraphAlgorithm {
-  override def graphStage(graph: GraphPerspective): GraphPerspective = {
+  override def algorithm(graph: GraphPerspective): GraphPerspective = {
     val randomiser = if (seed != -1) new Random(seed) else new Random()
     val infectedStatus = "infected"
     graph
@@ -30,7 +30,7 @@ class BinaryDiffusion(infectedNode:Long, seed:Long, outputFolder:String) extends
       }, 100, true)
   }
 
-  override def tableStage(graph: GraphPerspective): Table = {
+  override def tabularise(graph: GraphPerspective): Table = {
     graph.select(vertex => Row(vertex.ID(), vertex.getStateOrElse("infected", false)))
       .filter(row => row.get(1) == true)
   }

--- a/src/main/scala/com/raphtory/algorithms/BinaryDiffusion.scala
+++ b/src/main/scala/com/raphtory/algorithms/BinaryDiffusion.scala
@@ -5,7 +5,7 @@ import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row,
 import scala.util.Random
 
 class BinaryDiffusion(infectedNode:Long, seed:Long, outputFolder:String) extends GraphAlgorithm {
-  override def algorithm(graph: GraphPerspective): GraphPerspective = {
+  override def apply(graph: GraphPerspective): GraphPerspective = {
     val randomiser = if (seed != -1) new Random(seed) else new Random()
     val infectedStatus = "infected"
     graph

--- a/src/main/scala/com/raphtory/algorithms/CBOD.scala
+++ b/src/main/scala/com/raphtory/algorithms/CBOD.scala
@@ -21,8 +21,8 @@ class CBOD(label: String = "label", cutoff: Double = 0.0, output: String = "/tmp
   /**
    Run CBOD algorithm and sets "outlierscore" state
     **/
-  override def algorithm(graph: GraphPerspective): GraphPerspective = {
-      labeler.algorithm(graph)
+  override def apply(graph: GraphPerspective): GraphPerspective = {
+      labeler.apply(graph)
       .step { vertex => //Get neighbors' labels
         val vlabel = vertex.getState[Long](key = label)
         vertex.messageAllNeighbours(vlabel)

--- a/src/main/scala/com/raphtory/algorithms/CBOD.scala
+++ b/src/main/scala/com/raphtory/algorithms/CBOD.scala
@@ -21,8 +21,8 @@ class CBOD(label: String = "label", cutoff: Double = 0.0, output: String = "/tmp
   /**
    Run CBOD algorithm and sets "outlierscore" state
     **/
-  override def graphStage(graph: GraphPerspective): GraphPerspective = {
-      labeler.graphStage(graph)
+  override def algorithm(graph: GraphPerspective): GraphPerspective = {
+      labeler.algorithm(graph)
       .step { vertex => //Get neighbors' labels
         val vlabel = vertex.getState[Long](key = label)
         vertex.messageAllNeighbours(vlabel)
@@ -38,7 +38,7 @@ class CBOD(label: String = "label", cutoff: Double = 0.0, output: String = "/tmp
   /**
    * extract vertex ID and outlier score for vertices with outlierscore >= threshold
    **/
-  override def tableStage(graph: GraphPerspective): Table = {
+  override def tabularise(graph: GraphPerspective): Table = {
     graph.select { vertex =>
       Row(
         vertex.ID(),

--- a/src/main/scala/com/raphtory/algorithms/CBOD.scala
+++ b/src/main/scala/com/raphtory/algorithms/CBOD.scala
@@ -1,64 +1,62 @@
 package com.raphtory.algorithms
+
 import com.raphtory.algorithms.LPA.lpa
-import com.raphtory.core.model.algorithm.{GraphPerspective, Row}
+import com.raphtory.core.model.algorithm.{GraphPerspective, Row, Table, GraphAlgorithm, Identity}
 
 /**
 Description
   Returns outliers detected based on the community structure of the Graph.
 
-  Tha algorithm runs an instance of LPA on the graph, initially, and then defines an outlier score based on a node's
+  The algorithm assumes that the state of each vertex contains a community label (e.g., set by running LPA on the graph, initially)
+  and then defines an outlier score based on a node's
   community membership and how it compares to its neighbors community memberships.
 
 Parameters
-  weight (String) - Edge property (default: ""). To be specified in case of weighted graph.
+  label (String) - Identifier for community label
   cutoff (Double) - Outlier score threshold (default: 0.0). Identifies the outliers with an outlier score > cutoff.
-  maxIter (Int)   - Maximum iterations for LPA to run. (default: 500)
+  labeler (Option[GraphAlgorithm]) - Community algorithm to run to get labels (None by default)
 
 Returns
   outliers Map(Long, Double) – Map of (node, outlier score) sorted by their outlier score.
                   Returns `top` nodes with outlier score higher than `cutoff` if specified.
   **/
-class CBOD(weight: String = "", maxIter: Int = 500, cutoff: Double, seed: Long = -1, output: String = "/tmp/CBOD")
-        extends LPA {
-  override def algorithm(graph: GraphPerspective): Unit =
-    graph
-      .step { vertex =>
-        val lab = rnd.nextLong()
-        vertex.setState("lpalabel", lab)
-        vertex.messageAllNeighbours((vertex.ID(), lab))
-      }
-      .iterate( //Run LPA til it converges
-              vertex => lpa(vertex, weight, SP, rnd),
-              maxIter,
-              false
-      )
+class CBOD(label: String = "label", cutoff: Double = 0.0, output: String = "/tmp/CBOD", labeler:GraphAlgorithm = Identity())
+        extends GraphAlgorithm {
+  override def graphStage(graph: GraphPerspective): GraphPerspective = {
+      labeler.graphStage(graph)
       .step { vertex => //Get neighbors' labels
-        val vlabel = vertex.getState[Long]("lpalabel")
+        val vlabel = vertex.getState[Long](key = label)
         vertex.messageAllNeighbours(vlabel)
       }
       .step { v => // Get outlier score
-        val vlabel         = v.getState[Long]("lpalabel")
+        val vlabel         = v.getState[Long](key = label)
         val neighborLabels = v.messageQueue[Long]
         val outlierScore   = 1 - (neighborLabels.count(_ == vlabel) / neighborLabels.length.toDouble)
         v.setState("outlierscore", outlierScore)
       }
-      .select { vertex =>
-        Row(
-                vertex.ID(),
-                vertex.getStateOrElse[Double]("outlierscore", 10.0)
-        )
-      }
+  }
+
+  override def tableStage(graph: GraphPerspective): Table = {
+    graph.select { vertex =>
+      Row(
+        vertex.ID(),
+        vertex.getStateOrElse[Double]("outlierscore", 10.0)
+      )
+    }
       .filter(_.get(1).asInstanceOf[Double] >= cutoff)
-      .writeTo(output)
+  }
+
+  override def write(table: Table): Unit = {
+    table.writeTo(output)
+  }
 }
 
 object CBOD {
   def apply(
-      weight: String = "",
-      maxIter: Int = 500,
+      label: String = "label",
       cutoff: Double = 0.0,
-      seed: Long = -1,
-      output: String = "/tmp/CBOD"
+      output: String = "/tmp/CBOD",
+      labeler: GraphAlgorithm = Identity()
   ) =
-    new CBOD(weight, maxIter, cutoff, seed, output)
+    new CBOD(label, cutoff, output, labeler)
 }

--- a/src/main/scala/com/raphtory/algorithms/CBOD.scala
+++ b/src/main/scala/com/raphtory/algorithms/CBOD.scala
@@ -14,14 +14,14 @@ Description
 Parameters
   label (String) - Identifier for community label
   cutoff (Double) - Outlier score threshold (default: 0.0). Identifies the outliers with an outlier score > cutoff.
-  labeler (Option[GraphAlgorithm]) - Community algorithm to run to get labels (None by default)
-
-Returns
-  outliers Map(Long, Double) – Map of (node, outlier score) sorted by their outlier score.
-                  Returns `top` nodes with outlier score higher than `cutoff` if specified.
+  labeler (GraphAlgorithm) - Community algorithm to run to get labels (does nothing by default, i.e., labels should
+be already set on the input graph, either via chaining or defined as properties of the data)
   **/
 class CBOD(label: String = "label", cutoff: Double = 0.0, output: String = "/tmp/CBOD", labeler:GraphAlgorithm = Identity())
         extends GraphAlgorithm {
+  /**
+   Run CBOD algorithm and sets "outlierscore" state
+    **/
   override def graphStage(graph: GraphPerspective): GraphPerspective = {
       labeler.graphStage(graph)
       .step { vertex => //Get neighbors' labels
@@ -36,6 +36,9 @@ class CBOD(label: String = "label", cutoff: Double = 0.0, output: String = "/tmp
       }
   }
 
+  /**
+   * extract vertex ID and outlier score for vertices with outlierscore >= threshold
+   **/
   override def tableStage(graph: GraphPerspective): Table = {
     graph.select { vertex =>
       Row(

--- a/src/main/scala/com/raphtory/algorithms/CBOD.scala
+++ b/src/main/scala/com/raphtory/algorithms/CBOD.scala
@@ -1,6 +1,5 @@
 package com.raphtory.algorithms
 
-import com.raphtory.algorithms.LPA.lpa
 import com.raphtory.core.model.algorithm.{GraphPerspective, Row, Table, GraphAlgorithm, Identity}
 
 /**

--- a/src/main/scala/com/raphtory/algorithms/ConnectedComponents.scala
+++ b/src/main/scala/com/raphtory/algorithms/ConnectedComponents.scala
@@ -1,6 +1,6 @@
 package com.raphtory.algorithms
 
-import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row}
+import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row, Table}
 
 
 /**
@@ -23,7 +23,7 @@ Notes
 
 **/
 class ConnectedComponents(path:String) extends GraphAlgorithm{
-  override def algorithm(graph: GraphPerspective): Unit = {
+  override def graphStage(graph: GraphPerspective): GraphPerspective = {
     graph
       .step({
         vertex =>
@@ -40,8 +40,14 @@ class ConnectedComponents(path:String) extends GraphAlgorithm{
           else
             vertex.voteToHalt()
       }, iterations = 100, executeMessagedOnly = true)
-      .select(vertex => Row(vertex.ID(),vertex.getState[Long]("cclabel")))
-      .writeTo(path)
+  }
+
+  override def tableStage(graph: GraphPerspective): Table = {
+    graph.select(vertex => Row(vertex.ID(), vertex.getState[Long]("cclabel")))
+  }
+
+  override def write(table: Table): Unit = {
+    table.writeTo(path)
   }
 }
 

--- a/src/main/scala/com/raphtory/algorithms/ConnectedComponents.scala
+++ b/src/main/scala/com/raphtory/algorithms/ConnectedComponents.scala
@@ -23,7 +23,7 @@ Notes
 
 **/
 class ConnectedComponents(path:String) extends GraphAlgorithm{
-  override def algorithm(graph: GraphPerspective): GraphPerspective = {
+  override def apply(graph: GraphPerspective): GraphPerspective = {
     graph
       .step({
         vertex =>

--- a/src/main/scala/com/raphtory/algorithms/ConnectedComponents.scala
+++ b/src/main/scala/com/raphtory/algorithms/ConnectedComponents.scala
@@ -23,7 +23,7 @@ Notes
 
 **/
 class ConnectedComponents(path:String) extends GraphAlgorithm{
-  override def graphStage(graph: GraphPerspective): GraphPerspective = {
+  override def algorithm(graph: GraphPerspective): GraphPerspective = {
     graph
       .step({
         vertex =>
@@ -42,7 +42,7 @@ class ConnectedComponents(path:String) extends GraphAlgorithm{
       }, iterations = 100, executeMessagedOnly = true)
   }
 
-  override def tableStage(graph: GraphPerspective): Table = {
+  override def tabularise(graph: GraphPerspective): Table = {
     graph.select(vertex => Row(vertex.ID(), vertex.getState[Long]("cclabel")))
   }
 

--- a/src/main/scala/com/raphtory/algorithms/Degree.scala
+++ b/src/main/scala/com/raphtory/algorithms/Degree.scala
@@ -18,7 +18,7 @@ Returns
   total degree (Long) : The total degree
 **/
 class Degree(path:String) extends GraphAlgorithm{
-  override def tableStage(graph: GraphPerspective): Table = {
+  override def tabularise(graph: GraphPerspective): Table = {
     graph.select({
       vertex =>
         val inDegree = vertex.getInNeighbours().size

--- a/src/main/scala/com/raphtory/algorithms/Degree.scala
+++ b/src/main/scala/com/raphtory/algorithms/Degree.scala
@@ -1,6 +1,6 @@
 package com.raphtory.algorithms
 
-import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row}
+import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row, Table}
 
 /**
 Description
@@ -18,15 +18,18 @@ Returns
   total degree (Long) : The total degree
 **/
 class Degree(path:String) extends GraphAlgorithm{
-  override def algorithm(graph: GraphPerspective): Unit = {
+  override def tableStage(graph: GraphPerspective): Table = {
     graph.select({
       vertex =>
-      val inDegree = vertex.getInNeighbours().size
-      val outDegree = vertex.getOutNeighbours().size
-      val totalDegree = vertex.getAllNeighbours().size
-    Row(vertex.getPropertyOrElse("name", vertex.ID()), inDegree, outDegree, totalDegree)
+        val inDegree = vertex.getInNeighbours().size
+        val outDegree = vertex.getOutNeighbours().size
+        val totalDegree = vertex.getAllNeighbours().size
+        Row(vertex.getPropertyOrElse("name", vertex.ID()), inDegree, outDegree, totalDegree)
     })
-      .writeTo(path)
+  }
+
+  override def write(table: Table): Unit = {
+    table.writeTo(path)
   }
 }
 

--- a/src/main/scala/com/raphtory/algorithms/Descendants.scala
+++ b/src/main/scala/com/raphtory/algorithms/Descendants.scala
@@ -1,6 +1,6 @@
 package com.raphtory.algorithms
 
-import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row}
+import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row, Table}
 
 class Descendants(path:String,
                   seed:String,
@@ -9,7 +9,7 @@ class Descendants(path:String,
                   directed:Boolean=true)
   extends GraphAlgorithm{
 
-  override def algorithm(graph: GraphPerspective): Unit = {
+  override def graphStage(graph: GraphPerspective): GraphPerspective = {
     graph.step({
       vertex =>
         if (vertex.ID() == checkID(seed)) {
@@ -20,24 +20,30 @@ class Descendants(path:String,
             e =>
               vertex.messageNeighbour(e.ID(), e.firstActivityAfter(time).time)
           })
-          vertex.setState("descendant",false)
+          vertex.setState("descendant", false)
         }
     })
       .iterate({
         vertex =>
           val earliestTime = vertex.messageQueue[Long]
             .min
-          vertex.setState("descendant",true)
+          vertex.setState("descendant", true)
           val outEdges = (if (directed) vertex.getOutEdges() else vertex.getEdges())
             .filter(e => e.latestActivity().time > earliestTime)
-          .filter(e => e.firstActivityAfter(earliestTime).time < earliestTime + delta)
+            .filter(e => e.firstActivityAfter(earliestTime).time < earliestTime + delta)
           outEdges.foreach({
             e =>
               vertex.messageNeighbour(e.ID(), e.firstActivityAfter(earliestTime).time)
           })
-      },executeMessagedOnly = true, iterations = 100)
-      .select(vertex => Row(vertex.getPropertyOrElse("name",vertex.ID()), vertex.getStateOrElse[Boolean]("descendant",false)))
-      .writeTo(path)
+      }, executeMessagedOnly = true, iterations = 100)
+  }
+
+  override def tableStage(graph: GraphPerspective): Table = {
+    graph.select(vertex => Row(vertex.getPropertyOrElse("name", vertex.ID()), vertex.getStateOrElse[Boolean]("descendant", false)))
+  }
+
+  override def write(table: Table): Unit = {
+    table.writeTo(path)
   }
 }
 

--- a/src/main/scala/com/raphtory/algorithms/Descendants.scala
+++ b/src/main/scala/com/raphtory/algorithms/Descendants.scala
@@ -9,7 +9,7 @@ class Descendants(path:String,
                   directed:Boolean=true)
   extends GraphAlgorithm{
 
-  override def graphStage(graph: GraphPerspective): GraphPerspective = {
+  override def algorithm(graph: GraphPerspective): GraphPerspective = {
     graph.step({
       vertex =>
         if (vertex.ID() == checkID(seed)) {
@@ -38,7 +38,7 @@ class Descendants(path:String,
       }, executeMessagedOnly = true, iterations = 100)
   }
 
-  override def tableStage(graph: GraphPerspective): Table = {
+  override def tabularise(graph: GraphPerspective): Table = {
     graph.select(vertex => Row(vertex.getPropertyOrElse("name", vertex.ID()), vertex.getStateOrElse[Boolean]("descendant", false)))
   }
 

--- a/src/main/scala/com/raphtory/algorithms/Descendants.scala
+++ b/src/main/scala/com/raphtory/algorithms/Descendants.scala
@@ -9,7 +9,7 @@ class Descendants(path:String,
                   directed:Boolean=true)
   extends GraphAlgorithm{
 
-  override def algorithm(graph: GraphPerspective): GraphPerspective = {
+  override def apply(graph: GraphPerspective): GraphPerspective = {
     graph.step({
       vertex =>
         if (vertex.ID() == checkID(seed)) {

--- a/src/main/scala/com/raphtory/algorithms/Distinctiveness.scala
+++ b/src/main/scala/com/raphtory/algorithms/Distinctiveness.scala
@@ -26,7 +26,7 @@ import scala.math.{log10, pow}
 
 class Distinctiveness(path:String, alpha:Double=1.0) extends GraphAlgorithm{
 
-  override def algorithm(graph: GraphPerspective): GraphPerspective = {
+  override def apply(graph: GraphPerspective): GraphPerspective = {
     graph.step({
       vertex =>
         val edges = vertex.getEdges()

--- a/src/main/scala/com/raphtory/algorithms/Distinctiveness.scala
+++ b/src/main/scala/com/raphtory/algorithms/Distinctiveness.scala
@@ -26,7 +26,7 @@ import scala.math.{log10, pow}
 
 class Distinctiveness(path:String, alpha:Double=1.0) extends GraphAlgorithm{
 
-  override def graphStage(graph: GraphPerspective): GraphPerspective = {
+  override def algorithm(graph: GraphPerspective): GraphPerspective = {
     graph.step({
       vertex =>
         val edges = vertex.getEdges()
@@ -41,7 +41,7 @@ class Distinctiveness(path:String, alpha:Double=1.0) extends GraphAlgorithm{
     })
   }
 
-  override def tableStage(graph: GraphPerspective): Table = {
+  override def tabularise(graph: GraphPerspective): Table = {
     val N = graph.nodeCount().toDouble
     graph.select({
       vertex =>

--- a/src/main/scala/com/raphtory/algorithms/GenericTaint.scala
+++ b/src/main/scala/com/raphtory/algorithms/GenericTaint.scala
@@ -1,6 +1,6 @@
 package com.raphtory.algorithms
 
-import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row}
+import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row, Table}
 
 /**
 Description
@@ -23,14 +23,14 @@ Returns
 **/
 class GenericTaint(startTime: Long, infectedNodes: Set[Long], stopNodes: Set[Long] = Set(), output: String = "/tmp/generic_taint") extends GraphAlgorithm{
 
-  override def algorithm(graph: GraphPerspective): Unit = {
+  override def graphStage(graph: GraphPerspective): GraphPerspective = {
     graph
       // the step functions run on every single vertex ONCE at the beginning of the algorithm
       .step({
         // for each vertex in the graph
         vertex =>
           // check if it is one of our infected nodes
-          if (infectedNodes contains vertex.ID){
+          if (infectedNodes contains vertex.ID) {
             // set its state to tainted
             val result = List(("tainted", -1, startTime, "startPoint"))
             // set this node as the beginning state
@@ -50,7 +50,7 @@ class GenericTaint(startTime: Long, infectedNodes: Set[Long], stopNodes: Set[Lon
                         edge.ID(),
                         event.time,
                         vertex.ID()
-                        )
+                      )
                       )
                     }
                 )
@@ -91,7 +91,7 @@ class GenericTaint(startTime: Long, infectedNodes: Set[Long], stopNodes: Set[Lon
                       edge.ID(),
                       event.time,
                       vertex.ID()
-                      )
+                    )
                     )
                   }
                 )
@@ -107,7 +107,7 @@ class GenericTaint(startTime: Long, infectedNodes: Set[Long], stopNodes: Set[Lon
                       edge.ID(),
                       event.time,
                       vertex.ID()
-                      )
+                    )
                     )
                   }
                 )
@@ -117,18 +117,24 @@ class GenericTaint(startTime: Long, infectedNodes: Set[Long], stopNodes: Set[Lon
           else
             vertex.voteToHalt()
       }, 100, true)
-      // get all vertexes and their status
-      .select(vertex => Row(
-        vertex.ID(),
-        vertex.getStateOrElse("taintStatus", false),
-        vertex.getStateOrElse[Any]("taintHistory","false")
-      ))
+    // get all vertexes and their status
+  }
+
+  override def tableStage(graph: GraphPerspective): Table = {
+    graph.select(vertex => Row(
+      vertex.ID(),
+      vertex.getStateOrElse("taintStatus", false),
+      vertex.getStateOrElse[Any]("taintHistory", "false")
+    ))
       // filter for any that had been tainted and save to folder
-      .filter(r=> r.get(1) == true)
-      .explode( row => row.get(2).asInstanceOf[List[(String, Long, Long, Long)]].map(
-        tx => Row( row(0), tx._2, tx._3, tx._4)
+      .filter(r => r.get(1) == true)
+      .explode(row => row.get(2).asInstanceOf[List[(String, Long, Long, Long)]].map(
+        tx => Row(row(0), tx._2, tx._3, tx._4)
       ))
-      .writeTo(output)
+  }
+
+  override def write(table: Table): Unit = {
+    table.writeTo(output)
   }
 }
 

--- a/src/main/scala/com/raphtory/algorithms/GenericTaint.scala
+++ b/src/main/scala/com/raphtory/algorithms/GenericTaint.scala
@@ -23,7 +23,7 @@ Returns
 **/
 class GenericTaint(startTime: Long, infectedNodes: Set[Long], stopNodes: Set[Long] = Set(), output: String = "/tmp/generic_taint") extends GraphAlgorithm{
 
-  override def graphStage(graph: GraphPerspective): GraphPerspective = {
+  override def algorithm(graph: GraphPerspective): GraphPerspective = {
     graph
       // the step functions run on every single vertex ONCE at the beginning of the algorithm
       .step({
@@ -120,7 +120,7 @@ class GenericTaint(startTime: Long, infectedNodes: Set[Long], stopNodes: Set[Lon
     // get all vertexes and their status
   }
 
-  override def tableStage(graph: GraphPerspective): Table = {
+  override def tabularise(graph: GraphPerspective): Table = {
     graph.select(vertex => Row(
       vertex.ID(),
       vertex.getStateOrElse("taintStatus", false),

--- a/src/main/scala/com/raphtory/algorithms/GenericTaint.scala
+++ b/src/main/scala/com/raphtory/algorithms/GenericTaint.scala
@@ -23,7 +23,7 @@ Returns
 **/
 class GenericTaint(startTime: Long, infectedNodes: Set[Long], stopNodes: Set[Long] = Set(), output: String = "/tmp/generic_taint") extends GraphAlgorithm{
 
-  override def algorithm(graph: GraphPerspective): GraphPerspective = {
+  override def apply(graph: GraphPerspective): GraphPerspective = {
     graph
       // the step functions run on every single vertex ONCE at the beginning of the algorithm
       .step({

--- a/src/main/scala/com/raphtory/algorithms/GraphState.scala
+++ b/src/main/scala/com/raphtory/algorithms/GraphState.scala
@@ -3,7 +3,7 @@ package com.raphtory.algorithms
 import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row, Table}
 
 class GraphState(path:String) extends GraphAlgorithm{
-  override def tableStage(graph: GraphPerspective): Table = {
+  override def tabularise(graph: GraphPerspective): Table = {
     graph.select(vertex => {
       val inDeg = vertex.getInEdges().size
       val outDeg = vertex.getOutEdges().size

--- a/src/main/scala/com/raphtory/algorithms/GraphState.scala
+++ b/src/main/scala/com/raphtory/algorithms/GraphState.scala
@@ -1,32 +1,35 @@
 package com.raphtory.algorithms
 
-import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row}
+import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row, Table}
 
 class GraphState(path:String) extends GraphAlgorithm{
-  override def algorithm(graph: GraphPerspective): Unit = {
-    graph.select(vertex=> {
-        val inDeg = vertex.getInEdges().size
-        val outDeg = vertex.getOutEdges().size
-        val deg = inDeg + outDeg
-        val vdeletions = vertex.history().count(f => !f.event)
-        val vcreations = vertex.history().count(f =>f.event)
-        val outedgedeletions =vertex.getOutEdges().map(f=>f.history().count(f => !f.event)).sum
-        val outedgecreations =vertex.getOutEdges().map(f=>f.history().count(f => f.event)).sum
+  override def tableStage(graph: GraphPerspective): Table = {
+    graph.select(vertex => {
+      val inDeg = vertex.getInEdges().size
+      val outDeg = vertex.getOutEdges().size
+      val deg = inDeg + outDeg
+      val vdeletions = vertex.history().count(f => !f.event)
+      val vcreations = vertex.history().count(f => f.event)
+      val outedgedeletions = vertex.getOutEdges().map(f => f.history().count(f => !f.event)).sum
+      val outedgecreations = vertex.getOutEdges().map(f => f.history().count(f => f.event)).sum
 
-        val inedgedeletions =vertex.getInEdges().map(f=>f.history().count(f => !f.event)).sum
-        val inedgecreations =vertex.getInEdges().map(f=>f.history().count(f => f.event)).sum
+      val inedgedeletions = vertex.getInEdges().map(f => f.history().count(f => !f.event)).sum
+      val inedgecreations = vertex.getInEdges().map(f => f.history().count(f => f.event)).sum
 
-        val properties = vertex.getPropertySet().size
-        val propertyhistory = vertex.getPropertySet().toArray.map(x=> vertex.getPropertyHistory(x).size).sum
-        val outedgeProperties = vertex.getOutEdges().map(edge => edge.getPropertySet().size).sum
-        val outedgePropertyHistory = vertex.getOutEdges().map(edge => edge.getPropertySet().toArray.map(x=> edge.getPropertyHistory(x).size).sum).sum
+      val properties = vertex.getPropertySet().size
+      val propertyhistory = vertex.getPropertySet().toArray.map(x => vertex.getPropertyHistory(x).size).sum
+      val outedgeProperties = vertex.getOutEdges().map(edge => edge.getPropertySet().size).sum
+      val outedgePropertyHistory = vertex.getOutEdges().map(edge => edge.getPropertySet().toArray.map(x => edge.getPropertyHistory(x).size).sum).sum
 
-        val inedgeProperties = vertex.getInEdges().map(edge => edge.getPropertySet().size).sum
-        val inedgePropertyHistory = vertex.getInEdges().map(edge => edge.getPropertySet().toArray.map(x=> edge.getPropertyHistory(x).size).sum).sum
+      val inedgeProperties = vertex.getInEdges().map(edge => edge.getPropertySet().size).sum
+      val inedgePropertyHistory = vertex.getInEdges().map(edge => edge.getPropertySet().toArray.map(x => edge.getPropertyHistory(x).size).sum).sum
 
-        Row(vertex.ID(),inDeg, outDeg,deg, vdeletions,vcreations,outedgedeletions,outedgecreations,inedgedeletions,inedgecreations,properties,propertyhistory,outedgeProperties,outedgePropertyHistory,inedgeProperties,inedgePropertyHistory)
+      Row(vertex.ID(), inDeg, outDeg, deg, vdeletions, vcreations, outedgedeletions, outedgecreations, inedgedeletions, inedgecreations, properties, propertyhistory, outedgeProperties, outedgePropertyHistory, inedgeProperties, inedgePropertyHistory)
     })
-      .writeTo(path)
+  }
+
+  override def write(table: Table): Unit = {
+    table.writeTo(path)
   }
 }
 

--- a/src/main/scala/com/raphtory/algorithms/LPA.scala
+++ b/src/main/scala/com/raphtory/algorithms/LPA.scala
@@ -35,7 +35,7 @@ class LPA(top: Int= 0, weight: String= "", maxIter: Int = 500, seed:Long= -1, ou
   val rnd: Random = if (seed == -1) new scala.util.Random else new scala.util.Random(seed)
   val SP = 0.2F // Stickiness probability
 
-  override def algorithm(graph: GraphPerspective): GraphPerspective = {
+  override def apply(graph: GraphPerspective): GraphPerspective = {
     graph.step({
       vertex =>
         val lab = rnd.nextLong()

--- a/src/main/scala/com/raphtory/algorithms/LPA.scala
+++ b/src/main/scala/com/raphtory/algorithms/LPA.scala
@@ -35,7 +35,7 @@ class LPA(top: Int= 0, weight: String= "", maxIter: Int = 500, seed:Long= -1, ou
   val rnd: Random = if (seed == -1) new scala.util.Random else new scala.util.Random(seed)
   val SP = 0.2F // Stickiness probability
 
-  override def graphStage(graph: GraphPerspective): GraphPerspective = {
+  override def algorithm(graph: GraphPerspective): GraphPerspective = {
     graph.step({
       vertex =>
         val lab = rnd.nextLong()
@@ -47,7 +47,7 @@ class LPA(top: Int= 0, weight: String= "", maxIter: Int = 500, seed:Long= -1, ou
     }, maxIter, false)
   }
 
-  override def tableStage(graph: GraphPerspective): Table = {
+  override def tabularise(graph: GraphPerspective): Table = {
     graph.select({
 
       vertex =>

--- a/src/main/scala/com/raphtory/algorithms/LPA.scala
+++ b/src/main/scala/com/raphtory/algorithms/LPA.scala
@@ -1,7 +1,7 @@
 package com.raphtory.algorithms
 
 import com.raphtory.algorithms.LPA.lpa
-import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row}
+import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row, Table}
 import com.raphtory.core.model.graph.visitor.Vertex
 
 import scala.util.Random
@@ -35,25 +35,33 @@ class LPA(top: Int= 0, weight: String= "", maxIter: Int = 500, seed:Long= -1, ou
   val rnd: Random = if (seed == -1) new scala.util.Random else new scala.util.Random(seed)
   val SP = 0.2F // Stickiness probability
 
-  override def algorithm(graph: GraphPerspective): Unit = {
+  override def graphStage(graph: GraphPerspective): GraphPerspective = {
     graph.step({
       vertex =>
         val lab = rnd.nextLong()
         vertex.setState("lpalabel", lab)
-        vertex.messageAllNeighbours((vertex.ID(),lab))
+        vertex.messageAllNeighbours((vertex.ID(), lab))
     }).iterate({
       vertex =>
         lpa(vertex, weight, SP, rnd)
-    }, maxIter,false).select({
+    }, maxIter, false)
+  }
 
-      vertex => Row(
-        vertex.ID(),
-        vertex.getState("lpalabel"),
-      )
-    }).writeTo(output)
+  override def tableStage(graph: GraphPerspective): Table = {
+    graph.select({
+
+      vertex =>
+        Row(
+          vertex.ID(),
+          vertex.getState("lpalabel"),
+        )
+    })
+  }
+
+  override def write(table: Table): Unit = {
+    table.writeTo(output)
   }
   // TODO AGGREGATION STATS - See old code in old dir
-
 }
 
 object LPA{

--- a/src/main/scala/com/raphtory/algorithms/MotifAlpha.scala
+++ b/src/main/scala/com/raphtory/algorithms/MotifAlpha.scala
@@ -17,7 +17,7 @@ Returns
 **/
 class MotifAlpha(fileOutput:String="/tmp/motif_alpha") extends GraphAlgorithm {
 
-  override def tableStage(graph: GraphPerspective): Table = {
+  override def tabularise(graph: GraphPerspective): Table = {
     graph
       .select({
         vertex =>

--- a/src/main/scala/com/raphtory/algorithms/MotifAlpha.scala
+++ b/src/main/scala/com/raphtory/algorithms/MotifAlpha.scala
@@ -1,6 +1,6 @@
 package com.raphtory.algorithms
 
-import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row}
+import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row, Table}
 
 /**
 Description
@@ -17,21 +17,25 @@ Returns
 **/
 class MotifAlpha(fileOutput:String="/tmp/motif_alpha") extends GraphAlgorithm {
 
-  override def algorithm(graph: GraphPerspective): Unit = {
+  override def tableStage(graph: GraphPerspective): Table = {
     graph
       .select({
         vertex =>
           if (vertex.explodeInEdges().nonEmpty & vertex.explodeOutEdges().nonEmpty) {
             val out = vertex.explodeInEdges()
               .map(inEdge => vertex.explodeOutEdges()
-                .filter( e => e.getTimestamp() > inEdge.getTimestamp() & e.dst() != inEdge.src() & e.dst() != inEdge.dst()).size).sum
+                .filter(e => e.getTimestamp() > inEdge.getTimestamp() & e.dst() != inEdge.src() & e.dst() != inEdge.dst()).size).sum
             Row(vertex.ID(), out)
           }
-          else{
+          else {
             Row(vertex.ID(), 0)
           }
       }
-      ).writeTo(fileOutput)
+      )
+  }
+
+  override def write(table: Table): Unit = {
+    table.writeTo(fileOutput)
   }
 
 }

--- a/src/main/scala/com/raphtory/algorithms/MultilayerLPA.scala
+++ b/src/main/scala/com/raphtory/algorithms/MultilayerLPA.scala
@@ -1,7 +1,5 @@
 package com.raphtory.algorithms
-import com.raphtory.core.model.algorithm.GraphAlgorithm
-import com.raphtory.core.model.algorithm.GraphPerspective
-import com.raphtory.core.model.algorithm.Row
+import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row, Table}
 import com.raphtory.core.model.graph.visitor.Vertex
 
 import scala.collection.mutable.{ListBuffer, Queue}
@@ -48,91 +46,7 @@ class MultilayerLPA(
   val rnd: Random               = if (seed == -1) new scala.util.Random else new scala.util.Random(seed)
   val SP                        = 0.2f // Stickiness probability
 
-  override def algorithm(graph: GraphPerspective): Unit = {
-    graph
-      .step { vertex =>
-        // Assign random labels for all instances in time of a vertex as Map(ts, lab)
-        val tlabels =
-          layers.filter(ts => vertex.aliveAt(ts, layerSize)).map(ts => (ts, rnd.nextLong()))
-        vertex.setState("mlpalabel", tlabels)
-        val message = (vertex.ID(), tlabels.map(x => (x._1, x._2)))
-        vertex.messageAllNeighbours(message)
-      }
-      .iterate(
-              { vertex =>
-                val vlabel     = vertex.getState[List[(Long, Long)]]("mlpalabel").toMap
-                val msgQueue   = vertex.messageQueue[(Long, List[(Long, Long)])]
-                var voteStatus = vertex.getOrSetState[Boolean]("vote", false)
-                var voteCount  = 0
-                val newLabel = vlabel.map {
-                  tv =>
-                    val ts     = tv._1
-                    val Curlab = tv._2
-
-                    // Get weights/labels of neighbours of vertex at time ts
-                    val nei_ts_freq = weightFunction(vertex, ts) // ID -> freq
-                    var newlab = if (nei_ts_freq.nonEmpty) {
-                      val nei_labs = msgQueue
-                        .filter(x => nei_ts_freq.keySet.contains(x._1)) // filter messages from neighbours at time ts only
-                        .map { msg =>
-                          val freq     = nei_ts_freq(msg._1)
-                          val label_ts = msg._2.filter(_._1 == ts).head._2
-                          (label_ts, freq) //get label and its frequency at time ts -> (lab, freq)
-                        }.to[ListBuffer]
-
-                      //Get labels of past/future instances of vertex
-                      if (vlabel.contains(ts - layerSize)) {
-                        nei_labs += ((vlabel(ts - layerSize), interLayerWeights(omega, vertex, ts - layerSize)))
-                      }
-
-                      if (vlabel.contains(ts + layerSize)) {
-                        nei_labs += ((vlabel(ts + layerSize), interLayerWeights(omega, vertex, ts)))
-                      }
-
-                      // Get label most prominent in neighborhood of vertex
-                      val max_freq = nei_labs.groupBy(_._1).mapValues(_.map(_._2).sum)
-                      max_freq.filter(_._2 == max_freq.values.max).keySet.max
-                    } else Curlab
-
-                    if (newlab == Curlab)
-                      voteCount += 1
-
-                    newlab = if (rnd.nextFloat() < SP) Curlab else newlab
-                    (ts, newlab)
-                }.toList
-
-                // Update node label and broadcast
-                vertex.setState("mlpalabel", newLabel)
-                val message = (vertex.ID(), newLabel)
-                vertex.messageAllNeighbours(message)
-
-                // Update vote status
-                voteStatus = if (voteStatus || (voteCount == vlabel.size)) {
-                  vertex.voteToHalt()
-                  true
-                } else
-                  false
-                vertex.setState("vote", voteStatus)
-
-              },
-              maxIter,
-              true
-      )
-      .select { vertex =>
-        Row(
-            vertex.getProperty("name").getOrElse(vertex.ID()).toString,
-            vertex.getState("mlpalabel")
-        )
-      }
-      .explode{
-        row =>
-          row.get(1).asInstanceOf[List[(Long, Long)]]
-            .map { lts =>
-              Row(lts._2, row.get(0) + "_" + lts._1.toString)
-            }
-      }
-      .writeTo(output)
-
+  override def graphStage(graph: GraphPerspective): GraphPerspective = {
     def interLayerWeights(omega: Double, v: Vertex, ts: Long): Float =
       omega match {
         case -1 =>
@@ -146,7 +60,98 @@ class MultilayerLPA(
         .map(e => (e.ID(), e.getProperty(weight).getOrElse(1.0f)))
         .groupBy(_._1)
         .mapValues(x => x.map(_._2).sum / x.size) // (ID -> Freq)
+
+    graph
+      .step { vertex =>
+        // Assign random labels for all instances in time of a vertex as Map(ts, lab)
+        val tlabels =
+          layers.filter(ts => vertex.aliveAt(ts, layerSize)).map(ts => (ts, rnd.nextLong()))
+        vertex.setState("mlpalabel", tlabels)
+        val message = (vertex.ID(), tlabels.map(x => (x._1, x._2)))
+        vertex.messageAllNeighbours(message)
+      }
+      .iterate(
+        { vertex =>
+          val vlabel = vertex.getState[List[(Long, Long)]]("mlpalabel").toMap
+          val msgQueue = vertex.messageQueue[(Long, List[(Long, Long)])]
+          var voteStatus = vertex.getOrSetState[Boolean]("vote", false)
+          var voteCount = 0
+          val newLabel = vlabel.map {
+            tv =>
+              val ts = tv._1
+              val Curlab = tv._2
+
+              // Get weights/labels of neighbours of vertex at time ts
+              val nei_ts_freq = weightFunction(vertex, ts) // ID -> freq
+              var newlab = if (nei_ts_freq.nonEmpty) {
+                val nei_labs = msgQueue
+                  .filter(x => nei_ts_freq.keySet.contains(x._1)) // filter messages from neighbours at time ts only
+                  .map { msg =>
+                    val freq = nei_ts_freq(msg._1)
+                    val label_ts = msg._2.filter(_._1 == ts).head._2
+                    (label_ts, freq) //get label and its frequency at time ts -> (lab, freq)
+                  }.to[ListBuffer]
+
+                //Get labels of past/future instances of vertex
+                if (vlabel.contains(ts - layerSize)) {
+                  nei_labs += ((vlabel(ts - layerSize), interLayerWeights(omega, vertex, ts - layerSize)))
+                }
+
+                if (vlabel.contains(ts + layerSize)) {
+                  nei_labs += ((vlabel(ts + layerSize), interLayerWeights(omega, vertex, ts)))
+                }
+
+                // Get label most prominent in neighborhood of vertex
+                val max_freq = nei_labs.groupBy(_._1).mapValues(_.map(_._2).sum)
+                max_freq.filter(_._2 == max_freq.values.max).keySet.max
+              } else Curlab
+
+              if (newlab == Curlab)
+                voteCount += 1
+
+              newlab = if (rnd.nextFloat() < SP) Curlab else newlab
+              (ts, newlab)
+          }.toList
+
+          // Update node label and broadcast
+          vertex.setState("mlpalabel", newLabel)
+          val message = (vertex.ID(), newLabel)
+          vertex.messageAllNeighbours(message)
+
+          // Update vote status
+          voteStatus = if (voteStatus || (voteCount == vlabel.size)) {
+            vertex.voteToHalt()
+            true
+          } else
+            false
+          vertex.setState("vote", voteStatus)
+
+        },
+        maxIter,
+        true
+      )
   }
+
+  override def tableStage(graph: GraphPerspective): Table = {
+    graph.select { vertex =>
+      Row(
+        vertex.getProperty("name").getOrElse(vertex.ID()).toString,
+        vertex.getState("mlpalabel")
+      )
+    }
+      .explode {
+        row =>
+          row.get(1).asInstanceOf[List[(Long, Long)]]
+            .map { lts =>
+              Row(lts._2, row.get(0) + "_" + lts._1.toString)
+            }
+      }
+  }
+
+  override def write(table: Table): Unit = {
+    table.writeTo(output)
+  }
+
 }
 object MultilayerLPA {
   def apply(

--- a/src/main/scala/com/raphtory/algorithms/MultilayerLPA.scala
+++ b/src/main/scala/com/raphtory/algorithms/MultilayerLPA.scala
@@ -46,7 +46,7 @@ class MultilayerLPA(
   val rnd: Random               = if (seed == -1) new scala.util.Random else new scala.util.Random(seed)
   val SP                        = 0.2f // Stickiness probability
 
-  override def algorithm(graph: GraphPerspective): GraphPerspective = {
+  override def apply(graph: GraphPerspective): GraphPerspective = {
     def interLayerWeights(omega: Double, v: Vertex, ts: Long): Float =
       omega match {
         case -1 =>

--- a/src/main/scala/com/raphtory/algorithms/MultilayerLPA.scala
+++ b/src/main/scala/com/raphtory/algorithms/MultilayerLPA.scala
@@ -46,7 +46,7 @@ class MultilayerLPA(
   val rnd: Random               = if (seed == -1) new scala.util.Random else new scala.util.Random(seed)
   val SP                        = 0.2f // Stickiness probability
 
-  override def graphStage(graph: GraphPerspective): GraphPerspective = {
+  override def algorithm(graph: GraphPerspective): GraphPerspective = {
     def interLayerWeights(omega: Double, v: Vertex, ts: Long): Float =
       omega match {
         case -1 =>
@@ -132,7 +132,7 @@ class MultilayerLPA(
       )
   }
 
-  override def tableStage(graph: GraphPerspective): Table = {
+  override def tabularise(graph: GraphPerspective): Table = {
     graph.select { vertex =>
       Row(
         vertex.getProperty("name").getOrElse(vertex.ID()).toString,

--- a/src/main/scala/com/raphtory/algorithms/NeighbourAverageDegree.scala
+++ b/src/main/scala/com/raphtory/algorithms/NeighbourAverageDegree.scala
@@ -1,22 +1,28 @@
 package com.raphtory.algorithms
 
-import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row}
+import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row, Table}
 
 class NeighbourAverageDegree(path:String) extends GraphAlgorithm{
-  override def algorithm(graph: GraphPerspective): Unit = {
+  override def graphStage(graph: GraphPerspective): GraphPerspective = {
     graph.step({
       vertex =>
         val degree = vertex.getAllNeighbours().size
         vertex.messageAllNeighbours(degree)
     })
-      .select({
-        vertex =>
-          val degrees = vertex.messageQueue[Int]
-          val degree = vertex.getAllNeighbours().size
-          val avgNeigh = if (degree > 0) degrees.sum.toFloat/degree else 0.0
-          Row(vertex.getPropertyOrElse("name", vertex.ID()), degree, avgNeigh)
-      })
-      .writeTo(path)
+  }
+
+  override def tableStage(graph: GraphPerspective): Table = {
+    graph.select({
+      vertex =>
+        val degrees = vertex.messageQueue[Int]
+        val degree = vertex.getAllNeighbours().size
+        val avgNeigh = if (degree > 0) degrees.sum.toFloat / degree else 0.0
+        Row(vertex.getPropertyOrElse("name", vertex.ID()), degree, avgNeigh)
+    })
+  }
+
+  override def write(table: Table): Unit = {
+    table.writeTo(path)
   }
 }
 

--- a/src/main/scala/com/raphtory/algorithms/NeighbourAverageDegree.scala
+++ b/src/main/scala/com/raphtory/algorithms/NeighbourAverageDegree.scala
@@ -3,7 +3,7 @@ package com.raphtory.algorithms
 import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row, Table}
 
 class NeighbourAverageDegree(path:String) extends GraphAlgorithm{
-  override def graphStage(graph: GraphPerspective): GraphPerspective = {
+  override def algorithm(graph: GraphPerspective): GraphPerspective = {
     graph.step({
       vertex =>
         val degree = vertex.getAllNeighbours().size
@@ -11,7 +11,7 @@ class NeighbourAverageDegree(path:String) extends GraphAlgorithm{
     })
   }
 
-  override def tableStage(graph: GraphPerspective): Table = {
+  override def tabularise(graph: GraphPerspective): Table = {
     graph.select({
       vertex =>
         val degrees = vertex.messageQueue[Int]

--- a/src/main/scala/com/raphtory/algorithms/NeighbourAverageDegree.scala
+++ b/src/main/scala/com/raphtory/algorithms/NeighbourAverageDegree.scala
@@ -3,7 +3,7 @@ package com.raphtory.algorithms
 import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row, Table}
 
 class NeighbourAverageDegree(path:String) extends GraphAlgorithm{
-  override def algorithm(graph: GraphPerspective): GraphPerspective = {
+  override def apply(graph: GraphPerspective): GraphPerspective = {
     graph.step({
       vertex =>
         val degree = vertex.getAllNeighbours().size

--- a/src/main/scala/com/raphtory/algorithms/OutDegreeAverage.scala
+++ b/src/main/scala/com/raphtory/algorithms/OutDegreeAverage.scala
@@ -1,9 +1,9 @@
 package com.raphtory.algorithms
 
-import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row}
+import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row, Table}
 
 class OutDegreeAverage(output:String) extends GraphAlgorithm {
-  override def algorithm(graph: GraphPerspective): Unit = {
+  override def tableStage(graph: GraphPerspective): Table = {
     val nodeCount = graph.nodeCount()
     graph
       .select({
@@ -11,10 +11,15 @@ class OutDegreeAverage(output:String) extends GraphAlgorithm {
           val id = vertex.ID()
           val sized =
             try vertex.getOutEdges().size.toDouble / nodeCount.toDouble
-            catch { case _: ArithmeticException => 0 }
+            catch {
+              case _: ArithmeticException => 0
+            }
           Row(id, sized)
       })
-      .writeTo(output)
+  }
+
+  override def write(table: Table): Unit = {
+    table.writeTo(output)
   }
 }
 

--- a/src/main/scala/com/raphtory/algorithms/OutDegreeAverage.scala
+++ b/src/main/scala/com/raphtory/algorithms/OutDegreeAverage.scala
@@ -3,7 +3,7 @@ package com.raphtory.algorithms
 import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row, Table}
 
 class OutDegreeAverage(output:String) extends GraphAlgorithm {
-  override def tableStage(graph: GraphPerspective): Table = {
+  override def tabularise(graph: GraphPerspective): Table = {
     val nodeCount = graph.nodeCount()
     graph
       .select({

--- a/src/main/scala/com/raphtory/algorithms/PageRank.scala
+++ b/src/main/scala/com/raphtory/algorithms/PageRank.scala
@@ -26,7 +26,7 @@ Returns
 **/
 class PageRank(dampingFactor:Double = 0.85, iterateSteps:Int = 100, output:String = "/tmp/PageRank") extends  GraphAlgorithm {
 
-  override def graphStage(graph: GraphPerspective): GraphPerspective = {
+  override def algorithm(graph: GraphPerspective): GraphPerspective = {
     graph.step({
       vertex =>
         val initLabel = 1.0
@@ -54,7 +54,7 @@ class PageRank(dampingFactor:Double = 0.85, iterateSteps:Int = 100, output:Strin
       }, iterateSteps, false) // make iterate act on all vertices, not just messaged ones
   }
 
-  override def tableStage(graph: GraphPerspective): Table = {
+  override def tabularise(graph: GraphPerspective): Table = {
     graph.select({
       vertex =>
         Row(

--- a/src/main/scala/com/raphtory/algorithms/PageRank.scala
+++ b/src/main/scala/com/raphtory/algorithms/PageRank.scala
@@ -26,7 +26,7 @@ Returns
 **/
 class PageRank(dampingFactor:Double = 0.85, iterateSteps:Int = 100, output:String = "/tmp/PageRank") extends  GraphAlgorithm {
 
-  override def algorithm(graph: GraphPerspective): GraphPerspective = {
+  override def apply(graph: GraphPerspective): GraphPerspective = {
     graph.step({
       vertex =>
         val initLabel = 1.0

--- a/src/main/scala/com/raphtory/algorithms/SLPA.scala
+++ b/src/main/scala/com/raphtory/algorithms/SLPA.scala
@@ -32,7 +32,7 @@ Speaker-listener Interaction Dynamic Process by Jierui Xie, Boleslaw K. Szymansk
 
 class SLPA(iterNumber: Int = 50,speakerRule:Rule, listenerRule:Rule, output:String= "/tmp/SLPA") extends GraphAlgorithm {
 
-  override def graphStage(graph: GraphPerspective): GraphPerspective = {
+  override def algorithm(graph: GraphPerspective): GraphPerspective = {
     graph.step({
       // Initialise vertex memory
       vertex =>
@@ -53,7 +53,7 @@ class SLPA(iterNumber: Int = 50,speakerRule:Rule, listenerRule:Rule, output:Stri
       }, executeMessagedOnly = true, iterations = iterNumber)
   }
 
-  override def tableStage(graph: GraphPerspective): Table = {
+  override def tabularise(graph: GraphPerspective): Table = {
     graph.select({
       vertex =>
         val memory = vertex.getState[mutable.Queue[Long]]("memory")

--- a/src/main/scala/com/raphtory/algorithms/SLPA.scala
+++ b/src/main/scala/com/raphtory/algorithms/SLPA.scala
@@ -32,7 +32,7 @@ Speaker-listener Interaction Dynamic Process by Jierui Xie, Boleslaw K. Szymansk
 
 class SLPA(iterNumber: Int = 50,speakerRule:Rule, listenerRule:Rule, output:String= "/tmp/SLPA") extends GraphAlgorithm {
 
-  override def algorithm(graph: GraphPerspective): GraphPerspective = {
+  override def apply(graph: GraphPerspective): GraphPerspective = {
     graph.step({
       // Initialise vertex memory
       vertex =>

--- a/src/main/scala/com/raphtory/algorithms/TriangleCount.scala
+++ b/src/main/scala/com/raphtory/algorithms/TriangleCount.scala
@@ -36,7 +36,7 @@ Notes
 **/
 class TriangleCount(path:String) extends GraphAlgorithm {
 
-  override def graphStage(graph: GraphPerspective): GraphPerspective = {
+  override def algorithm(graph: GraphPerspective): GraphPerspective = {
     graph.step({
       vertex =>
         vertex.setState("triangles", 0)
@@ -48,7 +48,7 @@ class TriangleCount(path:String) extends GraphAlgorithm {
     })
   }
 
-  override def tableStage(graph: GraphPerspective): Table = {
+  override def tabularise(graph: GraphPerspective): Table = {
     graph.select({
       vertex =>
         val neighbours = vertex.getAllNeighbours().toSet

--- a/src/main/scala/com/raphtory/algorithms/TriangleCount.scala
+++ b/src/main/scala/com/raphtory/algorithms/TriangleCount.scala
@@ -36,7 +36,7 @@ Notes
 **/
 class TriangleCount(path:String) extends GraphAlgorithm {
 
-  override def algorithm(graph: GraphPerspective): GraphPerspective = {
+  override def apply(graph: GraphPerspective): GraphPerspective = {
     graph.step({
       vertex =>
         vertex.setState("triangles", 0)

--- a/src/main/scala/com/raphtory/algorithms/TriangleCount.scala
+++ b/src/main/scala/com/raphtory/algorithms/TriangleCount.scala
@@ -1,6 +1,6 @@
 package com.raphtory.algorithms
 
-import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row}
+import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row, Table}
 
 /**
 Description
@@ -36,29 +36,35 @@ Notes
 **/
 class TriangleCount(path:String) extends GraphAlgorithm {
 
-  override def algorithm(graph: GraphPerspective): Unit = {
+  override def graphStage(graph: GraphPerspective): GraphPerspective = {
     graph.step({
       vertex =>
-        vertex.setState("triangles",0)
+        vertex.setState("triangles", 0)
         val neighbours = vertex.getAllNeighbours().toSet
         neighbours.foreach({
           nb =>
             vertex.messageNeighbour(nb, neighbours)
         })
     })
-      .select({
-        vertex =>
-          val neighbours = vertex.getAllNeighbours().toSet
-          val queue = vertex.messageQueue[Set[Long]]
-          var tri = 0
-          queue.foreach(
-            nbs =>
-              tri+=nbs.intersect(neighbours).size
-          )
-          vertex.setState("triangles",tri/2)
-          Row(vertex.getPropertyOrElse("name", vertex.ID()), vertex.getState[Int]("triangles"))
-      })
-      .writeTo(path)
+  }
+
+  override def tableStage(graph: GraphPerspective): Table = {
+    graph.select({
+      vertex =>
+        val neighbours = vertex.getAllNeighbours().toSet
+        val queue = vertex.messageQueue[Set[Long]]
+        var tri = 0
+        queue.foreach(
+          nbs =>
+            tri += nbs.intersect(neighbours).size
+        )
+        vertex.setState("triangles", tri / 2)
+        Row(vertex.getPropertyOrElse("name", vertex.ID()), vertex.getState[Int]("triangles"))
+    })
+  }
+
+  override def write(table: Table): Unit = {
+    table.writeTo(path)
   }
 }
 

--- a/src/main/scala/com/raphtory/algorithms/WattsCascade.scala
+++ b/src/main/scala/com/raphtory/algorithms/WattsCascade.scala
@@ -36,7 +36,7 @@ class WattsCascade(infectedSeed:Array[Long], UNIFORM_RANDOM:Int = 1, UNIFORM_SAM
 
   val randomiser = if (seed != -1) new Random(seed) else new Random()
 
-  override def graphStage(graph: GraphPerspective): GraphPerspective = {
+  override def algorithm(graph: GraphPerspective): GraphPerspective = {
     graph
       .step({
         vertex =>
@@ -69,7 +69,7 @@ class WattsCascade(infectedSeed:Array[Long], UNIFORM_RANDOM:Int = 1, UNIFORM_SAM
       }, 100, true)
   }
 
-  override def tableStage(graph: GraphPerspective): Table = {
+  override def tabularise(graph: GraphPerspective): Table = {
     graph.select({ vertex =>
       Row(
         vertex.ID,

--- a/src/main/scala/com/raphtory/algorithms/WattsCascade.scala
+++ b/src/main/scala/com/raphtory/algorithms/WattsCascade.scala
@@ -36,7 +36,7 @@ class WattsCascade(infectedSeed:Array[Long], UNIFORM_RANDOM:Int = 1, UNIFORM_SAM
 
   val randomiser = if (seed != -1) new Random(seed) else new Random()
 
-  override def algorithm(graph: GraphPerspective): GraphPerspective = {
+  override def apply(graph: GraphPerspective): GraphPerspective = {
     graph
       .step({
         vertex =>

--- a/src/main/scala/com/raphtory/algorithms/WattsCascade.scala
+++ b/src/main/scala/com/raphtory/algorithms/WattsCascade.scala
@@ -1,6 +1,6 @@
 package com.raphtory.algorithms
 
-import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row}
+import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row, Table}
 
 import scala.util.Random
 
@@ -36,21 +36,21 @@ class WattsCascade(infectedSeed:Array[Long], UNIFORM_RANDOM:Int = 1, UNIFORM_SAM
 
   val randomiser = if (seed != -1) new Random(seed) else new Random()
 
-  override def algorithm(graph: GraphPerspective): Unit = {
+  override def graphStage(graph: GraphPerspective): GraphPerspective = {
     graph
       .step({
         vertex =>
           if (infectedSeed.contains(vertex.ID())) {
-            vertex.setState("infected",true)
+            vertex.setState("infected", true)
             vertex.messageAllNeighbours(1.0)
           }
           else {
-            vertex.setState("infected",false)
+            vertex.setState("infected", false)
           }
           if (threshold_choice == UNIFORM_RANDOM) {
             vertex.setState("threshold", randomiser.nextFloat())
           } else {
-            vertex.setState("threshold",threshold_choice)
+            vertex.setState("threshold", threshold_choice)
           }
       })
       .iterate({
@@ -58,21 +58,29 @@ class WattsCascade(infectedSeed:Array[Long], UNIFORM_RANDOM:Int = 1, UNIFORM_SAM
           val degree = vertex.getInEdges().size + vertex.getOutEdges().size
           val newLabel =
             if (degree > 0 && !vertex.getStateOrElse[Boolean]("infected", false))
-              (vertex.messageQueue[Double].sum/degree > threshold_choice)
+              (vertex.messageQueue[Double].sum / degree > threshold_choice)
             else
               vertex.getState[Boolean]("infected")
           if (newLabel != vertex.getState[Boolean]("infected")) {
             vertex.messageAllNeighbours(1.0)
-            vertex.setState("infected",true)
+            vertex.setState("infected", true)
           } else
             vertex.voteToHalt()
       }, 100, true)
-      .select({ vertex => Row(
+  }
+
+  override def tableStage(graph: GraphPerspective): Table = {
+    graph.select({ vertex =>
+      Row(
         vertex.ID,
         vertex.getPropertyOrElse[String]("name", "None"),
-        vertex.getStateOrElse[Boolean]("infected", false))}
-      )
-      .writeTo(output)
+        vertex.getStateOrElse[Boolean]("infected", false))
+    }
+    )
+  }
+
+  override def write(table: Table): Unit = {
+    table.writeTo(output)
   }
 }
 

--- a/src/main/scala/com/raphtory/algorithms/WeightedPageRank.scala
+++ b/src/main/scala/com/raphtory/algorithms/WeightedPageRank.scala
@@ -4,7 +4,7 @@ import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row,
 
 class WeightedPageRank (dampingFactor:Float = 0.85F, iterateSteps:Int = 100, output:String = "/tmp/PageRank") extends  GraphAlgorithm{
 
-  override def algorithm(graph: GraphPerspective): GraphPerspective = {
+  override def apply(graph: GraphPerspective): GraphPerspective = {
     graph.step({
       vertex =>
         val initLabel = 1.0F

--- a/src/main/scala/com/raphtory/algorithms/WeightedPageRank.scala
+++ b/src/main/scala/com/raphtory/algorithms/WeightedPageRank.scala
@@ -4,7 +4,7 @@ import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row,
 
 class WeightedPageRank (dampingFactor:Float = 0.85F, iterateSteps:Int = 100, output:String = "/tmp/PageRank") extends  GraphAlgorithm{
 
-  override def graphStage(graph: GraphPerspective): GraphPerspective = {
+  override def algorithm(graph: GraphPerspective): GraphPerspective = {
     graph.step({
       vertex =>
         val initLabel = 1.0F
@@ -39,7 +39,7 @@ class WeightedPageRank (dampingFactor:Float = 0.85F, iterateSteps:Int = 100, out
       }, iterateSteps, false)
   }
 
-  override def tableStage(graph: GraphPerspective): Table = {
+  override def tabularise(graph: GraphPerspective): Table = {
     graph.select({
       vertex =>
         Row(

--- a/src/main/scala/com/raphtory/algorithms/twoHopNeighbour.scala
+++ b/src/main/scala/com/raphtory/algorithms/twoHopNeighbour.scala
@@ -34,7 +34,7 @@ Warning
   The number of iterations makes a difference to ensure all messages have been read.
 **/
 class twoHopNeighbour(nodeID:Long = -1, output: String = "/tmp/twoHopNeighbour") extends GraphAlgorithm {
-  override def graphStage(graph: GraphPerspective): GraphPerspective = {
+  override def algorithm(graph: GraphPerspective): GraphPerspective = {
     graph
       .step(
         vertex =>
@@ -66,7 +66,7 @@ class twoHopNeighbour(nodeID:Long = -1, output: String = "/tmp/twoHopNeighbour")
       )
   }
 
-  override def tableStage(graph: GraphPerspective): Table = {
+  override def tabularise(graph: GraphPerspective): Table = {
     graph.select(vertex =>
       Row(
         vertex.getStateOrElse("twoHopResponse", false),

--- a/src/main/scala/com/raphtory/algorithms/twoHopNeighbour.scala
+++ b/src/main/scala/com/raphtory/algorithms/twoHopNeighbour.scala
@@ -34,7 +34,7 @@ Warning
   The number of iterations makes a difference to ensure all messages have been read.
 **/
 class twoHopNeighbour(nodeID:Long = -1, output: String = "/tmp/twoHopNeighbour") extends GraphAlgorithm {
-  override def algorithm(graph: GraphPerspective): GraphPerspective = {
+  override def apply(graph: GraphPerspective): GraphPerspective = {
     graph
       .step(
         vertex =>

--- a/src/main/scala/com/raphtory/algorithms/twoHopNeighbour.scala
+++ b/src/main/scala/com/raphtory/algorithms/twoHopNeighbour.scala
@@ -1,8 +1,9 @@
 package com.raphtory.algorithms
 
-import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row}
+import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row, Table}
 
 import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
 
 /**
 Description
@@ -33,11 +34,11 @@ Warning
   The number of iterations makes a difference to ensure all messages have been read.
 **/
 class twoHopNeighbour(nodeID:Long = -1, output: String = "/tmp/twoHopNeighbour") extends GraphAlgorithm {
-  override def algorithm(graph: GraphPerspective): Unit = {
+  override def graphStage(graph: GraphPerspective): GraphPerspective = {
     graph
       .step(
         vertex =>
-          if (nodeID == -1 || vertex.ID() == nodeID){
+          if (nodeID == -1 || vertex.ID() == nodeID) {
             vertex.getEdges().foreach(edge => edge.send(("twoHopRequest", vertex.ID, 0)))
           }
       )
@@ -63,24 +64,30 @@ class twoHopNeighbour(nodeID:Long = -1, output: String = "/tmp/twoHopNeighbour")
           }
         }, 25, true
       )
-      .select(vertex =>
-        Row(
-          vertex.getStateOrElse("twoHopResponse", false),
-          vertex.ID(),
-          vertex.getStateOrElse("twoHops", "")
-        )
+  }
+
+  override def tableStage(graph: GraphPerspective): Table = {
+    graph.select(vertex =>
+      Row(
+        vertex.getStateOrElse("twoHopResponse", false),
+        vertex.ID(),
+        vertex.getStateOrElse("twoHops", "")
       )
+    )
       .filter(
         row =>
           row.get(0) == true)
       .explode(
         row =>
-          row.get(2).asInstanceOf[mutable.ListBuffer[(Long, Long)]]
+          row.get(2).asInstanceOf[ListBuffer[(Long, Long)]]
             .toList.map(hops =>
-              Row(row.get(1), hops._1, hops._2)
+            Row(row.get(1), hops._1, hops._2)
           )
       )
-      .writeTo(output)
+  }
+
+  override def write(table: Table): Unit = {
+    table.writeTo(output)
   }
 }
 

--- a/src/main/scala/com/raphtory/core/build/client/RaphtoryClient.scala
+++ b/src/main/scala/com/raphtory/core/build/client/RaphtoryClient.scala
@@ -22,14 +22,14 @@ class RaphtoryClient(leader:String,port:Int) {
 
   }
 
-  def pointQuery(graphAlgorithm: GraphAlgorithm,timestamp:Long,windows:List[Long]=List()) = {
-    handler ! PointQuery(getID(graphAlgorithm),graphAlgorithm,timestamp,windows)
+  def pointQuery(algorithm: GraphAlgorithm, timestamp:Long, windows:List[Long]=List()) = {
+    handler ! PointQuery(getID(algorithm),algorithm,timestamp,windows)
   }
-  def rangeQuery(graphAlgorithm: GraphAlgorithm,start:Long, end:Long, increment:Long,windows:List[Long]=List()) = {
-    handler ! RangeQuery(getID(graphAlgorithm),graphAlgorithm,start,end,increment,windows)
+  def rangeQuery(algorithm: GraphAlgorithm, start:Long, end:Long, increment:Long, windows:List[Long]=List()) = {
+    handler ! RangeQuery(getID(algorithm),algorithm,start,end,increment,windows)
   }
-  def liveQuery(graphAlgorithm: GraphAlgorithm,increment:Long,windows:List[Long]=List()) = {
-    handler ! LiveQuery(getID(graphAlgorithm),graphAlgorithm,increment,windows)
+  def liveQuery(algorithm: GraphAlgorithm, increment:Long, windows:List[Long]=List()) = {
+    handler ! LiveQuery(getID(algorithm),algorithm,increment,windows)
   }
 
 }

--- a/src/main/scala/com/raphtory/core/build/server/RaphtoryGraph.scala
+++ b/src/main/scala/com/raphtory/core/build/server/RaphtoryGraph.scala
@@ -29,14 +29,14 @@ class RaphtoryGraph [T:ClassTag](spout: Spout[T], graphBuilder: GraphBuilder[T])
     val queryManager    = system.actorOf(Props(new QueryManagerConnector()), "QueryManagerConnector")
 
 
-    def pointQuery(graphAlgorithm: GraphAlgorithm,timestamp:Long,windows:List[Long]=List()) = {
-      queryManager ! PointQuery(getID(graphAlgorithm),graphAlgorithm,timestamp,windows)
+    def pointQuery(algorithm: GraphAlgorithm, timestamp:Long, windows:List[Long]=List()) = {
+      queryManager ! PointQuery(getID(algorithm),algorithm,timestamp,windows)
     }
-    def rangeQuery(graphAlgorithm: GraphAlgorithm,start:Long, end:Long, increment:Long,windows:List[Long]=List()) = {
-      queryManager ! RangeQuery(getID(graphAlgorithm),graphAlgorithm,start,end,increment,windows)
+    def rangeQuery(algorithm: GraphAlgorithm, start:Long, end:Long, increment:Long, windows:List[Long]=List()) = {
+      queryManager ! RangeQuery(getID(algorithm),algorithm,start,end,increment,windows)
     }
-    def liveQuery(graphAlgorithm: GraphAlgorithm,increment:Long,windows:List[Long]=List()) = {
-      queryManager ! LiveQuery(getID(graphAlgorithm),graphAlgorithm,increment,windows)
+    def liveQuery(algorithm: GraphAlgorithm, increment:Long, windows:List[Long]=List()) = {
+      queryManager ! LiveQuery(getID(algorithm),algorithm,increment,windows)
     }
 
   private def getID(algorithm:GraphAlgorithm):String = {
@@ -56,4 +56,6 @@ object RaphtoryGraph {
   def apply[T:ClassTag](spout: Spout[T], graphBuilder: GraphBuilder[T]) = {
     new RaphtoryGraph[T](spout,graphBuilder)
   }
+
+  type Windows = List[Long]
 }

--- a/src/main/scala/com/raphtory/core/components/querymanager/QueryHandler.scala
+++ b/src/main/scala/com/raphtory/core/components/querymanager/QueryHandler.scala
@@ -70,7 +70,7 @@ abstract class QueryHandler(jobID:String,algorithm: GraphAlgorithm) extends Raph
   private def executeGraph(state: State, currentOpperation: GraphFunction, vertexCount:Int, readyCount: Int, receivedMessageCount: Int, sentMessageCount: Int, allVoteToHalt: Boolean):Receive = withDefaultMessageHandler("Execute Graph") {
     case StartGraph =>
       val graphPerspective = new GenericGraphPerspective(vertexCount)
-      algorithm.algorithm(graphPerspective)
+      algorithm.run(graphPerspective)
       val table = graphPerspective.getTable()
       graphPerspective.getNextOperation() match {
         case Some(f:Select) =>

--- a/src/main/scala/com/raphtory/core/model/algorithm/AlgorithmChain.scala
+++ b/src/main/scala/com/raphtory/core/model/algorithm/AlgorithmChain.scala
@@ -11,11 +11,11 @@ class AlgorithmChain(algorithms: Seq[GraphAlgorithm]) extends GraphAlgorithm {
     gp
   }
 
-  override def tableStage(graphPerspective: GraphPerspective): Table = {
+  override def tableStage(graph: GraphPerspective): Table = {
     if(algorithms.nonEmpty)
-      algorithms.last.tableStage(graphPerspective)
+      algorithms.last.tableStage(graph)
     else
-      super.tableStage(graphPerspective)
+      super.tableStage(graph)
   }
 
   override def write(table: Table): Unit = {

--- a/src/main/scala/com/raphtory/core/model/algorithm/AlgorithmChain.scala
+++ b/src/main/scala/com/raphtory/core/model/algorithm/AlgorithmChain.scala
@@ -2,20 +2,20 @@ package com.raphtory.core.model.algorithm
 
 class AlgorithmChain(algorithms: Seq[GraphAlgorithm]) extends GraphAlgorithm {
 
-  override def graphStage(graphPerspective: GraphPerspective): GraphPerspective = {
+  override def algorithm(graphPerspective: GraphPerspective): GraphPerspective = {
     var gp = graphPerspective
     if(algorithms.nonEmpty) {
       for(algorithm <- algorithms)
-        gp = algorithm.graphStage(gp)
+        gp = algorithm.algorithm(gp)
     }
     gp
   }
 
-  override def tableStage(graph: GraphPerspective): Table = {
+  override def tabularise(graph: GraphPerspective): Table = {
     if(algorithms.nonEmpty)
-      algorithms.last.tableStage(graph)
+      algorithms.last.tabularise(graph)
     else
-      super.tableStage(graph)
+      super.tabularise(graph)
   }
 
   override def write(table: Table): Unit = {

--- a/src/main/scala/com/raphtory/core/model/algorithm/AlgorithmChain.scala
+++ b/src/main/scala/com/raphtory/core/model/algorithm/AlgorithmChain.scala
@@ -1,0 +1,32 @@
+package com.raphtory.core.model.algorithm
+
+class AlgorithmChain(algorithms: Seq[GraphAlgorithm]) extends GraphAlgorithm {
+
+  override def graphStage(graphPerspective: GraphPerspective): GraphPerspective = {
+    var gp = graphPerspective
+    if(algorithms.nonEmpty) {
+      for(algorithm <- algorithms)
+        gp = algorithm.graphStage(gp)
+    }
+    gp
+  }
+
+  override def tableStage(graphPerspective: GraphPerspective): Table = {
+    if(algorithms.nonEmpty)
+      algorithms.last.tableStage(graphPerspective)
+    else
+      super.tableStage(graphPerspective)
+  }
+
+  override def write(table: Table): Unit = {
+    if(algorithms.nonEmpty)
+      algorithms.last.write(table)
+    else
+      super.write(table)
+  }
+
+}
+
+object AlgorithmChain {
+  def apply(algorithms: GraphAlgorithm*) = new AlgorithmChain(algorithms)
+}

--- a/src/main/scala/com/raphtory/core/model/algorithm/Chain.scala
+++ b/src/main/scala/com/raphtory/core/model/algorithm/Chain.scala
@@ -1,12 +1,14 @@
 package com.raphtory.core.model.algorithm
 
-class AlgorithmChain(algorithms: Seq[GraphAlgorithm]) extends GraphAlgorithm {
+import scala.Seq
 
-  override def algorithm(graphPerspective: GraphPerspective): GraphPerspective = {
+class Chain(algorithms: Seq[GraphAlgorithm]) extends GraphAlgorithm {
+
+  override def apply(graphPerspective: GraphPerspective): GraphPerspective = {
     var gp = graphPerspective
     if(algorithms.nonEmpty) {
       for(algorithm <- algorithms)
-        gp = algorithm.algorithm(gp)
+        gp = algorithm.apply(gp)
     }
     gp
   }
@@ -25,8 +27,13 @@ class AlgorithmChain(algorithms: Seq[GraphAlgorithm]) extends GraphAlgorithm {
       super.write(table)
   }
 
+  override def ->(graphAlgorithm: GraphAlgorithm):Chain = {
+    Chain(algorithms.toList ++ List(graphAlgorithm))
+  }
+
 }
 
-object AlgorithmChain {
-  def apply(algorithms: GraphAlgorithm*) = new AlgorithmChain(algorithms)
+object Chain {
+  def apply(algorithms: GraphAlgorithm*) = new Chain(algorithms)
+  def apply(algorithms: List[GraphAlgorithm]) = new Chain(algorithms)
 }

--- a/src/main/scala/com/raphtory/core/model/algorithm/GraphAlgorithm.scala
+++ b/src/main/scala/com/raphtory/core/model/algorithm/GraphAlgorithm.scala
@@ -3,11 +3,11 @@ package com.raphtory.core.model.algorithm
 import net.openhft.hashing.LongHashFunction
 
 abstract class GraphAlgorithm extends Serializable {
-  def graphStage(graph: GraphPerspective):GraphPerspective = {graph}
-  def tableStage(graph: GraphPerspective):Table = {graph.select(vertex => Row())}
+  def algorithm(graph: GraphPerspective):GraphPerspective = {graph}
+  def tabularise(graph: GraphPerspective):Table = {graph.select(vertex => Row())}
   def write(table: Table): Unit = {}
-  def algorithm(graph:GraphPerspective) = {
-    write(tableStage(graphStage(graph)))
+  def run(graph:GraphPerspective):Unit = {
+    write(tabularise(algorithm(graph)))
   }
 
   final def checkID(uniqueChars: String): Long = LongHashFunction.xx3().hashChars(uniqueChars)

--- a/src/main/scala/com/raphtory/core/model/algorithm/GraphAlgorithm.scala
+++ b/src/main/scala/com/raphtory/core/model/algorithm/GraphAlgorithm.scala
@@ -3,12 +3,14 @@ package com.raphtory.core.model.algorithm
 import net.openhft.hashing.LongHashFunction
 
 abstract class GraphAlgorithm extends Serializable {
-  def algorithm(graph: GraphPerspective):GraphPerspective = {graph}
+  def apply(graph: GraphPerspective):GraphPerspective = {graph}
   def tabularise(graph: GraphPerspective):Table = {graph.select(vertex => Row())}
   def write(table: Table): Unit = {}
   def run(graph:GraphPerspective):Unit = {
-    write(tabularise(algorithm(graph)))
+    write(tabularise(apply(graph)))
   }
+
+  def ->(graphAlgorithm: GraphAlgorithm):Chain = {Chain(this,graphAlgorithm)}
 
   final def checkID(uniqueChars: String): Long = LongHashFunction.xx3().hashChars(uniqueChars)
 }

--- a/src/main/scala/com/raphtory/core/model/algorithm/GraphAlgorithm.scala
+++ b/src/main/scala/com/raphtory/core/model/algorithm/GraphAlgorithm.scala
@@ -3,8 +3,8 @@ package com.raphtory.core.model.algorithm
 import net.openhft.hashing.LongHashFunction
 
 abstract class GraphAlgorithm extends Serializable {
-  def graphStage(graphPerspective: GraphPerspective):GraphPerspective = {graphPerspective}
-  def tableStage(graphPerspective: GraphPerspective):Table = {graphPerspective.select(vertex => Row())}
+  def graphStage(graph: GraphPerspective):GraphPerspective = {graph}
+  def tableStage(graph: GraphPerspective):Table = {graph.select(vertex => Row())}
   def write(table: Table): Unit = {}
   def algorithm(graph:GraphPerspective) = {
     write(tableStage(graphStage(graph)))

--- a/src/main/scala/com/raphtory/core/model/algorithm/GraphAlgorithm.scala
+++ b/src/main/scala/com/raphtory/core/model/algorithm/GraphAlgorithm.scala
@@ -3,9 +3,13 @@ package com.raphtory.core.model.algorithm
 import net.openhft.hashing.LongHashFunction
 
 abstract class GraphAlgorithm extends Serializable {
-  def algorithm(graph:GraphPerspective)
+  def graphStage(graphPerspective: GraphPerspective):GraphPerspective = {graphPerspective}
+  def tableStage(graphPerspective: GraphPerspective):Table = {graphPerspective.select(vertex => Row())}
+  def write(table: Table): Unit = {}
+  def algorithm(graph:GraphPerspective) = {
+    write(tableStage(graphStage(graph)))
+  }
 
   final def checkID(uniqueChars: String): Long = LongHashFunction.xx3().hashChars(uniqueChars)
 }
-
 

--- a/src/main/scala/com/raphtory/core/model/algorithm/Identity.scala
+++ b/src/main/scala/com/raphtory/core/model/algorithm/Identity.scala
@@ -1,0 +1,8 @@
+package com.raphtory.core.model.algorithm
+
+class Identity extends GraphAlgorithm {
+}
+
+object Identity {
+  def apply() = new Identity()
+}


### PR DESCRIPTION
I've started working on making the Algorithm API composable: 

The main idea is to break up the algorithm into three stages:

1. graphStage: takes a graph as input and returns a graph (can be composed)
2. tableStage: takes a graph and runs select to return a table (not composable)
3. write: takes table as input and writes out results (not composable)

This also implements an AlgorithmChain which takes a sequence of algorithms as input and runs the graph stages in sequence and then runs the table and write out of the final algorithm in the chain.

Suggestions for method names and comments very welcome!