### PR TITLE
Feature/batch loading refactor

### DIFF
--- a/src/main/scala/com/raphtory/core/components/partition/LocalBatchHandler.scala
+++ b/src/main/scala/com/raphtory/core/components/partition/LocalBatchHandler.scala
@@ -39,11 +39,10 @@ class LocalBatchHandler[T: ClassTag](
   override def run(): Unit =
     runIngestion
 
-  private def runIngestion() = {
-    spout.setBuilder(graphBuilder)
+  private def runIngestion(): Unit = {
     while (spout.hasNextIterator()) {
       startIngesting()
-      spout.executeNextIterator()
+      spout.nextIterator().foreach(graphBuilder.parseTuple)
     }
 
     stopIngesting()

--- a/src/main/scala/com/raphtory/core/components/spout/Spout.scala
+++ b/src/main/scala/com/raphtory/core/components/spout/Spout.scala
@@ -4,21 +4,12 @@ import com.raphtory.core.components.graphbuilder.GraphBuilder
 
 import scala.reflect.runtime.universe._
 
-trait Spout[T] {
-
-  var graphBuilder: GraphBuilder[T] = _
-
-  def hasNext(): Boolean
-  def next(): T
-
-  def hasNextIterator(): Boolean
-  def nextIterator(): Iterator[T]
-  def executeNextIterator(): Unit
-  private[core] def setBuilder(gb: GraphBuilder[T]) = graphBuilder = gb
+trait Spout[T] extends Iterator[T] {
+  def hasNextIterator(): Boolean  = hasNext
+  def nextIterator(): Iterator[T] = this
 
   def close(): Unit = {}
 
   def spoutReschedules(): Boolean
   def executeReschedule(): Unit = {}
-
 }

--- a/src/main/scala/com/raphtory/core/components/spout/SpoutExecutor.scala
+++ b/src/main/scala/com/raphtory/core/components/spout/SpoutExecutor.scala
@@ -41,7 +41,7 @@ class SpoutExecutor[T](
     executeSpout()
 
   private def executeSpout() = {
-    while (spout.hasNext()) {
+    while (spout.hasNext) {
       linesProcessed = linesProcessed + 1
       if (linesProcessed % 100_000 == 0)
         logger.debug(s"Spout: sent $linesProcessed messages.")

--- a/src/main/scala/com/raphtory/spouts/FileSpout.scala
+++ b/src/main/scala/com/raphtory/spouts/FileSpout.scala
@@ -53,7 +53,7 @@ class FileSpout[T: TypeTag](val path: String = "", val lineConverter: (String =>
     case None       => Iterator[String]()
   }
 
-  override def hasNext(): Boolean =
+  override def hasNext: Boolean =
     if (lines.hasNext)
       true
     else {
@@ -171,8 +171,6 @@ class FileSpout[T: TypeTag](val path: String = "", val lineConverter: (String =>
       case None       => Iterator[String]()
     }
   }
-
-  override def hasNextIterator(): Boolean = hasNext()
 
   override def nextIterator(): Iterator[T] =
     if (typeOf[T] =:= typeOf[String]) lines.asInstanceOf[Iterator[T]]

--- a/src/main/scala/com/raphtory/spouts/FileSpout.scala
+++ b/src/main/scala/com/raphtory/spouts/FileSpout.scala
@@ -178,15 +178,6 @@ class FileSpout[T: TypeTag](val path: String = "", val lineConverter: (String =>
     if (typeOf[T] =:= typeOf[String]) lines.asInstanceOf[Iterator[T]]
     else lines.map(lineConverter)
 
-  override def executeNextIterator(): Unit =
-    for (line <- lines)
-      try graphBuilder.parseTuple(lineConverter(line))
-      catch {
-        case ex: Exception =>
-          logger.error(s"Spout: Failed to process file, error: ${ex.getMessage}.")
-          throw ex
-      }
-
 }
 
 object FileSpout {

--- a/src/main/scala/com/raphtory/spouts/IdentitySpout.scala
+++ b/src/main/scala/com/raphtory/spouts/IdentitySpout.scala
@@ -4,11 +4,9 @@ import com.raphtory.core.components.spout.Spout
 import scala.reflect.runtime.universe.TypeTag
 
 class IdentitySpout[T]() extends Spout[T] {
-  override def hasNext(): Boolean         = false
-  override def hasNextIterator(): Boolean = false
+  override def hasNext: Boolean = false
 
-  override def next(): T                   = ???
-  override def nextIterator(): Iterator[T] = ???
+  override def next(): T = ???
 
   override def spoutReschedules(): Boolean = false
 

--- a/src/main/scala/com/raphtory/spouts/IdentitySpout.scala
+++ b/src/main/scala/com/raphtory/spouts/IdentitySpout.scala
@@ -12,5 +12,4 @@ class IdentitySpout[T]() extends Spout[T] {
 
   override def spoutReschedules(): Boolean = false
 
-  override def executeNextIterator(): Unit = ???
 }

--- a/src/main/scala/com/raphtory/spouts/ResourceSpout.scala
+++ b/src/main/scala/com/raphtory/spouts/ResourceSpout.scala
@@ -21,7 +21,4 @@ case class ResourceSpout(resource: String) extends Spout[String] {
 
   override def nextIterator(): Iterator[String] = lines
 
-  override def executeNextIterator(): Unit =
-    for (line <- lines)
-      try graphBuilder.parseTuple(line)
 }

--- a/src/main/scala/com/raphtory/spouts/ResourceSpout.scala
+++ b/src/main/scala/com/raphtory/spouts/ResourceSpout.scala
@@ -9,15 +9,13 @@ case class ResourceSpout(resource: String) extends Spout[String] {
   val source = Source.fromResource(resource)
   val lines  = source.getLines()
 
-  override def hasNext(): Boolean = lines.hasNext
+  override def hasNext: Boolean = lines.hasNext
 
   override def next(): String = lines.next()
 
   override def close(): Unit = source.close()
 
   override def spoutReschedules(): Boolean = false
-
-  override def hasNextIterator(): Boolean = lines.hasNext
 
   override def nextIterator(): Iterator[String] = lines
 

--- a/src/main/scala/com/raphtory/spouts/StaticGraphSpout.scala
+++ b/src/main/scala/com/raphtory/spouts/StaticGraphSpout.scala
@@ -45,7 +45,4 @@ case class StaticGraphSpout(fileDataPath: String) extends Spout[String] {
       data
     }
 
-  override def executeNextIterator(): Unit =
-    for (line <- nextIterator())
-      try graphBuilder.parseTuple(line)
 }

--- a/src/main/scala/com/raphtory/spouts/StaticGraphSpout.scala
+++ b/src/main/scala/com/raphtory/spouts/StaticGraphSpout.scala
@@ -14,7 +14,7 @@ case class StaticGraphSpout(fileDataPath: String) extends Spout[String] {
   var lineNo = 1
   var count  = 0
 
-  override def hasNext(): Boolean = lines.hasNext
+  override def hasNext: Boolean = lines.hasNext
 
   override def next(): String = {
     val line = lines.next()
@@ -32,17 +32,4 @@ case class StaticGraphSpout(fileDataPath: String) extends Spout[String] {
   }
 
   override def spoutReschedules(): Boolean = false
-
-  override def hasNextIterator(): Boolean = lines.hasNext
-
-  override def nextIterator(): Iterator[String] =
-    lines.map { line =>
-      val data = s"$line $lineNo"
-      lineNo += 1
-      count += 1
-      if (count % 100_000 == 0)
-        logger.debug(s"File spout sent $count messages.")
-      data
-    }
-
 }

--- a/src/test/scala/com/raphtory/twittertest/TwitterTest.scala
+++ b/src/test/scala/com/raphtory/twittertest/TwitterTest.scala
@@ -13,7 +13,6 @@ import java.io.File
 import scala.language.postfixOps
 import scala.sys.process._
 
-@DoNotDiscover
 class TwitterTest extends BaseRaphtoryAlgoTest[String] {
   override val testDir: String         = "/tmp/raphtoryTwitterTest"
   override def batchLoading(): Boolean = true


### PR DESCRIPTION
Refactor spout API

- Spout trait extends Iterator
- default implementation for `hasNextIterator` and `nextIterator`
- no more reference to `GraphBuilder` in `Spout`
- `LocalBatchHandler` calls `parseTuple` on results from `Spout` (no issues here as mapping functions over an iterator is lazy)