### PR TITLE
Feature/optionally include properties

### DIFF
--- a/src/main/scala/com/raphtory/core/model/graph/visitor/Vertex.scala
+++ b/src/main/scala/com/raphtory/core/model/graph/visitor/Vertex.scala
@@ -51,10 +51,10 @@ trait Vertex extends EntityVisitor {
 
   // analytical state
   def setState(key: String, value: Any): Unit
-  def getState[T: ClassTag](key: String):T
-  def getStateOrElse[T: ClassTag](key: String,value:T):T
-  def containsState(key: String): Boolean
-  def getOrSetState[T: ClassTag](key: String, value: T): T
+  def getState[T: ClassTag](key: String, includeProperties: Boolean = false):T
+  def getStateOrElse[T: ClassTag](key: String,value:T, includeProperties: Boolean = false):T
+  def containsState(key: String, includeProperties: Boolean = false): Boolean
+  def getOrSetState[T: ClassTag](key: String, value: T, includeProperties: Boolean = false): T
   def appendToState[T: ClassTag](key: String, value: Any):Unit
 
   // Also need a function for receiving messages, but the user should not have access to this

--- a/src/main/scala/com/raphtory/core/model/graph/visitor/Vertex.scala
+++ b/src/main/scala/com/raphtory/core/model/graph/visitor/Vertex.scala
@@ -51,9 +51,11 @@ trait Vertex extends EntityVisitor {
 
   // analytical state
   def setState(key: String, value: Any): Unit
+  // if includeProperties = true, key is looked up first in analytical state with a fall-through to properties if not found
   def getState[T: ClassTag](key: String, includeProperties: Boolean = false):T
   def getStateOrElse[T: ClassTag](key: String,value:T, includeProperties: Boolean = false):T
   def containsState(key: String, includeProperties: Boolean = false): Boolean
+  // if includeProperties = true and value is pulled in from properties, the new value is set as state
   def getOrSetState[T: ClassTag](key: String, value: T, includeProperties: Boolean = false): T
   def appendToState[T: ClassTag](key: String, value: Any):Unit
 


### PR DESCRIPTION
Implement a flag to include values defined as properties when looking up state on vertices. This is useful in conjunction with the  composable API (see #217) as it means that an algorithm can declare that it does not care whether a value was the result of computations done by a previous algorithm in the chain or something that was defined when the data was ingested.