### PR TITLE
Bug/Reenable vote to halt

### DIFF
--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -27,8 +27,8 @@
         </Logger>
         <Logger name="com.raphtory.core" level="INFO">
         </Logger>
-        <Logger name="com.raphtory.core.components.querymanager" level="DEBUG">
-        </Logger>
+<!--        <Logger name="com.raphtory.core.components.querymanager" level="DEBUG">-->
+<!--        </Logger>-->
         <Logger name="com.raphtory.core.components.querymanager.QueryManager" level="INFO">
         </Logger>
 

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -25,10 +25,13 @@
         </Logger>
         <Logger name="com.raphtory.develop" level="INFO">
         </Logger>
-        <Logger name="com.raphtory.core" level="DEBUG">
+        <Logger name="com.raphtory.core" level="INFO">
         </Logger>
-        <Logger name="com.raphtory.core.components.querymanager.QueryHandler" level="DEBUG">
+        <Logger name="com.raphtory.core.components.querymanager" level="DEBUG">
         </Logger>
+        <Logger name="com.raphtory.core.components.querymanager.QueryManager" level="INFO">
+        </Logger>
+
         <Root level="info">
             <AppenderRef ref="Console"/>
         </Root>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -25,7 +25,9 @@
         </Logger>
         <Logger name="com.raphtory.develop" level="INFO">
         </Logger>
-        <Logger name="com.raphtory.core" level="INFO">
+        <Logger name="com.raphtory.core" level="DEBUG">
+        </Logger>
+        <Logger name="com.raphtory.core.components.querymanager.QueryHandler" level="DEBUG">
         </Logger>
         <Root level="info">
             <AppenderRef ref="Console"/>

--- a/src/main/scala/com/raphtory/core/components/Component.scala
+++ b/src/main/scala/com/raphtory/core/components/Component.scala
@@ -1,18 +1,10 @@
 package com.raphtory.core.components
 
-import com.raphtory.core.components.graphbuilder.GraphAlteration
 import com.raphtory.core.config.PulsarController
 import com.raphtory.serialisers.PulsarKryoSerialiser
-import com.raphtory.serialisers.avro
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.Logger
-import org.apache.pulsar.client.admin.PulsarAdminException
-import org.apache.pulsar.client.api.Consumer
-import org.apache.pulsar.client.api.Message
 import org.apache.pulsar.client.api.MessageListener
-import org.apache.pulsar.client.api.Producer
-import org.apache.pulsar.client.api.Schema
-import org.apache.pulsar.common.policies.data.RetentionPolicies
 import org.slf4j.LoggerFactory
 
 import scala.reflect.runtime.universe._

--- a/src/main/scala/com/raphtory/core/components/Component.scala
+++ b/src/main/scala/com/raphtory/core/components/Component.scala
@@ -49,9 +49,8 @@ abstract class Component[T: TypeTag](conf: Config, private val pulsarController:
       catch {
         case e: Exception =>
           logger.error(s"Deployment $deploymentID: Failed to handle message.")
-          e.printStackTrace()
-
           consumer.negativeAcknowledge(msg)
+          throw e
       }
       finally msg.release()
     }

--- a/src/test/scala/com/raphtory/lotrtest/Runner.scala
+++ b/src/test/scala/com/raphtory/lotrtest/Runner.scala
@@ -1,0 +1,17 @@
+package com.raphtory.lotrtest
+
+import com.google.protobuf.ByteString.Output
+import com.raphtory.GraphState
+import com.raphtory.core.components.spout.instance.FileSpout
+import com.raphtory.core.deploy.Raphtory
+import com.raphtory.output.FileOutputFormat
+
+object Runner extends App {
+
+  val spout        = FileSpout("/tmp/lotr.csv")
+  val graphBuilder = new LOTRGraphBuilder()
+  val graph        = Raphtory.createGraph(spout, graphBuilder)
+  graph.pointQuery(GraphState(), FileOutputFormat("/tmp"), 30000).waitForJob()
+  graph.stop()
+
+}

--- a/src/test/scala/com/raphtory/lotrtest/Runner.scala
+++ b/src/test/scala/com/raphtory/lotrtest/Runner.scala
@@ -2,6 +2,7 @@ package com.raphtory.lotrtest
 
 import com.google.protobuf.ByteString.Output
 import com.raphtory.GraphState
+import com.raphtory.algorithms.generic.ConnectedComponents
 import com.raphtory.core.components.spout.instance.FileSpout
 import com.raphtory.core.deploy.Raphtory
 import com.raphtory.output.FileOutputFormat
@@ -11,7 +12,7 @@ object Runner extends App {
   val spout        = FileSpout("/tmp/lotr.csv")
   val graphBuilder = new LOTRGraphBuilder()
   val graph        = Raphtory.createGraph(spout, graphBuilder)
-  graph.pointQuery(GraphState(), FileOutputFormat("/tmp"), 30000).waitForJob()
+  graph.pointQuery(ConnectedComponents(), FileOutputFormat("/tmp"), 30000).waitForJob()
   graph.stop()
 
 }


### PR DESCRIPTION
**What changes were proposed in this pull request?**

- Reenabled the vote to halt functionality that was not working correctly inside of the query handler as the flag was never being checked.
- Added step by step debug logging to the query handler along with singular timers to see how long each stage of an algorithm is taking.

**To improve performance and stability in large scale deployments
Does this PR introduce any user-facing change?**

- Nothing user-facing is changed.

**How was this patch tested?**

- This was tested locally comparing the results of the full test suite
