### PR TITLE
"name" function for vertices

### DIFF
--- a/src/main/scala/com/raphtory/algorithms/generic/CBOD.scala
+++ b/src/main/scala/com/raphtory/algorithms/generic/CBOD.scala
@@ -41,7 +41,7 @@ class CBOD(label: String = "label", cutoff: Double = 0.0, output: String = "/tmp
   override def tabularise(graph: GraphPerspective): Table = {
     graph.select { vertex =>
       Row(
-        vertex.ID(),
+        vertex.name(),
         vertex.getStateOrElse[Double]("outlierscore", 10.0)
       )
     }

--- a/src/main/scala/com/raphtory/algorithms/generic/ConnectedComponents.scala
+++ b/src/main/scala/com/raphtory/algorithms/generic/ConnectedComponents.scala
@@ -43,7 +43,7 @@ class ConnectedComponents(path:String) extends GraphAlgorithm{
   }
 
   override def tabularise(graph: GraphPerspective): Table = {
-    graph.select(vertex => Row(vertex.ID(), vertex.getState[Long]("cclabel")))
+    graph.select(vertex => Row(vertex.name(), vertex.getState[Long]("cclabel")))
   }
 
   override def write(table: Table): Unit = {

--- a/src/main/scala/com/raphtory/algorithms/generic/centrality/Degree.scala
+++ b/src/main/scala/com/raphtory/algorithms/generic/centrality/Degree.scala
@@ -24,7 +24,7 @@ class Degree(path:String) extends GraphAlgorithm{
         val inDegree = vertex.getInNeighbours().size
         val outDegree = vertex.getOutNeighbours().size
         val totalDegree = vertex.getAllNeighbours().size
-        Row(vertex.getPropertyOrElse("name", vertex.ID()), inDegree, outDegree, totalDegree)
+        Row(vertex.name(), inDegree, outDegree, totalDegree)
     })
   }
 

--- a/src/main/scala/com/raphtory/algorithms/generic/centrality/Distinctiveness.scala
+++ b/src/main/scala/com/raphtory/algorithms/generic/centrality/Distinctiveness.scala
@@ -51,7 +51,7 @@ class Distinctiveness(path:String, alpha:Double=1.0) extends GraphAlgorithm{
         val D3c = D3(vertex, messages, N, alpha)
         val D4c = D4(vertex, messages, N, alpha)
         val D5c = D5(vertex, messages, N, alpha)
-        Row(vertex.getPropertyOrElse("name", vertex.ID()), D1c, D2c, D3c, D4c, D5c)
+        Row(vertex.name(), D1c, D2c, D3c, D4c, D5c)
     })
   }
 

--- a/src/main/scala/com/raphtory/algorithms/generic/centrality/NeighbourAverageDegree.scala
+++ b/src/main/scala/com/raphtory/algorithms/generic/centrality/NeighbourAverageDegree.scala
@@ -17,7 +17,7 @@ class NeighbourAverageDegree(path:String) extends GraphAlgorithm{
         val degrees = vertex.messageQueue[Int]
         val degree = vertex.getAllNeighbours().size
         val avgNeigh = if (degree > 0) degrees.sum.toFloat / degree else 0.0
-        Row(vertex.getPropertyOrElse("name", vertex.ID()), degree, avgNeigh)
+        Row(vertex.name(), degree, avgNeigh)
     })
   }
 

--- a/src/main/scala/com/raphtory/algorithms/generic/centrality/OutDegreeAverage.scala
+++ b/src/main/scala/com/raphtory/algorithms/generic/centrality/OutDegreeAverage.scala
@@ -8,13 +8,12 @@ class OutDegreeAverage(output:String) extends GraphAlgorithm {
     graph
       .select({
         vertex =>
-          val id = vertex.ID()
           val sized =
             try vertex.getOutEdges().size.toDouble / nodeCount.toDouble
             catch {
               case _: ArithmeticException => 0
             }
-          Row(id, sized)
+          Row(vertex.name(), sized)
       })
   }
 

--- a/src/main/scala/com/raphtory/algorithms/generic/centrality/PageRank.scala
+++ b/src/main/scala/com/raphtory/algorithms/generic/centrality/PageRank.scala
@@ -36,7 +36,7 @@ class PageRank(dampingFactor:Double = 0.85, iterateSteps:Int = 100, output:Strin
           vertex.messageOutNeighbours(initLabel / outDegree)
     }).
       iterate({ vertex =>
-        val vname = vertex.getPropertyOrElse("name", vertex.ID().toString) // for logging purposes
+        val vname = vertex.name() // for logging purposes
         val currentLabel = vertex.getState[Double]("prlabel")
 
         val queue = vertex.messageQueue[Double]
@@ -58,7 +58,7 @@ class PageRank(dampingFactor:Double = 0.85, iterateSteps:Int = 100, output:Strin
     graph.select({
       vertex =>
         Row(
-          vertex.getPropertyOrElse("name", vertex.ID()),
+          vertex.name(),
           vertex.getStateOrElse("prlabel", -1)
         )
     })

--- a/src/main/scala/com/raphtory/algorithms/generic/centrality/TriangleCount.scala
+++ b/src/main/scala/com/raphtory/algorithms/generic/centrality/TriangleCount.scala
@@ -59,7 +59,7 @@ class TriangleCount(path:String) extends GraphAlgorithm {
             tri += nbs.intersect(neighbours).size
         )
         vertex.setState("triangles", tri / 2)
-        Row(vertex.getPropertyOrElse("name", vertex.ID()), vertex.getState[Int]("triangles"))
+        Row(vertex.name(), vertex.getState[Int]("triangles"))
     })
   }
 

--- a/src/main/scala/com/raphtory/algorithms/generic/centrality/WeightedDegree.scala
+++ b/src/main/scala/com/raphtory/algorithms/generic/centrality/WeightedDegree.scala
@@ -32,7 +32,7 @@ class WeightedDegree(weightProperty:String="weight",output:String = "/tmp/Weight
           .map(e => e.getPropertyOrElse(weightProperty, 1.0))
           .sum
         val totWeight = inWeight + outWeight
-        Row(vertex.getPropertyOrElse("name", vertex.ID()), inWeight, outWeight, totWeight)
+        Row(vertex.name(), inWeight, outWeight, totWeight)
     })
   }
 

--- a/src/main/scala/com/raphtory/algorithms/generic/centrality/WeightedPageRank.scala
+++ b/src/main/scala/com/raphtory/algorithms/generic/centrality/WeightedPageRank.scala
@@ -43,7 +43,7 @@ class WeightedPageRank (dampingFactor:Float = 0.85F, iterateSteps:Int = 100, out
     graph.select({
       vertex =>
         Row(
-          vertex.getPropertyOrElse("name", vertex.ID()),
+          vertex.name(),
           vertex.getStateOrElse("prlabel", -1)
         )
     })

--- a/src/main/scala/com/raphtory/algorithms/generic/community/LPA.scala
+++ b/src/main/scala/com/raphtory/algorithms/generic/community/LPA.scala
@@ -52,7 +52,7 @@ class LPA(top: Int= 0, weight: String= "", maxIter: Int = 500, seed:Long= -1, ou
 
       vertex =>
         Row(
-          vertex.ID(),
+          vertex.name(),
           vertex.getState("lpalabel"),
         )
     })

--- a/src/main/scala/com/raphtory/algorithms/generic/community/SLPA.scala
+++ b/src/main/scala/com/raphtory/algorithms/generic/community/SLPA.scala
@@ -57,7 +57,7 @@ class SLPA(iterNumber: Int = 50,speakerRule:Rule, listenerRule:Rule, output:Stri
     graph.select({
       vertex =>
         val memory = vertex.getState[mutable.Queue[Long]]("memory")
-        Row(vertex.getPropertyOrElse("name", vertex.ID()), "[" + memory.mkString(" ") + "]")
+        Row(vertex.name(), "[" + memory.mkString(" ") + "]")
     })
   }
 

--- a/src/main/scala/com/raphtory/algorithms/generic/dynamic/BinaryDiffusion.scala
+++ b/src/main/scala/com/raphtory/algorithms/generic/dynamic/BinaryDiffusion.scala
@@ -31,7 +31,7 @@ class BinaryDiffusion(infectedNode:Long, seed:Long, outputFolder:String) extends
   }
 
   override def tabularise(graph: GraphPerspective): Table = {
-    graph.select(vertex => Row(vertex.ID(), vertex.getStateOrElse("infected", false)))
+    graph.select(vertex => Row(vertex.name(), vertex.getStateOrElse("infected", false)))
       .filter(row => row.get(1) == true)
   }
 

--- a/src/main/scala/com/raphtory/algorithms/generic/dynamic/WattsCascade.scala
+++ b/src/main/scala/com/raphtory/algorithms/generic/dynamic/WattsCascade.scala
@@ -72,7 +72,7 @@ class WattsCascade(infectedSeed:Array[Long], UNIFORM_RANDOM:Int = 1, UNIFORM_SAM
   override def tabularise(graph: GraphPerspective): Table = {
     graph.select({ vertex =>
       Row(
-        vertex.ID,
+        vertex.name(),
         vertex.getPropertyOrElse[String]("name", "None"),
         vertex.getStateOrElse[Boolean]("infected", false))
     }

--- a/src/main/scala/com/raphtory/algorithms/generic/twoHopNeighbour.scala
+++ b/src/main/scala/com/raphtory/algorithms/generic/twoHopNeighbour.scala
@@ -70,7 +70,7 @@ class twoHopNeighbour(nodeID:Long = -1, output: String = "/tmp/twoHopNeighbour")
     graph.select(vertex =>
       Row(
         vertex.getStateOrElse("twoHopResponse", false),
-        vertex.ID(),
+        vertex.name(),
         vertex.getStateOrElse("twoHops", "")
       )
     )

--- a/src/main/scala/com/raphtory/algorithms/temporal/Ancestors.scala
+++ b/src/main/scala/com/raphtory/algorithms/temporal/Ancestors.scala
@@ -39,7 +39,7 @@ class Ancestors(path:String,
   }
 
   override def tabularise(graph: GraphPerspective): Table = {
-    graph.select(vertex => Row(vertex.getPropertyOrElse("name", vertex.ID()), vertex.getStateOrElse[Boolean]("ancestor", false)))
+    graph.select(vertex => Row(vertex.name(), vertex.getStateOrElse[Boolean]("ancestor", false)))
   }
 
   override def write(table: Table): Unit = {

--- a/src/main/scala/com/raphtory/algorithms/temporal/Descendants.scala
+++ b/src/main/scala/com/raphtory/algorithms/temporal/Descendants.scala
@@ -39,7 +39,7 @@ class Descendants(path:String,
   }
 
   override def tabularise(graph: GraphPerspective): Table = {
-    graph.select(vertex => Row(vertex.getPropertyOrElse("name", vertex.ID()), vertex.getStateOrElse[Boolean]("descendant", false)))
+    graph.select(vertex => Row(vertex.name(), vertex.getStateOrElse[Boolean]("descendant", false)))
   }
 
   override def write(table: Table): Unit = {

--- a/src/main/scala/com/raphtory/algorithms/temporal/MotifAlpha.scala
+++ b/src/main/scala/com/raphtory/algorithms/temporal/MotifAlpha.scala
@@ -25,10 +25,10 @@ class MotifAlpha(fileOutput:String="/tmp/motif_alpha") extends GraphAlgorithm {
             val out = vertex.explodeInEdges()
               .map(inEdge => vertex.explodeOutEdges()
                 .filter(e => e.getTimestamp() > inEdge.getTimestamp() & e.dst() != inEdge.src() & e.dst() != inEdge.dst()).size).sum
-            Row(vertex.ID(), out)
+            Row(vertex.name(), out)
           }
           else {
-            Row(vertex.ID(), 0)
+            Row(vertex.name(), 0)
           }
       }
       )

--- a/src/main/scala/com/raphtory/algorithms/temporal/community/MultilayerLPA.scala
+++ b/src/main/scala/com/raphtory/algorithms/temporal/community/MultilayerLPA.scala
@@ -136,7 +136,7 @@ class MultilayerLPA(
   override def tabularise(graph: GraphPerspective): Table = {
     graph.select { vertex =>
       Row(
-        vertex.getProperty("name").getOrElse(vertex.ID()).toString,
+        vertex.name(),
         vertex.getState("mlpalabel")
       )
     }

--- a/src/main/scala/com/raphtory/algorithms/temporal/dynamic/GenericTaint.scala
+++ b/src/main/scala/com/raphtory/algorithms/temporal/dynamic/GenericTaint.scala
@@ -122,7 +122,7 @@ class GenericTaint(startTime: Long, infectedNodes: Set[Long], stopNodes: Set[Lon
 
   override def tabularise(graph: GraphPerspective): Table = {
     graph.select(vertex => Row(
-      vertex.ID(),
+      vertex.name(),
       vertex.getStateOrElse("taintStatus", false),
       vertex.getStateOrElse[Any]("taintHistory", "false")
     ))

--- a/src/main/scala/com/raphtory/core/implementations/pojograph/entities/external/PojoExVertex.scala
+++ b/src/main/scala/com/raphtory/core/implementations/pojograph/entities/external/PojoExVertex.scala
@@ -17,8 +17,6 @@ class PojoExVertex(private val v: PojoVertex,
 
   override def ID() = v.vertexId
 
-  def name(nameProperty:String="name"): String = getPropertyOrElse(nameProperty,ID.toString)
-
   private val multiQueue: VertexMultiQueue = new VertexMultiQueue() //Map of queues for all ongoing processing
   private var computationValues: Map[String, Any] = Map.empty //Partial results kept between supersteps in calculation
 

--- a/src/main/scala/com/raphtory/core/implementations/pojograph/entities/external/PojoExVertex.scala
+++ b/src/main/scala/com/raphtory/core/implementations/pojograph/entities/external/PojoExVertex.scala
@@ -17,6 +17,8 @@ class PojoExVertex(private val v: PojoVertex,
 
   override def ID() = v.vertexId
 
+  def name(nameProperty:String="name"): String = getPropertyOrElse(nameProperty,ID.toString)
+
   private val multiQueue: VertexMultiQueue = new VertexMultiQueue() //Map of queues for all ongoing processing
   private var computationValues: Map[String, Any] = Map.empty //Partial results kept between supersteps in calculation
 

--- a/src/main/scala/com/raphtory/core/model/graph/visitor/Vertex.scala
+++ b/src/main/scala/com/raphtory/core/model/graph/visitor/Vertex.scala
@@ -7,7 +7,7 @@ import scala.reflect.ClassTag
 trait Vertex extends EntityVisitor {
 
   def ID():Long
-  def name(nameProperty:String="name"):String
+  def name(nameProperty:String="name"): String = getPropertyOrElse(nameProperty,ID.toString)
 
   //functionality for checking messages
   def hasMessage(): Boolean

--- a/src/main/scala/com/raphtory/core/model/graph/visitor/Vertex.scala
+++ b/src/main/scala/com/raphtory/core/model/graph/visitor/Vertex.scala
@@ -7,6 +7,7 @@ import scala.reflect.ClassTag
 trait Vertex extends EntityVisitor {
 
   def ID():Long
+  def name(nameProperty:String="name"):String
 
   //functionality for checking messages
   def hasMessage(): Boolean


### PR DESCRIPTION
This is to try and make it easier/more standardised to output a vertex's name in algorithm results. 

`vertex.name(nameProperty:String)` is the same as `vertex.getPropertyOrElse(nameProperty, vertex.ID)` so that the vertex's assigned ID (long) is returned if it doesn't have a name property. The input `nameProperty` defaults to `"name"` meaning that `vertex.name()` becomes a nice shorthand if we assume that the name property is called "name".

I don't know whether this is the correct/best way of doing this, let me know what you think! :) 