### PR TITLE
Raphtory Pulsar Consumer async: receive async messages.

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -47,6 +47,13 @@ raphtory {
     countPerServer          = 2
     countPerServer          = ${?RAPHTORY_BUILDERS_COUNTPERSERVER}
   }
+
+  consumers {
+    maxMessagesForBatch       = 10000
+    timeoutForBatchMillis     = 1
+    consumerPoolPolicy        = true
+  }
+
   partitions {
     serverCount             = 1
     serverCount             = ${?RAPHTORY_PARTITIONS_SERVERCOUNT}

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -25,7 +25,7 @@
         </Logger>
         <Logger name="com.raphtory.develop" level="INFO">
         </Logger>
-        <Logger name="com.raphtory.core" level="INFO">
+        <Logger name="com.raphtory.core" level="DEBUG">
         </Logger>
 <!--        <Logger name="org.apache.pulsar.client.admin" level="DEBUG">-->
 <!--        </Logger>-->

--- a/src/main/scala/com/raphtory/core/components/Component.scala
+++ b/src/main/scala/com/raphtory/core/components/Component.scala
@@ -29,9 +29,9 @@ abstract class Component[T](conf: Config, private val pulsarController: PulsarCo
   val hasDeletions: Boolean              = conf.getBoolean("raphtory.data.containsDeletions")
   val totalPartitions: Int               = partitionServers * partitionsPerServer
   private val kryo: PulsarKryoSerialiser = PulsarKryoSerialiser()
-  val cancelableConsumer    : Option[Consumer[T]]= None
+  val consumer: Option[Consumer[T]]      = None
 
-  def handleMessage(msg: Message[T]) : Boolean
+  def handleMessage(msg: Message[T]): Boolean
   def run()
   def stop()
 

--- a/src/main/scala/com/raphtory/core/components/partition/QueryExecutor.scala
+++ b/src/main/scala/com/raphtory/core/components/partition/QueryExecutor.scala
@@ -16,8 +16,7 @@ import com.raphtory.core.components.querymanager.TableBuilt
 import com.raphtory.core.components.querymanager.TableFunctionComplete
 import com.raphtory.core.components.querymanager.VertexMessage
 import com.raphtory.core.components.querymanager.VertexMessageBatch
-import com.raphtory.core.config.MonixScheduler
-import com.raphtory.core.config.PulsarController
+import com.raphtory.core.config.{AsyncConsumer, MonixScheduler, PulsarController}
 import com.raphtory.core.graph.GraphPartition
 import com.raphtory.core.graph.LensInterface
 import com.raphtory.core.storage.pojograph.PojoGraphLens
@@ -27,12 +26,12 @@ import com.typesafe.config.Config
 import org.apache.pulsar.client.api._
 
 class QueryExecutor(
-    partitionID: Int,
-    storage: GraphPartition,
-    jobID: String,
-    conf: Config,
-    pulsarController: PulsarController
-) extends Component[Array[Byte]](conf: Config, pulsarController) {
+                     partitionID: Int,
+                     storage: GraphPartition,
+                     jobID: String,
+                     conf: Config,
+                     pulsarController: PulsarController
+                   ) extends Component[Array[Byte]](conf: Config, pulsarController) {
 
   var graphLens: LensInterface  = _
   var sentMessageCount: Int     = 0
@@ -41,54 +40,55 @@ class QueryExecutor(
 
   private val taskManager: Producer[Array[Byte]]          = toQueryHandlerProducer(jobID)
   private val neighbours: Map[Int, Producer[Array[Byte]]] = toQueryExecutorProducers(jobID)
-  var cancelableConsumer: Option[Consumer[Array[Byte]]]   = None
+  private val monixScheduler = new MonixScheduler
+  override val cancelableConsumer =  Some(startQueryExecutorConsumer(Schema.BYTES,partitionID,jobID))
 
   override def run(): Unit = {
     logger.debug(s"Job '$jobID' at Partition '$partitionID': Starting query executor consumer.")
 
     taskManager sendAsync serialise(ExecutorEstablished(partitionID))
-    cancelableConsumer = Some(startQueryExecutorConsumer(Schema.BYTES, partitionID, jobID))
+    monixScheduler.scheduler.execute(AsyncConsumer(this))
   }
 
   override def stop(): Unit = {
     cancelableConsumer match {
       case Some(value) =>
         value.close()
-      case None        =>
     }
     taskManager.close()
     neighbours.foreach(_._2.close())
   }
 
-  override def handleMessage(msg: Message[Array[Byte]]): Unit = {
+  override def handleMessage(msg: Message[Array[Byte]]): Boolean = {
+    var scheduleAgain = true
     deserialise[QueryManagement](msg.getValue) match {
 
       case VertexMessageBatch(msgBatch)                =>
         logger.trace(
-                s"Job '$jobID' at Partition '$partitionID': Executing 'VertexMessageBatch', '[${msgBatch
-                  .mkString(",")}]'."
+          s"Job '$jobID' at Partition '$partitionID': Executing 'VertexMessageBatch', '[${msgBatch
+            .mkString(",")}]'."
         )
         msgBatch.foreach(message => graphLens.receiveMessage(message))
         receivedMessageCount += msgBatch.size
 
       case msg: VertexMessage[_]                       =>
         logger.trace(
-                s"Job '$jobID' at Partition '$partitionID': Executing 'VertexMessage', '$msg'."
+          s"Job '$jobID' at Partition '$partitionID': Executing 'VertexMessage', '$msg'."
         )
         graphLens.receiveMessage(msg)
         receivedMessageCount += 1
 
       case CreatePerspective(timestamp, window)        =>
         logger.debug(
-                s"Job '$jobID' at Partition '$partitionID': Creating perspective at time '$timestamp' with window '$window'."
+          s"Job '$jobID' at Partition '$partitionID': Creating perspective at time '$timestamp' with window '$window'."
         )
         val lens = PojoGraphLens(
-                jobID,
-                timestamp,
-                window,
-                0,
-                storage,
-                VertexMessageHandler(conf, neighbours)
+          jobID,
+          timestamp,
+          window,
+          0,
+          storage,
+          VertexMessageHandler(conf, neighbours)
         )
         graphLens = lens
         sentMessageCount = 0
@@ -97,7 +97,7 @@ class QueryExecutor(
 
       case SetMetaData(vertices)                       =>
         logger.debug(
-                s"Job $jobID at Partition '$partitionID': Executing 'SetMetaData' function on graph."
+          s"Job $jobID at Partition '$partitionID': Executing 'SetMetaData' function on graph."
         )
 
         graphLens.setFullGraphSize(vertices)
@@ -114,7 +114,7 @@ class QueryExecutor(
         graphLens.getMessageHandler().flushMessages()
         taskManager sendAsync serialise(GraphFunctionComplete(sentMessages, receivedMessageCount))
         logger.debug(
-                s"Job '$jobID' at Partition '$partitionID': Step function produced and sent '$sentMessages' messages."
+          s"Job '$jobID' at Partition '$partitionID': Step function produced and sent '$sentMessages' messages."
         )
         sentMessageCount = sentMessages
 
@@ -123,14 +123,14 @@ class QueryExecutor(
 
         if (executeMessagedOnly) {
           logger.debug(
-                  s"Job '$jobID' at Partition '$partitionID': Executing 'Iterate' function on messaged vertices only."
+            s"Job '$jobID' at Partition '$partitionID': Executing 'Iterate' function on messaged vertices only."
           )
 
           graphLens.runMessagedGraphFunction(f)
         }
         else {
           logger.debug(
-                  s"Job '$jobID' at Partition '$partitionID': Executing 'Iterate' function on all vertices."
+            s"Job '$jobID' at Partition '$partitionID': Executing 'Iterate' function on all vertices."
           )
 
           graphLens.runGraphFunction(f)
@@ -139,13 +139,13 @@ class QueryExecutor(
         val sentMessages = graphLens.getMessageHandler().getCount()
         graphLens.getMessageHandler().flushMessages()
         taskManager sendAsync serialise(
-                GraphFunctionComplete(receivedMessageCount, sentMessages, graphLens.checkVotes())
+          GraphFunctionComplete(receivedMessageCount, sentMessages, graphLens.checkVotes())
         )
         votedToHalt = graphLens.checkVotes()
         sentMessageCount = sentMessages
 
         logger.debug(
-                s"Job '$jobID' at Partition '$partitionID': Iterate function produced and sent '$sentMessages' messages."
+          s"Job '$jobID' at Partition '$partitionID': Iterate function produced and sent '$sentMessages' messages."
         )
       case VertexFilter(f)                             =>
         taskManager sendAsync serialise(GraphFunctionComplete(0, 0))
@@ -163,29 +163,29 @@ class QueryExecutor(
 
       case TableFilter(f)                              =>
         logger.debug(
-                s"Job '$jobID' at Partition '$partitionID': Executing 'TableFilter' query on graph."
+          s"Job '$jobID' at Partition '$partitionID': Executing 'TableFilter' query on graph."
         )
         graphLens.filteredTable(f)
         taskManager sendAsync serialise(TableFunctionComplete)
 
       case Explode(f)                                  =>
         logger.debug(
-                s"Job '$jobID' at Partition '$partitionID': Executing 'Explode' query on graph."
+          s"Job '$jobID' at Partition '$partitionID': Executing 'Explode' query on graph."
         )
         graphLens.explodeTable(f)
         taskManager sendAsync serialise(TableFunctionComplete)
 
       case WriteTo(outputFormat)                       =>
         logger.debug(
-                s"Job '$jobID' at Partition '$partitionID': Writing results to '$outputFormat'."
+          s"Job '$jobID' at Partition '$partitionID': Writing results to '$outputFormat'."
         )
         val producer =
           if (outputFormat.isInstanceOf[PulsarOutputFormat])
             Some(
-                    pulsarController.accessClient
-                      .newProducer(Schema.STRING)
-                      .topic(outputFormat.asInstanceOf[PulsarOutputFormat].pulsarTopic)
-                      .create()
+              pulsarController.accessClient
+                .newProducer(Schema.STRING)
+                .topic(outputFormat.asInstanceOf[PulsarOutputFormat].pulsarTopic)
+                .create()
             )
           else
             None
@@ -196,12 +196,12 @@ class QueryExecutor(
             outputFormat match {
               case format: PulsarOutputFormat =>
                 format.writeToPulsar(
-                        graphLens.getTimestamp(),
-                        graphLens.getWindow(),
-                        jobID,
-                        row,
-                        partitionID,
-                        producer.get
+                  graphLens.getTimestamp(),
+                  graphLens.getWindow(),
+                  jobID,
+                  row,
+                  partitionID,
+                  producer.get
                 )
               case format                     =>
                 format
@@ -216,16 +216,18 @@ class QueryExecutor(
         // It's a Warning, but not a severe one
         if (logger.underlying.isDebugEnabled)
           logger.warn(
-                  s"Job '$jobID' at Partition '$partitionID': Received 'EndQuery' message. " +
-                    s"This function is not supported yet."
+            s"Job '$jobID' at Partition '$partitionID': Received 'EndQuery' message. " +
+              s"This function is not supported yet."
           )
+        scheduleAgain = false
 
       case _: CheckMessages                            =>
         logger.debug(s"Job '$jobID' at Partition '$partitionID': Received 'CheckMessages'.")
         taskManager sendAsync serialise(
-                GraphFunctionComplete(receivedMessageCount, sentMessageCount, votedToHalt)
+          GraphFunctionComplete(receivedMessageCount, sentMessageCount, votedToHalt)
         )
     }
+    scheduleAgain
   }
 
 }

--- a/src/main/scala/com/raphtory/core/components/partition/QueryExecutor.scala
+++ b/src/main/scala/com/raphtory/core/components/partition/QueryExecutor.scala
@@ -16,7 +16,9 @@ import com.raphtory.core.components.querymanager.TableBuilt
 import com.raphtory.core.components.querymanager.TableFunctionComplete
 import com.raphtory.core.components.querymanager.VertexMessage
 import com.raphtory.core.components.querymanager.VertexMessageBatch
-import com.raphtory.core.config.{AsyncConsumer, MonixScheduler, PulsarController}
+import com.raphtory.core.config.AsyncConsumer
+import com.raphtory.core.config.MonixScheduler
+import com.raphtory.core.config.PulsarController
 import com.raphtory.core.graph.GraphPartition
 import com.raphtory.core.graph.LensInterface
 import com.raphtory.core.storage.pojograph.PojoGraphLens
@@ -26,12 +28,12 @@ import com.typesafe.config.Config
 import org.apache.pulsar.client.api._
 
 class QueryExecutor(
-                     partitionID: Int,
-                     storage: GraphPartition,
-                     jobID: String,
-                     conf: Config,
-                     pulsarController: PulsarController
-                   ) extends Component[Array[Byte]](conf: Config, pulsarController) {
+    partitionID: Int,
+    storage: GraphPartition,
+    jobID: String,
+    conf: Config,
+    pulsarController: PulsarController
+) extends Component[Array[Byte]](conf: Config, pulsarController) {
 
   var graphLens: LensInterface  = _
   var sentMessageCount: Int     = 0
@@ -40,8 +42,8 @@ class QueryExecutor(
 
   private val taskManager: Producer[Array[Byte]]          = toQueryHandlerProducer(jobID)
   private val neighbours: Map[Int, Producer[Array[Byte]]] = toQueryExecutorProducers(jobID)
-  private val monixScheduler = new MonixScheduler
-  override val cancelableConsumer =  Some(startQueryExecutorConsumer(Schema.BYTES,partitionID,jobID))
+  private val monixScheduler                              = new MonixScheduler
+  override val consumer                                   = Some(startQueryExecutorConsumer(Schema.BYTES, partitionID, jobID))
 
   override def run(): Unit = {
     logger.debug(s"Job '$jobID' at Partition '$partitionID': Starting query executor consumer.")
@@ -51,10 +53,7 @@ class QueryExecutor(
   }
 
   override def stop(): Unit = {
-    cancelableConsumer match {
-      case Some(value) =>
-        value.close()
-    }
+    //consumer.close()
     taskManager.close()
     neighbours.foreach(_._2.close())
   }
@@ -65,30 +64,30 @@ class QueryExecutor(
 
       case VertexMessageBatch(msgBatch)                =>
         logger.trace(
-          s"Job '$jobID' at Partition '$partitionID': Executing 'VertexMessageBatch', '[${msgBatch
-            .mkString(",")}]'."
+                s"Job '$jobID' at Partition '$partitionID': Executing 'VertexMessageBatch', '[${msgBatch
+                  .mkString(",")}]'."
         )
         msgBatch.foreach(message => graphLens.receiveMessage(message))
         receivedMessageCount += msgBatch.size
 
       case msg: VertexMessage[_]                       =>
         logger.trace(
-          s"Job '$jobID' at Partition '$partitionID': Executing 'VertexMessage', '$msg'."
+                s"Job '$jobID' at Partition '$partitionID': Executing 'VertexMessage', '$msg'."
         )
         graphLens.receiveMessage(msg)
         receivedMessageCount += 1
 
       case CreatePerspective(timestamp, window)        =>
         logger.debug(
-          s"Job '$jobID' at Partition '$partitionID': Creating perspective at time '$timestamp' with window '$window'."
+                s"Job '$jobID' at Partition '$partitionID': Creating perspective at time '$timestamp' with window '$window'."
         )
         val lens = PojoGraphLens(
-          jobID,
-          timestamp,
-          window,
-          0,
-          storage,
-          VertexMessageHandler(conf, neighbours)
+                jobID,
+                timestamp,
+                window,
+                0,
+                storage,
+                VertexMessageHandler(conf, neighbours)
         )
         graphLens = lens
         sentMessageCount = 0
@@ -97,7 +96,7 @@ class QueryExecutor(
 
       case SetMetaData(vertices)                       =>
         logger.debug(
-          s"Job $jobID at Partition '$partitionID': Executing 'SetMetaData' function on graph."
+                s"Job $jobID at Partition '$partitionID': Executing 'SetMetaData' function on graph."
         )
 
         graphLens.setFullGraphSize(vertices)
@@ -114,7 +113,7 @@ class QueryExecutor(
         graphLens.getMessageHandler().flushMessages()
         taskManager sendAsync serialise(GraphFunctionComplete(sentMessages, receivedMessageCount))
         logger.debug(
-          s"Job '$jobID' at Partition '$partitionID': Step function produced and sent '$sentMessages' messages."
+                s"Job '$jobID' at Partition '$partitionID': Step function produced and sent '$sentMessages' messages."
         )
         sentMessageCount = sentMessages
 
@@ -123,14 +122,14 @@ class QueryExecutor(
 
         if (executeMessagedOnly) {
           logger.debug(
-            s"Job '$jobID' at Partition '$partitionID': Executing 'Iterate' function on messaged vertices only."
+                  s"Job '$jobID' at Partition '$partitionID': Executing 'Iterate' function on messaged vertices only."
           )
 
           graphLens.runMessagedGraphFunction(f)
         }
         else {
           logger.debug(
-            s"Job '$jobID' at Partition '$partitionID': Executing 'Iterate' function on all vertices."
+                  s"Job '$jobID' at Partition '$partitionID': Executing 'Iterate' function on all vertices."
           )
 
           graphLens.runGraphFunction(f)
@@ -139,13 +138,13 @@ class QueryExecutor(
         val sentMessages = graphLens.getMessageHandler().getCount()
         graphLens.getMessageHandler().flushMessages()
         taskManager sendAsync serialise(
-          GraphFunctionComplete(receivedMessageCount, sentMessages, graphLens.checkVotes())
+                GraphFunctionComplete(receivedMessageCount, sentMessages, graphLens.checkVotes())
         )
         votedToHalt = graphLens.checkVotes()
         sentMessageCount = sentMessages
 
         logger.debug(
-          s"Job '$jobID' at Partition '$partitionID': Iterate function produced and sent '$sentMessages' messages."
+                s"Job '$jobID' at Partition '$partitionID': Iterate function produced and sent '$sentMessages' messages."
         )
       case VertexFilter(f)                             =>
         taskManager sendAsync serialise(GraphFunctionComplete(0, 0))
@@ -163,29 +162,29 @@ class QueryExecutor(
 
       case TableFilter(f)                              =>
         logger.debug(
-          s"Job '$jobID' at Partition '$partitionID': Executing 'TableFilter' query on graph."
+                s"Job '$jobID' at Partition '$partitionID': Executing 'TableFilter' query on graph."
         )
         graphLens.filteredTable(f)
         taskManager sendAsync serialise(TableFunctionComplete)
 
       case Explode(f)                                  =>
         logger.debug(
-          s"Job '$jobID' at Partition '$partitionID': Executing 'Explode' query on graph."
+                s"Job '$jobID' at Partition '$partitionID': Executing 'Explode' query on graph."
         )
         graphLens.explodeTable(f)
         taskManager sendAsync serialise(TableFunctionComplete)
 
       case WriteTo(outputFormat)                       =>
         logger.debug(
-          s"Job '$jobID' at Partition '$partitionID': Writing results to '$outputFormat'."
+                s"Job '$jobID' at Partition '$partitionID': Writing results to '$outputFormat'."
         )
         val producer =
           if (outputFormat.isInstanceOf[PulsarOutputFormat])
             Some(
-              pulsarController.accessClient
-                .newProducer(Schema.STRING)
-                .topic(outputFormat.asInstanceOf[PulsarOutputFormat].pulsarTopic)
-                .create()
+                    pulsarController.accessClient
+                      .newProducer(Schema.STRING)
+                      .topic(outputFormat.asInstanceOf[PulsarOutputFormat].pulsarTopic)
+                      .create()
             )
           else
             None
@@ -196,12 +195,12 @@ class QueryExecutor(
             outputFormat match {
               case format: PulsarOutputFormat =>
                 format.writeToPulsar(
-                  graphLens.getTimestamp(),
-                  graphLens.getWindow(),
-                  jobID,
-                  row,
-                  partitionID,
-                  producer.get
+                        graphLens.getTimestamp(),
+                        graphLens.getWindow(),
+                        jobID,
+                        row,
+                        partitionID,
+                        producer.get
                 )
               case format                     =>
                 format
@@ -216,15 +215,15 @@ class QueryExecutor(
         // It's a Warning, but not a severe one
         if (logger.underlying.isDebugEnabled)
           logger.warn(
-            s"Job '$jobID' at Partition '$partitionID': Received 'EndQuery' message. " +
-              s"This function is not supported yet."
+                  s"Job '$jobID' at Partition '$partitionID': Received 'EndQuery' message. " +
+                    s"This function is not supported yet."
           )
         scheduleAgain = false
 
       case _: CheckMessages                            =>
         logger.debug(s"Job '$jobID' at Partition '$partitionID': Received 'CheckMessages'.")
         taskManager sendAsync serialise(
-          GraphFunctionComplete(receivedMessageCount, sentMessageCount, votedToHalt)
+                GraphFunctionComplete(receivedMessageCount, sentMessageCount, votedToHalt)
         )
     }
     scheduleAgain

--- a/src/main/scala/com/raphtory/core/components/partition/Reader.scala
+++ b/src/main/scala/com/raphtory/core/components/partition/Reader.scala
@@ -4,7 +4,9 @@ import com.raphtory.core.components.querymanager.EstablishExecutor
 import com.raphtory.core.components.Component
 import com.raphtory.core.components.querymanager.EstablishExecutor
 import com.raphtory.core.components.querymanager.WatermarkTime
-import com.raphtory.core.config.{AsyncConsumer, MonixScheduler, PulsarController}
+import com.raphtory.core.config.AsyncConsumer
+import com.raphtory.core.config.MonixScheduler
+import com.raphtory.core.config.PulsarController
 import com.raphtory.core.graph.GraphPartition
 import com.typesafe.config.Config
 import monix.execution.Scheduler
@@ -17,17 +19,17 @@ import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.mutable
 
 class Reader(
-              partitionID: Int,
-              storage: GraphPartition,
-              scheduler: Scheduler,
-              conf: Config,
-              pulsarController: PulsarController
-            ) extends Component[Array[Byte]](conf: Config, pulsarController: PulsarController) {
+    partitionID: Int,
+    storage: GraphPartition,
+    scheduler: Scheduler,
+    conf: Config,
+    pulsarController: PulsarController
+) extends Component[Array[Byte]](conf: Config, pulsarController: PulsarController) {
 
-  private val executorMap                               = mutable.Map[String, QueryExecutor]()
-  private val watermarkPublish                          = watermarkPublisher()
-  override val cancelableConsumer = Some(startReaderConsumer(Schema.BYTES,partitionID))
-  private val monixScheduler = new MonixScheduler
+  private val executorMap      = mutable.Map[String, QueryExecutor]()
+  private val watermarkPublish = watermarkPublisher()
+  override val consumer        = Some(startReaderConsumer(Schema.BYTES, partitionID))
+  private val monixScheduler   = new MonixScheduler
 
   class Watermarker extends Runnable {
 
@@ -43,10 +45,7 @@ class Reader(
   }
 
   override def stop(): Unit = {
-    cancelableConsumer match {
-      case Some(value) =>
-        value.close()
-    }
+    //consumer.close()
     watermarkPublish.close()
     executorMap.foreach(_._2.stop())
   }

--- a/src/main/scala/com/raphtory/core/components/querymanager/QueryHandler.scala
+++ b/src/main/scala/com/raphtory/core/components/querymanager/QueryHandler.scala
@@ -7,7 +7,7 @@ import Stages.Stage
 import com.raphtory.core.algorithm.OutputFormat
 import com.raphtory.core.algorithm._
 import com.raphtory.core.components.Component
-import com.raphtory.core.config.PulsarController
+import com.raphtory.core.config.{AsyncConsumer, MonixScheduler, PulsarController}
 import com.raphtory.core.graph.Perspective
 import com.raphtory.core.graph.PerspectiveController
 import com.typesafe.config.Config
@@ -20,14 +20,14 @@ import org.apache.pulsar.client.api.Schema
 import java.util.concurrent.TimeUnit
 
 abstract class QueryHandler(
-    queryManager: QueryManager,
-    scheduler: Scheduler,
-    jobID: String,
-    algorithm: GraphAlgorithm,
-    outputFormat: OutputFormat,
-    conf: Config,
-    pulsarController: PulsarController
-) extends Component[Array[Byte]](conf: Config, pulsarController: PulsarController) {
+                             queryManager: QueryManager,
+                             scheduler: Scheduler,
+                             jobID: String,
+                             algorithm: GraphAlgorithm,
+                             outputFormat: OutputFormat,
+                             conf: Config,
+                             pulsarController: PulsarController
+                           ) extends Component[Array[Byte]](conf: Config, pulsarController: PulsarController) {
 
   private val self: Producer[Array[Byte]]                 = toQueryHandlerProducer(jobID)
   private val readers: Producer[Array[Byte]]              = toReaderProducer
@@ -60,20 +60,22 @@ abstract class QueryHandler(
     }
   }
   private val recheckTimer                              = new RecheckTimer()
-  var cancelableConsumer: Option[Consumer[Array[Byte]]] = None
+
+
+  private val monixScheduler = new MonixScheduler
+  override val cancelableConsumer =  Some(startQueryHandlerConsumer(Schema.BYTES,jobID))
 
   override def run(): Unit = {
     readers sendAsync serialise(EstablishExecutor(jobID))
-    cancelableConsumer = Some(startQueryHandlerConsumer(Schema.BYTES, jobID))
-
+    monixScheduler.scheduler.execute(AsyncConsumer(this))
     logger.debug(s"Job '$jobID': Starting query handler consumer.")
   }
+
 
   override def stop(): Unit = {
     cancelableConsumer match {
       case Some(value) =>
         value.close()
-      case None        =>
     }
     self.close()
     readers.close()
@@ -81,14 +83,17 @@ abstract class QueryHandler(
     workerList.foreach(_._2.close())
   }
 
-  override def handleMessage(msg: Message[Array[Byte]]): Unit =
+  override def handleMessage(msg: Message[Array[Byte]]): Boolean = {
+    var scheduleAgain = true
     currentState match {
       case Stages.SpawnExecutors       => currentState = spawnExecutors(msg)
       case Stages.EstablishPerspective => currentState = establishPerspective(msg)
       case Stages.ExecuteGraph         => currentState = executeGraph(msg)
       case Stages.ExecuteTable         => currentState = executeTable(msg)
-      case Stages.EndTask              => //TODO?
+      case Stages.EndTask              => scheduleAgain = false
     }
+    scheduleAgain
+  }
 
   ////OPERATION STATES
   //Communicate with all readers and get them to spawn a QueryExecutor for their partition
@@ -143,8 +148,8 @@ abstract class QueryHandler(
           allVoteToHalt = true
 
           logger.debug(
-                  s"Job '$jobID': Executing graph with windows '${currentPerspective.window}' " +
-                    s"at timestamp '${currentPerspective.timestamp}'."
+            s"Job '$jobID': Executing graph with windows '${currentPerspective.window}' " +
+              s"at timestamp '${currentPerspective.timestamp}'."
           )
 
           Stages.ExecuteGraph
@@ -198,7 +203,7 @@ abstract class QueryHandler(
               case Iterate(f, iterations, executeMessagedOnly) =>
                 if (iterations == 1 || (allVoteToHalt && votedToHalt)) {
                   logger.debug(
-                          s"Job '$jobID': Starting next operation '${algorithm.getClass.getSimpleName}'."
+                    s"Job '$jobID': Starting next operation '${algorithm.getClass.getSimpleName}'."
                   )
                   nextGraphOperation(vertexCount)
                 }
@@ -210,7 +215,7 @@ abstract class QueryHandler(
                   sentMessageCount = 0
                   allVoteToHalt = true
                   logger.debug(
-                          s"Job '$jobID': Executing '${algorithm.getClass.getSimpleName}' function."
+                    s"Job '$jobID': Executing '${algorithm.getClass.getSimpleName}' function."
                   )
                   Stages.ExecuteGraph
                 }
@@ -220,7 +225,7 @@ abstract class QueryHandler(
           else {
             messagetoAllJobWorkers(CheckMessages(jobID))
             logger.debug(
-                    s"Job '$jobID': Received messages:$receivedMessages , Sent messages: $sentMessages."
+              s"Job '$jobID': Received messages:$receivedMessages , Sent messages: $sentMessages."
             )
             readyCount = 0
             receivedMessageCount = 0
@@ -248,7 +253,7 @@ abstract class QueryHandler(
         }
         else {
           logger.debug(
-                  s"Job '$jobID': Executing '${currentOperation.getClass.getSimpleName}' operation."
+            s"Job '$jobID': Executing '${currentOperation.getClass.getSimpleName}' operation."
           )
           Stages.ExecuteTable
         }
@@ -261,7 +266,7 @@ abstract class QueryHandler(
         }
         else {
           logger.debug(
-                  s"Job '$jobID': Executing '${currentOperation.getClass.getSimpleName}' operation."
+            s"Job '$jobID': Executing '${currentOperation.getClass.getSimpleName}' operation."
           )
           Stages.ExecuteTable
         }
@@ -284,7 +289,7 @@ abstract class QueryHandler(
         Stages.EstablishPerspective
       case Some(perspective)                                        =>
         logger.debug(
-                s"Job '$jobID': Perspective '$perspective' is not ready, currently at '$latestTime'."
+          s"Job '$jobID': Perspective '$perspective' is not ready, currently at '$latestTime'."
         )
         logTimeTaken(perspective)
         currentPerspective = perspective
@@ -306,13 +311,13 @@ abstract class QueryHandler(
       currentPerspective.window match {
         case Some(window) =>
           logger.trace(
-                  s"Job '$jobID': Perspective at Time '${currentPerspective.timestamp}' with " +
-                    s"Window $window took ${System.currentTimeMillis() - lastTime} ms to run."
+            s"Job '$jobID': Perspective at Time '${currentPerspective.timestamp}' with " +
+              s"Window $window took ${System.currentTimeMillis() - lastTime} ms to run."
           )
         case None         =>
           logger.trace(
-                  s"Job '$jobID': Perspective at Time '${currentPerspective.timestamp}' " +
-                    s"took ${System.currentTimeMillis() - lastTime} ms to run. "
+            s"Job '$jobID': Perspective at Time '${currentPerspective.timestamp}' " +
+              s"took ${System.currentTimeMillis() - lastTime} ms to run. "
           )
       }
     lastTime = System.currentTimeMillis()
@@ -357,8 +362,8 @@ abstract class QueryHandler(
         receivedMessageCount = 0
         sentMessageCount = 0
         logger.debug(
-                s"Job '$jobID': Executing next perspective with windows '${currentPerspective.window}'" +
-                  s" and timestamp '${currentPerspective.timestamp}'."
+          s"Job '$jobID': Executing next perspective with windows '${currentPerspective.window}'" +
+            s" and timestamp '${currentPerspective.timestamp}'."
         )
         executeNextPerspective()
     }

--- a/src/main/scala/com/raphtory/core/components/querymanager/QueryManager.scala
+++ b/src/main/scala/com/raphtory/core/components/querymanager/QueryManager.scala
@@ -5,7 +5,9 @@ import com.raphtory.core.components.Component
 import com.raphtory.core.components.querymanager.handler.LiveQueryHandler
 import com.raphtory.core.components.querymanager.handler.PointQueryHandler
 import com.raphtory.core.components.querymanager.handler.RangeQueryHandler
-import com.raphtory.core.config.{AsyncConsumer, MonixScheduler, PulsarController}
+import com.raphtory.core.config.AsyncConsumer
+import com.raphtory.core.config.MonixScheduler
+import com.raphtory.core.config.PulsarController
 import com.typesafe.config.Config
 import monix.execution.Scheduler
 import org.apache.pulsar.client.api.Consumer
@@ -15,12 +17,12 @@ import org.apache.pulsar.client.api.Schema
 import scala.collection.mutable
 
 class QueryManager(scheduler: Scheduler, conf: Config, pulsarController: PulsarController)
-  extends Component[Array[Byte]](conf: Config, pulsarController: PulsarController) {
-  private val currentQueries                            = mutable.Map[String, QueryHandler]()
-  private val watermarkGlobal                           = globalwatermarkPublisher()
-  private val watermarks                                = mutable.Map[Int, WatermarkTime]()
+        extends Component[Array[Byte]](conf: Config, pulsarController: PulsarController) {
+  private val currentQueries  = mutable.Map[String, QueryHandler]()
+  private val watermarkGlobal = globalwatermarkPublisher()
+  private val watermarks      = mutable.Map[Int, WatermarkTime]()
 
-  override val cancelableConsumer =  Some(startQueryManagerConsumer(Schema.BYTES))
+  override val consumer      = Some(startQueryManagerConsumer(Schema.BYTES))
   private val monixScheduler = new MonixScheduler
 
   override def run(): Unit = {
@@ -28,12 +30,8 @@ class QueryManager(scheduler: Scheduler, conf: Config, pulsarController: PulsarC
     monixScheduler.scheduler.execute(AsyncConsumer(this))
   }
 
-
   override def stop(): Unit = {
-    cancelableConsumer match {
-      case Some(value) =>
-        value.close()
-    }
+    //consumer.close()
     currentQueries.foreach(_._2.stop())
     watermarkGlobal.close()
   }
@@ -44,7 +42,7 @@ class QueryManager(scheduler: Scheduler, conf: Config, pulsarController: PulsarC
       case query: PointQuery        =>
         val jobID        = query.name
         logger.debug(
-          s"Handling query name: ${query.name}, windows: ${query.windows}, timestamp: ${query.timestamp}, algorithm: ${query.algorithm}"
+                s"Handling query name: ${query.name}, windows: ${query.windows}, timestamp: ${query.timestamp}, algorithm: ${query.algorithm}"
         )
         val queryHandler = spawnPointQuery(jobID, query)
         trackNewQuery(jobID, queryHandler)
@@ -52,7 +50,7 @@ class QueryManager(scheduler: Scheduler, conf: Config, pulsarController: PulsarC
       case query: RangeQuery        =>
         val jobID        = query.name
         logger.debug(
-          s"Handling query name: ${query.name}, windows: ${query.windows}, algorithm: ${query.algorithm}"
+                s"Handling query name: ${query.name}, windows: ${query.windows}, algorithm: ${query.algorithm}"
         )
         val queryHandler = spawnRangeQuery(jobID, query)
         trackNewQuery(jobID, queryHandler)
@@ -60,7 +58,7 @@ class QueryManager(scheduler: Scheduler, conf: Config, pulsarController: PulsarC
       case query: LiveQuery         =>
         val jobID        = query.name
         logger.debug(
-          s"Handling query name: ${query.name}, windows: ${query.windows}, algorithm: ${query.algorithm}"
+                s"Handling query name: ${query.name}, windows: ${query.windows}, algorithm: ${query.algorithm}"
         )
         val queryHandler = spawnLiveQuery(jobID, query)
         trackNewQuery(jobID, queryHandler)
@@ -84,15 +82,15 @@ class QueryManager(scheduler: Scheduler, conf: Config, pulsarController: PulsarC
     logger.info(s"Point Query '${query.name}' received, your job ID is '$id'.")
 
     val queryHandler = new PointQueryHandler(
-      this,
-      scheduler,
-      id,
-      query.algorithm,
-      query.timestamp,
-      query.windows,
-      query.outputFormat,
-      conf,
-      pulsarController
+            this,
+            scheduler,
+            id,
+            query.algorithm,
+            query.timestamp,
+            query.windows,
+            query.outputFormat,
+            conf,
+            pulsarController
     )
     scheduler.execute(queryHandler)
     queryHandler
@@ -102,17 +100,17 @@ class QueryManager(scheduler: Scheduler, conf: Config, pulsarController: PulsarC
     logger.info(s"Range Query '${query.name}' received, your job ID is '$id'.")
 
     val queryHandler = new RangeQueryHandler(
-      this,
-      scheduler,
-      id,
-      query.algorithm,
-      query.start,
-      query.end,
-      query.increment,
-      query.windows,
-      query.outputFormat,
-      conf: Config,
-      pulsarController: PulsarController
+            this,
+            scheduler,
+            id,
+            query.algorithm,
+            query.start,
+            query.end,
+            query.increment,
+            query.windows,
+            query.outputFormat,
+            conf: Config,
+            pulsarController: PulsarController
     )
     scheduler.execute(queryHandler)
     queryHandler
@@ -122,22 +120,22 @@ class QueryManager(scheduler: Scheduler, conf: Config, pulsarController: PulsarC
     logger.info(s"Live Query '${query.name}' received, your job ID is '$id'.")
 
     val queryHandler = new LiveQueryHandler(
-      this,
-      scheduler,
-      id,
-      query.algorithm,
-      query.increment,
-      query.windows,
-      query.outputFormat,
-      conf,
-      pulsarController
+            this,
+            scheduler,
+            id,
+            query.algorithm,
+            query.increment,
+            query.windows,
+            query.outputFormat,
+            conf,
+            pulsarController
     )
     scheduler.execute(queryHandler)
     queryHandler
   }
 
   private def trackNewQuery(jobID: String, queryHandler: QueryHandler): Unit =
-  //sender() ! ManagingTask(queryHandler)
+    //sender() ! ManagingTask(queryHandler)
     currentQueries += ((jobID, queryHandler))
 
   def whatsTheTime(): Long = {

--- a/src/main/scala/com/raphtory/core/components/querytracker/QueryProgressTracker.scala
+++ b/src/main/scala/com/raphtory/core/components/querytracker/QueryProgressTracker.scala
@@ -11,28 +11,30 @@ import monix.execution.Scheduler
 import org.apache.pulsar.client.api.Consumer
 import org.apache.pulsar.client.api.Message
 import org.apache.pulsar.client.api.Schema
-import com.raphtory.core.config.{AsyncConsumer, MonixScheduler, PulsarController}
+import com.raphtory.core.config.AsyncConsumer
+import com.raphtory.core.config.MonixScheduler
+import com.raphtory.core.config.PulsarController
 
 import scala.collection.mutable.ListBuffer
 
 class QueryProgressTracker(
-                            deploymentID_jobID: String,
-                            deploymentID: String,
-                            jobID: String,
-                            scheduler: Scheduler,
-                            conf: Config,
-                            pulsarController: PulsarController
-                          ) extends Component[Array[Byte]](conf: Config, pulsarController: PulsarController) {
+    deploymentID_jobID: String,
+    deploymentID: String,
+    jobID: String,
+    scheduler: Scheduler,
+    conf: Config,
+    pulsarController: PulsarController
+) extends Component[Array[Byte]](conf: Config, pulsarController: PulsarController) {
 
-  private val kryo                                              = PulsarKryoSerialiser()
-  implicit private val schema: Schema[Array[Byte]]              = Schema.BYTES
-  private var perspectivesProcessed: Long                       = 0
-  private var jobDone: Boolean                                  = false
-  private val topicId: String                                   = deploymentID_jobID
-  private var perspectivesList: ListBuffer[Perspective]         = new ListBuffer[Perspective]()
-  private var perspectivesDurations: ListBuffer[Long]           = new ListBuffer[Long]()
-  private var latestPerspective: Perspective                    = null
-  override val cancelableConsumer  = Some(startQueryTrackerConsumer(schema, deploymentID + "_" + jobID))
+  private val kryo                                      = PulsarKryoSerialiser()
+  implicit private val schema: Schema[Array[Byte]]      = Schema.BYTES
+  private var perspectivesProcessed: Long               = 0
+  private var jobDone: Boolean                          = false
+  private val topicId: String                           = deploymentID_jobID
+  private var perspectivesList: ListBuffer[Perspective] = new ListBuffer[Perspective]()
+  private var perspectivesDurations: ListBuffer[Long]   = new ListBuffer[Long]()
+  private var latestPerspective: Perspective            = null
+  override val consumer                                 = Some(startQueryTrackerConsumer(schema, deploymentID + "_" + jobID))
 
   logger.info("Starting query progress tracker.")
 
@@ -41,10 +43,8 @@ class QueryProgressTracker(
 
   private val monixScheduler = new MonixScheduler
 
-  override def run(): Unit = {
+  override def run(): Unit =
     monixScheduler.scheduler.execute(AsyncConsumer(this))
-  }
-
 
   def getJobId(): String =
     jobID
@@ -64,15 +64,12 @@ class QueryProgressTracker(
     jobDone
 
   def waitForJob() =
-  //TODO as executor sleep
+    //TODO as executor sleep
     while (!jobDone)
       Thread.sleep(1000)
 
-  def stop(): Unit =
-    cancelableConsumer match {
-      case Some(value) =>
-        value.close()
-    }
+  def stop(): Unit = {}
+  //consumer.close()
 
   override def handleMessage(msg: Message[Array[Byte]]): Boolean = {
     var repeatScheduler = true
@@ -83,11 +80,11 @@ class QueryProgressTracker(
 
         if (p.window.nonEmpty)
           logger.info(
-            s"Job '$jobID': Perspective '${p.timestamp}' with window '${p.window.get}' finished in $perspectiveDuration ms."
+                  s"Job '$jobID': Perspective '${p.timestamp}' with window '${p.window.get}' finished in $perspectiveDuration ms."
           )
         else
           logger.info(
-            s"Job '$jobID': Perspective '${p.timestamp}' finished in $perspectiveDuration ms."
+                  s"Job '$jobID': Perspective '${p.timestamp}' finished in $perspectiveDuration ms."
           )
 
         perspectiveTime = System.currentTimeMillis
@@ -100,8 +97,8 @@ class QueryProgressTracker(
 
       case JobDone        =>
         logger.info(
-          s"Job $jobID: Query completed with $perspectivesProcessed perspectives " +
-            s"and finished in ${System.currentTimeMillis() - startTime} ms."
+                s"Job $jobID: Query completed with $perspectivesProcessed perspectives " +
+                  s"and finished in ${System.currentTimeMillis() - startTime} ms."
         )
 
         jobDone = true

--- a/src/main/scala/com/raphtory/core/components/querytracker/QueryProgressTracker.scala
+++ b/src/main/scala/com/raphtory/core/components/querytracker/QueryProgressTracker.scala
@@ -24,7 +24,11 @@ class QueryProgressTracker(
     scheduler: Scheduler,
     conf: Config,
     pulsarController: PulsarController
-) extends Component[Array[Byte]](conf: Config, pulsarController: PulsarController) {
+) extends Component[Array[Byte]](
+                conf: Config,
+                pulsarController: PulsarController,
+                scheduler: Scheduler
+        ) {
 
   private val kryo                                      = PulsarKryoSerialiser()
   implicit private val schema: Schema[Array[Byte]]      = Schema.BYTES
@@ -41,10 +45,8 @@ class QueryProgressTracker(
   val startTime: Long       = System.currentTimeMillis //fetch starting time
   var perspectiveTime: Long = startTime
 
-  private val monixScheduler = new MonixScheduler
-
   override def run(): Unit =
-    monixScheduler.scheduler.execute(AsyncConsumer(this))
+    scheduler.execute(AsyncConsumer(this))
 
   def getJobId(): String =
     jobID

--- a/src/main/scala/com/raphtory/core/components/spout/SpoutExecutor.scala
+++ b/src/main/scala/com/raphtory/core/components/spout/SpoutExecutor.scala
@@ -7,6 +7,6 @@ import org.apache.pulsar.client.api.Message
 
 abstract class SpoutExecutor[T](conf: Config, private val pulsarController: PulsarController)
         extends Component[T](conf: Config, pulsarController: PulsarController) {
-  override def handleMessage(msg: Message[T]): Unit = {}
+  override def handleMessage(msg: Message[T]): Boolean = { false }
 
 }

--- a/src/main/scala/com/raphtory/core/components/spout/SpoutExecutor.scala
+++ b/src/main/scala/com/raphtory/core/components/spout/SpoutExecutor.scala
@@ -11,6 +11,6 @@ abstract class SpoutExecutor[T](
     conf: Config,
     private val pulsarController: PulsarController,
     scheduler: Scheduler
-) extends Component[T](conf: Config, pulsarController: PulsarController) {
+) extends Component[T](conf: Config, pulsarController: PulsarController, scheduler: Scheduler) {
   override def handleMessage(msg: Message[T]): Boolean = false
 }

--- a/src/main/scala/com/raphtory/core/components/spout/SpoutExecutor.scala
+++ b/src/main/scala/com/raphtory/core/components/spout/SpoutExecutor.scala
@@ -5,6 +5,7 @@ import com.raphtory.core.config.PulsarController
 import com.typesafe.config.Config
 import monix.execution.Scheduler
 import org.apache.pulsar.client.api.Message
+import org.apache.pulsar.client.api.Schema
 
 abstract class SpoutExecutor[T](
     conf: Config,
@@ -12,5 +13,4 @@ abstract class SpoutExecutor[T](
     scheduler: Scheduler
 ) extends Component[T](conf: Config, pulsarController: PulsarController) {
   override def handleMessage(msg: Message[T]): Boolean = false
-
 }

--- a/src/main/scala/com/raphtory/core/components/spout/executor/FileSpoutExecutor.scala
+++ b/src/main/scala/com/raphtory/core/components/spout/executor/FileSpoutExecutor.scala
@@ -196,10 +196,10 @@ class FileSpoutExecutor[T](
         progressPercent = Math.ceil(percentage * readLength).toInt
         val test = lineConverter(line)
         producer.newMessage().value(test).sendAsync()
-        //        if (progressPercent % divisByTens == 0) {
-        //          divisByTens += 10
-        //          logger.info(f"Read: $progressPercent%d%% of file.")
-        //        }
+        if (progressPercent % divisByTens == 0) {
+          divisByTens += 10
+          logger.debug(f"Read: $progressPercent%d%% of file.")
+        }
       }
       source.close()
       logger.debug("Finished reading file.")

--- a/src/main/scala/com/raphtory/core/components/spout/executor/IdentitySpoutExecutor.scala
+++ b/src/main/scala/com/raphtory/core/components/spout/executor/IdentitySpoutExecutor.scala
@@ -4,12 +4,14 @@ import com.raphtory.core.components.spout.SpoutExecutor
 import com.raphtory.core.config.PulsarController
 import com.typesafe.config.Config
 import monix.execution.Scheduler
+import org.apache.pulsar.client.api.Schema
 
 class IdentitySpoutExecutor[T](
     conf: Config,
     pulsarController: PulsarController,
     scheduler: Scheduler
 ) extends SpoutExecutor[T](conf: Config, pulsarController: PulsarController, scheduler: Scheduler) {
+
   override def stop(): Unit = {}
   override def run(): Unit = {}
 }

--- a/src/main/scala/com/raphtory/core/config/AsyncConsumer.scala
+++ b/src/main/scala/com/raphtory/core/config/AsyncConsumer.scala
@@ -1,0 +1,44 @@
+package com.raphtory.core.config
+
+import com.raphtory.core.components.Component
+
+
+class AsyncConsumer[T](worker : Component[T]) extends Runnable{
+
+  val monixScheduler =  new MonixScheduler
+
+  def run() : Unit =  {
+    worker.cancelableConsumer match {
+      case Some(consumer) =>
+        consumer.receiveAsync().thenApplyAsync(msg => {
+          val reschedule = worker.handleMessage(msg)
+          consumer.acknowledgeAsync(msg)
+          if (reschedule) {
+            monixScheduler.scheduler.execute(this)
+          } else {
+            worker.stop()
+          }
+        })
+      //        Async Batching:
+      //        consumer.batchReceiveAsync().thenApplyAsync(msgs => {
+      //          var reschedule = true
+      //          var allReschedule = true
+      //          while (msgs.iterator().hasNext) {
+      //            val msg = msgs.iterator().next()
+      //            reschedule = worker.handleMessage(msg)
+      //            consumer.acknowledgeAsync(msg)
+      //            if (reschedule == false) allReschedule = false
+      //          }
+      //          // all handlers return true -> reschedule, else stop the worker
+      //          if (allReschedule) monixScheduler.scheduler.execute(this)
+      //          else worker.stop()
+      //        })
+      case None => throw new Error("Message handling consumer not initialised")
+    }
+  }
+
+}
+
+object AsyncConsumer{
+  def apply[T](worker: Component[T]) = new AsyncConsumer[T](worker)
+}

--- a/src/main/scala/com/raphtory/core/config/AsyncConsumer.scala
+++ b/src/main/scala/com/raphtory/core/config/AsyncConsumer.scala
@@ -2,43 +2,42 @@ package com.raphtory.core.config
 
 import com.raphtory.core.components.Component
 
+class AsyncConsumer[T](worker: Component[T]) extends Runnable {
 
-class AsyncConsumer[T](worker : Component[T]) extends Runnable{
+  val monixScheduler = new MonixScheduler
 
-  val monixScheduler =  new MonixScheduler
-
-  def run() : Unit =  {
-    worker.cancelableConsumer match {
+  def run(): Unit =
+    worker.consumer match {
       case Some(consumer) =>
-        consumer.receiveAsync().thenApplyAsync(msg => {
+        consumer.receiveAsync().thenApplyAsync { msg =>
           val reschedule = worker.handleMessage(msg)
           consumer.acknowledgeAsync(msg)
-          if (reschedule) {
+          if (reschedule)
             monixScheduler.scheduler.execute(this)
-          } else {
+          else
             worker.stop()
-          }
-        })
-      //        Async Batching:
-      //        consumer.batchReceiveAsync().thenApplyAsync(msgs => {
-      //          var reschedule = true
-      //          var allReschedule = true
-      //          while (msgs.iterator().hasNext) {
-      //            val msg = msgs.iterator().next()
-      //            reschedule = worker.handleMessage(msg)
-      //            consumer.acknowledgeAsync(msg)
-      //            if (reschedule == false) allReschedule = false
-      //          }
-      //          // all handlers return true -> reschedule, else stop the worker
-      //          if (allReschedule) monixScheduler.scheduler.execute(this)
-      //          else worker.stop()
-      //        })
-      case None => throw new Error("Message handling consumer not initialised")
+        }
+      case None           =>
+        throw new IllegalStateException("Trying to consume from a Consumer that doesn't exist")
     }
-  }
+
+  //        Async Batching:
+  //        consumer.batchReceiveAsync().thenApplyAsync(msgs => {
+  //          var reschedule = true
+  //          var allReschedule = true
+  //          while (msgs.iterator().hasNext) {
+  //            val msg = msgs.iterator().next()
+  //            reschedule = worker.handleMessage(msg)
+  //            consumer.acknowledgeAsync(msg)
+  //            if (reschedule == false) allReschedule = false
+  //          }
+  //          // all handlers return true -> reschedule, else stop the worker
+  //          if (allReschedule) monixScheduler.scheduler.execute(this)
+  //          else worker.stop()
+  //        })
 
 }
 
-object AsyncConsumer{
+object AsyncConsumer {
   def apply[T](worker: Component[T]) = new AsyncConsumer[T](worker)
 }

--- a/src/main/scala/com/raphtory/core/config/AsyncConsumer.scala
+++ b/src/main/scala/com/raphtory/core/config/AsyncConsumer.scala
@@ -4,8 +4,6 @@ import com.raphtory.core.components.Component
 
 class AsyncConsumer[T](worker: Component[T]) extends Runnable {
 
-  val monixScheduler = new MonixScheduler
-
   def run(): Unit =
     worker.consumer match {
       case Some(consumer) =>
@@ -13,7 +11,7 @@ class AsyncConsumer[T](worker: Component[T]) extends Runnable {
           val reschedule = worker.handleMessage(msg)
           consumer.acknowledgeAsync(msg)
           if (reschedule)
-            monixScheduler.scheduler.execute(this)
+            worker.getScheduler().execute(this)
           else
             worker.stop()
         }

--- a/src/main/scala/com/raphtory/core/config/ComponentFactory.scala
+++ b/src/main/scala/com/raphtory/core/config/ComponentFactory.scala
@@ -27,7 +27,8 @@ private[core] class ComponentFactory(conf: Config, pulsarController: PulsarContr
     logger.info(s"Creating '$totalBuilders' Graph Builders.")
 
     val builders = for (i <- (0 until totalBuilders)) yield {
-      val builderExecutor = new BuilderExecutor[T](schema, graphbuilder, conf, pulsarController)
+      val builderExecutor =
+        new BuilderExecutor[T](schema, graphbuilder, conf, pulsarController, scheduler)
       scheduler.execute(builderExecutor)
       ThreadedWorker(builderExecutor)
     }
@@ -57,7 +58,7 @@ private[core] class ComponentFactory(conf: Config, pulsarController: PulsarContr
       }
 
       val storage = new PojoBasedPartition(partitionID, conf)
-      val writer  = new Writer(partitionID, storage, conf, pulsarController)
+      val writer  = new Writer(partitionID, storage, conf, pulsarController, scheduler)
       val reader  = new Reader(partitionID, storage, scheduler, conf, pulsarController)
 
       scheduler.execute(writer)

--- a/src/main/scala/com/raphtory/core/config/PulsarController.scala
+++ b/src/main/scala/com/raphtory/core/config/PulsarController.scala
@@ -6,7 +6,8 @@ import org.apache.pulsar.client.api._
 import org.apache.pulsar.common.policies.data.RetentionPolicies
 
 import cats.effect.implicits.catsEffectSyntaxConcurrent
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
 
 import java.util.concurrent.TimeUnit
 import scala.collection.JavaConverters._
@@ -15,7 +16,7 @@ class PulsarController(conf: Config) {
   private val pulsarAddress: String = conf.getString("raphtory.pulsar.broker.address")
   val pulsarAdminAddress: String    = conf.getString("raphtory.pulsar.admin.address")
 
-  private val client: PulsarClient  =
+  private val client: PulsarClient =
     PulsarClient
       .builder()
       .ioThreads(10)
@@ -29,9 +30,9 @@ class PulsarController(conf: Config) {
     .allowTlsInsecureConnection(false)
     .build
 
-  val consumerMaxMessages : Long                    = conf.getLong("raphtory.consumers.maxMessagesForBatch")
-  val consumerBatchTimeout : Long                    = conf.getLong("raphtory.consumers.timeoutForBatchMillis")
-  val consumerPooling      : Boolean                = conf.getBoolean("raphtory.consumers.consumerPoolPolicy")
+  val consumerMaxMessages: Long  = conf.getLong("raphtory.consumers.maxMessagesForBatch")
+  val consumerBatchTimeout: Long = conf.getLong("raphtory.consumers.timeoutForBatchMillis")
+  val consumerPooling: Boolean   = conf.getBoolean("raphtory.consumers.consumerPoolPolicy")
 
   def accessClient: PulsarClient = client
 
@@ -75,10 +76,10 @@ class PulsarController(conf: Config) {
 
   // without message listener
   def createListeningConsumer[T](
-                                  subscriptionName: String,
-                                  schema: Schema[T],
-                                  topics: String*
-                                ): Consumer[T] =
+      subscriptionName: String,
+      schema: Schema[T],
+      topics: String*
+  ): Consumer[T] =
     client
       .newConsumer(schema)
       .topics(topics.toList.asJava)
@@ -86,11 +87,11 @@ class PulsarController(conf: Config) {
       .subscriptionType(SubscriptionType.Shared)
       .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
       .batchReceivePolicy(
-        BatchReceivePolicy
-          .builder()
-          .maxNumMessages(consumerMaxMessages.toInt)
-          .timeout(consumerBatchTimeout.toInt, TimeUnit.NANOSECONDS)
-          .build()
+              BatchReceivePolicy
+                .builder()
+                .maxNumMessages(consumerMaxMessages.toInt)
+                .timeout(consumerBatchTimeout.toInt, TimeUnit.NANOSECONDS)
+                .build()
       )
       .poolMessages(consumerPooling)
       .subscribe()
@@ -103,7 +104,9 @@ class PulsarController(conf: Config) {
       .subscriptionName(subscriptionName)
       .subscriptionType(SubscriptionType.Shared)
       .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
-      .batchReceivePolicy(BatchReceivePolicy.builder().maxNumMessages(consumerMaxMessages.toInt).build())
+      .batchReceivePolicy(
+              BatchReceivePolicy.builder().maxNumMessages(consumerMaxMessages.toInt).build()
+      )
       .poolMessages(consumerPooling)
       .subscribe()
 


### PR DESCRIPTION
* [x] - `Async` receive & acknowledge by consumer
* [x] - All executors extending `RaphtoryWorker` would use `MonixScheduler`
* [x] - Use `AsyncConsumer` class for handling consumer receive logic
* [x] - Delete MessageListener, move logic to `run`, where scheduler is invoked and `handleMessage` is called
* [x] - Different batch receive policies & timeouts, batch sizes, pooling while configuring consumer, number of `Monix` threads
* [x] - `FacebookTest` runs in ~19781ms, `LOTR`: Improvement from 1 min 4 sec to 56-57 seconds: 7-8 seconds improvement: 10% faster on small datasets