### PR TITLE
Reorganise algorithm folder

### DIFF
--- a/src/main/scala/com/raphtory/algorithms/generic/CBOD.scala
+++ b/src/main/scala/com/raphtory/algorithms/generic/CBOD.scala
@@ -1,6 +1,6 @@
-package com.raphtory.algorithms
+package com.raphtory.algorithms.generic
 
-import com.raphtory.core.model.algorithm.{GraphPerspective, Row, Table, GraphAlgorithm, Identity}
+import com.raphtory.core.model.algorithm._
 
 /**
 Description

--- a/src/main/scala/com/raphtory/algorithms/generic/ConnectedComponents.scala
+++ b/src/main/scala/com/raphtory/algorithms/generic/ConnectedComponents.scala
@@ -1,4 +1,4 @@
-package com.raphtory.algorithms
+package com.raphtory.algorithms.generic
 
 import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row, Table}
 

--- a/src/main/scala/com/raphtory/algorithms/generic/centrality/Degree.scala
+++ b/src/main/scala/com/raphtory/algorithms/generic/centrality/Degree.scala
@@ -1,4 +1,4 @@
-package com.raphtory.algorithms
+package com.raphtory.algorithms.generic.centrality
 
 import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row, Table}
 

--- a/src/main/scala/com/raphtory/algorithms/generic/centrality/Distinctiveness.scala
+++ b/src/main/scala/com/raphtory/algorithms/generic/centrality/Distinctiveness.scala
@@ -1,4 +1,4 @@
-package com.raphtory.algorithms
+package com.raphtory.algorithms.generic.centrality
 
 import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row, Table}
 import com.raphtory.core.model.graph.visitor.Vertex

--- a/src/main/scala/com/raphtory/algorithms/generic/centrality/NeighbourAverageDegree.scala
+++ b/src/main/scala/com/raphtory/algorithms/generic/centrality/NeighbourAverageDegree.scala
@@ -1,4 +1,4 @@
-package com.raphtory.algorithms
+package com.raphtory.algorithms.generic.centrality
 
 import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row, Table}
 

--- a/src/main/scala/com/raphtory/algorithms/generic/centrality/OutDegreeAverage.scala
+++ b/src/main/scala/com/raphtory/algorithms/generic/centrality/OutDegreeAverage.scala
@@ -1,4 +1,4 @@
-package com.raphtory.algorithms
+package com.raphtory.algorithms.generic.centrality
 
 import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row, Table}
 

--- a/src/main/scala/com/raphtory/algorithms/generic/centrality/PageRank.scala
+++ b/src/main/scala/com/raphtory/algorithms/generic/centrality/PageRank.scala
@@ -1,4 +1,4 @@
-package com.raphtory.algorithms
+package com.raphtory.algorithms.generic.centrality
 
 import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row, Table}
 

--- a/src/main/scala/com/raphtory/algorithms/generic/centrality/TriangleCount.scala
+++ b/src/main/scala/com/raphtory/algorithms/generic/centrality/TriangleCount.scala
@@ -1,4 +1,4 @@
-package com.raphtory.algorithms
+package com.raphtory.algorithms.generic.centrality
 
 import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row, Table}
 

--- a/src/main/scala/com/raphtory/algorithms/generic/centrality/WeightedDegree.scala
+++ b/src/main/scala/com/raphtory/algorithms/generic/centrality/WeightedDegree.scala
@@ -1,4 +1,4 @@
-package com.raphtory.algorithms
+package com.raphtory.algorithms.generic.centrality
 
 import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row, Table}
 

--- a/src/main/scala/com/raphtory/algorithms/generic/centrality/WeightedPageRank.scala
+++ b/src/main/scala/com/raphtory/algorithms/generic/centrality/WeightedPageRank.scala
@@ -1,4 +1,4 @@
-package com.raphtory.algorithms
+package com.raphtory.algorithms.generic.centrality
 
 import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row, Table}
 

--- a/src/main/scala/com/raphtory/algorithms/generic/community/LPA.scala
+++ b/src/main/scala/com/raphtory/algorithms/generic/community/LPA.scala
@@ -1,8 +1,8 @@
-package com.raphtory.algorithms
+package com.raphtory.algorithms.generic.community
 
-import com.raphtory.algorithms.LPA.lpa
 import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row, Table}
 import com.raphtory.core.model.graph.visitor.Vertex
+import com.raphtory.algorithms.generic.community.LPA.lpa
 
 import scala.util.Random
 

--- a/src/main/scala/com/raphtory/algorithms/generic/community/SLPA.scala
+++ b/src/main/scala/com/raphtory/algorithms/generic/community/SLPA.scala
@@ -1,4 +1,4 @@
-package com.raphtory.algorithms
+package com.raphtory.algorithms.generic.community
 
 import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row, Table}
 

--- a/src/main/scala/com/raphtory/algorithms/generic/dynamic/BinaryDiffusion.scala
+++ b/src/main/scala/com/raphtory/algorithms/generic/dynamic/BinaryDiffusion.scala
@@ -1,4 +1,4 @@
-package com.raphtory.algorithms
+package com.raphtory.algorithms.generic.dynamic
 
 import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row, Table}
 

--- a/src/main/scala/com/raphtory/algorithms/generic/dynamic/WattsCascade.scala
+++ b/src/main/scala/com/raphtory/algorithms/generic/dynamic/WattsCascade.scala
@@ -1,4 +1,4 @@
-package com.raphtory.algorithms
+package com.raphtory.algorithms.generic.dynamic
 
 import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row, Table}
 

--- a/src/main/scala/com/raphtory/algorithms/generic/twoHopNeighbour.scala
+++ b/src/main/scala/com/raphtory/algorithms/generic/twoHopNeighbour.scala
@@ -1,4 +1,4 @@
-package com.raphtory.algorithms
+package com.raphtory.algorithms.generic
 
 import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row, Table}
 

--- a/src/main/scala/com/raphtory/algorithms/temporal/Ancestors.scala
+++ b/src/main/scala/com/raphtory/algorithms/temporal/Ancestors.scala
@@ -1,4 +1,4 @@
-package com.raphtory.algorithms
+package com.raphtory.algorithms.temporal
 
 import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row, Table}
 

--- a/src/main/scala/com/raphtory/algorithms/temporal/Descendants.scala
+++ b/src/main/scala/com/raphtory/algorithms/temporal/Descendants.scala
@@ -1,4 +1,4 @@
-package com.raphtory.algorithms
+package com.raphtory.algorithms.temporal
 
 import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row, Table}
 

--- a/src/main/scala/com/raphtory/algorithms/temporal/MotifAlpha.scala
+++ b/src/main/scala/com/raphtory/algorithms/temporal/MotifAlpha.scala
@@ -1,4 +1,4 @@
-package com.raphtory.algorithms
+package com.raphtory.algorithms.temporal
 
 import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row, Table}
 

--- a/src/main/scala/com/raphtory/algorithms/temporal/community/MultilayerLPA.scala
+++ b/src/main/scala/com/raphtory/algorithms/temporal/community/MultilayerLPA.scala
@@ -1,8 +1,9 @@
-package com.raphtory.algorithms
+package com.raphtory.algorithms.temporal.community
+
 import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row, Table}
 import com.raphtory.core.model.graph.visitor.Vertex
 
-import scala.collection.mutable.{ListBuffer, Queue}
+import scala.collection.mutable.ListBuffer
 import scala.util.Random
 
 /**

--- a/src/main/scala/com/raphtory/algorithms/temporal/dynamic/GenericTaint.scala
+++ b/src/main/scala/com/raphtory/algorithms/temporal/dynamic/GenericTaint.scala
@@ -1,4 +1,4 @@
-package com.raphtory.algorithms
+package com.raphtory.algorithms.temporal.dynamic
 
 import com.raphtory.core.model.algorithm.{GraphAlgorithm, GraphPerspective, Row, Table}
 

--- a/src/test/scala/com/raphtory/allcommands/AllCommandsTest.scala
+++ b/src/test/scala/com/raphtory/allcommands/AllCommandsTest.scala
@@ -3,15 +3,15 @@ package com.raphtory.allcommands
 import org.scalatest.FunSuite
 import akka.pattern.ask
 import akka.util.Timeout
-import com.raphtory.algorithms.ConnectedComponents
 import com.raphtory.RaphtoryPD
 import com.raphtory.algorithms.GraphState
 import com.raphtory.core.components.querymanager.QueryManager.Message.{AreYouFinished, ManagingTask, PointQuery, RangeQuery, TaskFinished, Windows}
 import com.raphtory.core.components.leader.WatermarkManager.Message.{WatermarkTime, WhatsTheTime}
-import com.raphtory.core.model.algorithm.{GraphAlgorithm, GenericGraphPerspective}
+import com.raphtory.core.model.algorithm.{GenericGraphPerspective, GraphAlgorithm}
 import com.raphtory.spouts.FileSpout
 import spray.json._
 import com.google.common.hash.Hashing
+import com.raphtory.algorithms.generic.ConnectedComponents
 
 import java.io.File
 import java.nio.charset.StandardCharsets


### PR DESCRIPTION
This is an attempt at organising the algorithms folder. This first splits the algorithms into "generic" algorithms which just look at vertices and edges, ignoring the temporal properties of the data and "temporal" algorithms which actually explore the history of vertices and edges.

Within these two groups I've categorised the algorithms into

- centrality: compute node centrality values
- community: community detection algorithms
- dynamic: simulated dynamical process

There also remain a few unclassified algorithms. Any suggestions and comments welcome!