### PR TITLE
consistent naming for vertex messaging methods

### DIFF
--- a/src/main/scala/com/raphtory/algorithms/generic/centrality/PageRank.scala
+++ b/src/main/scala/com/raphtory/algorithms/generic/centrality/PageRank.scala
@@ -33,7 +33,7 @@ class PageRank(dampingFactor:Double = 0.85, iterateSteps:Int = 100, output:Strin
         vertex.setState("prlabel", initLabel)
         val outDegree = vertex.getOutNeighbours().size
         if (outDegree > 0.0)
-          vertex.messageAllOutgoingNeighbors(initLabel / outDegree)
+          vertex.messageOutNeighbours(initLabel / outDegree)
     }).
       iterate({ vertex =>
         val vname = vertex.getPropertyOrElse("name", vertex.ID().toString) // for logging purposes
@@ -45,7 +45,7 @@ class PageRank(dampingFactor:Double = 0.85, iterateSteps:Int = 100, output:Strin
 
         val outDegree = vertex.getOutNeighbours().size
         if (outDegree > 0) {
-          vertex.messageAllOutgoingNeighbors(newLabel / outDegree)
+          vertex.messageOutNeighbours(newLabel / outDegree)
         }
 
         if (Math.abs(newLabel - currentLabel) / currentLabel < 0.00001) {

--- a/src/main/scala/com/raphtory/algorithms/generic/centrality/TriangleCount.scala
+++ b/src/main/scala/com/raphtory/algorithms/generic/centrality/TriangleCount.scala
@@ -43,7 +43,7 @@ class TriangleCount(path:String) extends GraphAlgorithm {
         val neighbours = vertex.getAllNeighbours().toSet
         neighbours.foreach({
           nb =>
-            vertex.messageNeighbour(nb, neighbours)
+            vertex.messageVertex(nb, neighbours)
         })
     })
   }

--- a/src/main/scala/com/raphtory/algorithms/generic/centrality/WeightedPageRank.scala
+++ b/src/main/scala/com/raphtory/algorithms/generic/centrality/WeightedPageRank.scala
@@ -14,7 +14,7 @@ class WeightedPageRank (dampingFactor:Float = 0.85F, iterateSteps:Int = 100, out
           .sum
         vertex.getOutEdges().foreach({
           e =>
-            vertex.messageNeighbour(e.ID, e.getPropertyOrElse("weight", e.history().size).toFloat / outWeight)
+            vertex.messageVertex(e.ID, e.getPropertyOrElse("weight", e.history().size).toFloat / outWeight)
         })
     })
       .iterate({ vertex =>
@@ -30,7 +30,7 @@ class WeightedPageRank (dampingFactor:Float = 0.85F, iterateSteps:Int = 100, out
           .sum
         vertex.getOutEdges().foreach({
           e =>
-            vertex.messageNeighbour(e.ID, newLabel * e.getPropertyOrElse("weight", e.history().size).toFloat / outWeight)
+            vertex.messageVertex(e.ID, newLabel * e.getPropertyOrElse("weight", e.history().size).toFloat / outWeight)
         })
 
         if (Math.abs(newLabel - currentLabel) / currentLabel < 0.00001) {

--- a/src/main/scala/com/raphtory/algorithms/generic/twoHopNeighbour.scala
+++ b/src/main/scala/com/raphtory/algorithms/generic/twoHopNeighbour.scala
@@ -51,7 +51,7 @@ class twoHopNeighbour(nodeID:Long = -1, output: String = "/tmp/twoHopNeighbour")
             vertex.getAllNeighbours().foreach { neighbour =>
               requests.foreach(msg =>
                 if (msg._2 != neighbour) {
-                  vertex.messageNeighbour(msg._2, ("twoHopResponse", neighbour, vertex.ID))
+                  vertex.messageVertex(msg._2, ("twoHopResponse", neighbour, vertex.ID))
                 })
             }
           }

--- a/src/main/scala/com/raphtory/algorithms/temporal/Ancestors.scala
+++ b/src/main/scala/com/raphtory/algorithms/temporal/Ancestors.scala
@@ -18,7 +18,7 @@ class Ancestors(path:String,
             .filter(e => e.lastActivityBefore(time).time > time - delta)
           edges.foreach({
             e =>
-              vertex.messageNeighbour(e.ID(), e.lastActivityBefore(time).time)
+              vertex.messageVertex(e.ID(), e.lastActivityBefore(time).time)
           })
           vertex.setState("ancestor", false)
         }
@@ -33,7 +33,7 @@ class Ancestors(path:String,
             .filter(e => e.lastActivityBefore(time).time > latestTime - delta)
           inEdges.foreach({
             e =>
-              vertex.messageNeighbour(e.ID(), e.lastActivityBefore(latestTime).time)
+              vertex.messageVertex(e.ID(), e.lastActivityBefore(latestTime).time)
           })
       }, executeMessagedOnly = true, iterations = 100)
   }

--- a/src/main/scala/com/raphtory/algorithms/temporal/Descendants.scala
+++ b/src/main/scala/com/raphtory/algorithms/temporal/Descendants.scala
@@ -18,7 +18,7 @@ class Descendants(path:String,
             .filter(e => e.firstActivityAfter(time).time < time + delta)
           edges.foreach({
             e =>
-              vertex.messageNeighbour(e.ID(), e.firstActivityAfter(time).time)
+              vertex.messageVertex(e.ID(), e.firstActivityAfter(time).time)
           })
           vertex.setState("descendant", false)
         }
@@ -33,7 +33,7 @@ class Descendants(path:String,
             .filter(e => e.firstActivityAfter(earliestTime).time < earliestTime + delta)
           outEdges.foreach({
             e =>
-              vertex.messageNeighbour(e.ID(), e.firstActivityAfter(earliestTime).time)
+              vertex.messageVertex(e.ID(), e.firstActivityAfter(earliestTime).time)
           })
       }, executeMessagedOnly = true, iterations = 100)
   }

--- a/src/main/scala/com/raphtory/core/implementations/pojograph/entities/external/PojoExVertex.scala
+++ b/src/main/scala/com/raphtory/core/implementations/pojograph/entities/external/PojoExVertex.scala
@@ -143,19 +143,19 @@ class PojoExVertex(private val v: PojoVertex,
   override def messageSelf(data: Any): Unit =
     lens.sendMessage(VertexMessage(lens.superStep+1,ID(), data))
 
-  def messageNeighbour(vertexId: Long, data: Any): Unit = {
+  def messageVertex(vertexId: Long, data: Any): Unit = {
     val message = VertexMessage(lens.superStep+1,vertexId, data)
     lens.sendMessage(message)
   }
 
-  def messageAllOutgoingNeighbors(message: Any): Unit =
-    internalOutgoingEdges.keys.foreach(vId => messageNeighbour(vId, message))
+  def messageOutNeighbours(message: Any): Unit =
+    internalOutgoingEdges.keys.foreach(vId => messageVertex(vId, message))
 
   def messageAllNeighbours(message: Any) =
-    internalOutgoingEdges.keySet.union(internalIncomingEdges.keySet).foreach(vId => messageNeighbour(vId, message))
+    internalOutgoingEdges.keySet.union(internalIncomingEdges.keySet).foreach(vId => messageVertex(vId, message))
 
-  def messageAllIngoingNeighbors(message: Any): Unit =
-    internalIncomingEdges.keys.foreach(vId => messageNeighbour(vId, message))
+  def messageInNeighbours(message: Any): Unit =
+    internalIncomingEdges.keys.foreach(vId => messageVertex(vId, message))
 
   // todo hide
   def receiveMessage(msg: VertexMessage): Unit = {

--- a/src/main/scala/com/raphtory/core/model/graph/visitor/Vertex.scala
+++ b/src/main/scala/com/raphtory/core/model/graph/visitor/Vertex.scala
@@ -14,10 +14,10 @@ trait Vertex extends EntityVisitor {
   def voteToHalt(): Unit
   //Send message
   def messageSelf(data: Any):Unit
-  def messageNeighbour(vertexId: Long, data: Any): Unit
-  def messageAllOutgoingNeighbors(message: Any): Unit
+  def messageVertex(vertexId: Long, data: Any): Unit
+  def messageOutNeighbours(message: Any): Unit
   def messageAllNeighbours(message: Any)
-  def messageAllIngoingNeighbors(message: Any): Unit
+  def messageInNeighbours(message: Any): Unit
 
   //Get Neighbours
   def getAllNeighbours(after:Long=0L,before:Long=Long.MaxValue): List[Long]


### PR DESCRIPTION
- Clean up spelling and inconsistent names for messaging methods
- Rename `messageNeighbour` to `messageVertex` as it can take an arbitrary vertex id which does not have to be connected to the vertex sending the message 