### PR TITLE
Spout metrics

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,6 +54,9 @@ libraryDependencies += "com.typesafe"                 % "config"                
 
 libraryDependencies ~= { _.map(_.exclude("org.slf4j","slf4j-log4j12")) }
 
+libraryDependencies += "io.prometheus" % "simpleclient" % "0.15.0"
+libraryDependencies += "io.prometheus" % "simpleclient_hotspot" % "0.15.0"
+
 assembly / assemblyMergeStrategy := {
   case PathList("META-INF", "MANIFEST.MF") => MergeStrategy.discard
   case x if Assembly.isConfigFile(x) =>

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -23,6 +23,13 @@ raphtory {
 
     }
   }
+  prometheus {
+    server                  = 8899
+    spout_namespace         = "spout"
+    reader_namespace        = "reader"
+    writer_namespace        = "writer"
+    query_namespace         = "query"
+  }
   zookeeper {
     address                 = "127.0.0.1:2181"
     address                 = ${?RAPHTORY_ZOOKEEPER_ADDRESS}

--- a/src/main/scala/com/raphtory/core/client/RaphtoryGraph.scala
+++ b/src/main/scala/com/raphtory/core/client/RaphtoryGraph.scala
@@ -10,7 +10,9 @@ import com.raphtory.core.config.ZookeeperIDManager
 import com.typesafe.config.Config
 import monix.execution.Scheduler
 import org.apache.pulsar.client.api.Schema
+import io.prometheus.client.exporter.HTTPServer
 
+import java.io.IOException
 import scala.language.postfixOps
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe._
@@ -79,6 +81,12 @@ private[core] class RaphtoryGraph[T: ClassTag: TypeTag](
 
   logger.info(s"Created Graph object with deployment ID '$deploymentID'.")
   logger.info(s"Created Graph Spout topic with name '$spoutTopic'.")
+
+  try {
+    new HTTPServer(8899)
+  } catch {
+    case e: IOException => e.printStackTrace()
+  }
 
   def stop(): Unit = {
     partitions.writers.foreach(_.stop())

--- a/src/main/scala/com/raphtory/core/client/RaphtoryGraph.scala
+++ b/src/main/scala/com/raphtory/core/client/RaphtoryGraph.scala
@@ -57,6 +57,7 @@ private[core] class RaphtoryGraph[T: ClassTag: TypeTag](
 
   private val deploymentID: String = conf.getString("raphtory.deploy.id")
   private val spoutTopic: String   = conf.getString("raphtory.spout.topic")
+  private val prometheusPort: Int = conf.getInt("raphtory.prometheus.server")
 
   private val zookeeperAddress: String = conf.getString("raphtory.zookeeper.address")
 
@@ -83,7 +84,7 @@ private[core] class RaphtoryGraph[T: ClassTag: TypeTag](
   logger.info(s"Created Graph Spout topic with name '$spoutTopic'.")
 
   try {
-    new HTTPServer(8899)
+    new HTTPServer(prometheusPort)
   } catch {
     case e: IOException => e.printStackTrace()
   }

--- a/src/main/scala/com/raphtory/core/components/spout/SpoutExecutor.scala
+++ b/src/main/scala/com/raphtory/core/components/spout/SpoutExecutor.scala
@@ -9,6 +9,8 @@ import org.apache.pulsar.client.api.Message
 
 import java.util.concurrent.TimeUnit
 import scala.reflect.runtime.universe.TypeTag
+import com.raphtory.core.config.telemetry.SpoutTelemetry
+
 
 /** @DoNotDocument */
 class SpoutExecutor[T](
@@ -41,6 +43,7 @@ class SpoutExecutor[T](
     executeSpout()
 
   private def executeSpout() = {
+    SpoutTelemetry.totalSpoutReschedules.inc()
     while (spout.hasNext) {
       linesProcessed = linesProcessed + 1
       if (linesProcessed % 100_000 == 0)

--- a/src/main/scala/com/raphtory/core/config/telemetry/SpoutTelemetry.scala
+++ b/src/main/scala/com/raphtory/core/config/telemetry/SpoutTelemetry.scala
@@ -1,12 +1,16 @@
 package com.raphtory.core.config.telemetry
 
 import io.prometheus.client.{Counter, Gauge}
+import com.raphtory.core.config.ConfigHandler
 
 object SpoutTelemetry {
+
+  val conf = new ConfigHandler().getConfig
+
   val totalFilesProcessed: Counter =
     Counter
       .build
-      .namespace("spout")
+      .namespace(conf.getString("raphtory.prometheus.spout_namespace"))
       .name("total_files_processed")
       .help("Total files processed by spout")
       .register
@@ -14,7 +18,7 @@ object SpoutTelemetry {
   val totalSpoutReschedules: Counter =
     Counter
       .build
-      .namespace("spout")
+      .namespace(conf.getString("raphtory.prometheus.spout_namespace"))
       .name("total_spout_reschedules")
       .help("Total spout reschedules")
       .register
@@ -22,7 +26,7 @@ object SpoutTelemetry {
   val totalLinesParsed: Gauge =
     Gauge
       .build
-      .namespace("spout")
+      .namespace(conf.getString("raphtory.prometheus.spout_namespace"))
       .name("total_lines_parsed")
       .help("Total lines parsed")
       .register

--- a/src/main/scala/com/raphtory/core/config/telemetry/SpoutTelemetry.scala
+++ b/src/main/scala/com/raphtory/core/config/telemetry/SpoutTelemetry.scala
@@ -3,6 +3,15 @@ package com.raphtory.core.config.telemetry
 import io.prometheus.client.{Counter, Gauge}
 import com.raphtory.core.config.ConfigHandler
 
+/**
+  * {s}`SpoutTelemetry`
+  *  : Adds metrics for {s}`Spout` using Prometheus Client
+  *
+  *    Exposes Counter and Gauge stats for tracking number of files processed, lines parsed, spout reschedules and processing errors
+  *    Statistics are made available on http://localhost:8899 on running tests and can be visualised using Grafana dashboards
+  *
+  *
+  */
 object SpoutTelemetry {
 
   val conf = new ConfigHandler().getConfig
@@ -29,6 +38,14 @@ object SpoutTelemetry {
       .namespace(conf.getString("raphtory.prometheus.spout_namespace"))
       .name("total_lines_parsed")
       .help("Total lines parsed")
+      .register
+
+  val totalFileProcessingErrors: Counter =
+    Counter
+      .build
+      .namespace(conf.getString("raphtory.prometheus.spout_namespace"))
+      .name("total_file_errors")
+      .help("Total file processing errors")
       .register
 
 }

--- a/src/main/scala/com/raphtory/core/config/telemetry/SpoutTelemetry.scala
+++ b/src/main/scala/com/raphtory/core/config/telemetry/SpoutTelemetry.scala
@@ -1,0 +1,30 @@
+package com.raphtory.core.config.telemetry
+
+import io.prometheus.client.{Counter, Gauge}
+
+object SpoutTelemetry {
+  val totalFilesProcessed: Counter =
+    Counter
+      .build
+      .namespace("spout")
+      .name("total_files_processed")
+      .help("Total files processed by spout")
+      .register
+
+  val totalSpoutReschedules: Counter =
+    Counter
+      .build
+      .namespace("spout")
+      .name("total_spout_reschedules")
+      .help("Total spout reschedules")
+      .register
+
+  val totalLinesParsed: Gauge =
+    Gauge
+      .build
+      .namespace("spout")
+      .name("total_lines_parsed")
+      .help("Total lines parsed")
+      .register
+
+}

--- a/src/main/scala/com/raphtory/spouts/FileSpout.scala
+++ b/src/main/scala/com/raphtory/spouts/FileSpout.scala
@@ -82,12 +82,12 @@ class FileSpout[T: TypeTag](val path: String = "", val lineConverter: (String =>
     catch {
       case ex: Exception =>
         logger.error(s"Spout: Failed to process file, error: ${ex.getMessage}.")
+        SpoutTelemetry.totalFileProcessingErrors.inc()
         throw ex
     }
 
   private def processFile(file: File) = {
     logger.info(s"Spout: Processing file '${file.toPath.getFileName}' ...")
-    SpoutTelemetry.totalFilesProcessed.inc()
 
     val fileName = file.getPath.toLowerCase
     currentfile = file
@@ -99,10 +99,12 @@ class FileSpout[T: TypeTag](val path: String = "", val lineConverter: (String =>
       case _                             => Source.fromFile(file)
     }
 
+    SpoutTelemetry.totalFilesProcessed.inc()
     try source.getLines()
     catch {
       case ex: Exception =>
         logger.error(s"Spout: Failed to process file, error: ${ex.getMessage}.")
+        SpoutTelemetry.totalFileProcessingErrors.inc()
         source.close()
 
         // Remove hard-link

--- a/src/main/scala/com/raphtory/spouts/FileSpout.scala
+++ b/src/main/scala/com/raphtory/spouts/FileSpout.scala
@@ -3,6 +3,7 @@ package com.raphtory.spouts
 import com.raphtory.core.components.spout.Spout
 import com.raphtory.core.deploy.Raphtory
 import com.typesafe.config.Config
+import com.raphtory.core.config.telemetry.SpoutTelemetry
 import com.typesafe.scalalogging.Logger
 import org.slf4j.LoggerFactory
 import com.raphtory.util.FileUtils
@@ -86,6 +87,7 @@ class FileSpout[T: TypeTag](val path: String = "", val lineConverter: (String =>
 
   private def processFile(file: File) = {
     logger.info(s"Spout: Processing file '${file.toPath.getFileName}' ...")
+    SpoutTelemetry.totalFilesProcessed.inc()
 
     val fileName = file.getPath.toLowerCase
     currentfile = file


### PR DESCRIPTION
Adds `counter` metrics for spout

- On processing each file, increments counter `total_processed_files` counter
- On rescheduling spout, increments counter `spout_reschedule`
- Adds a `gauge` for total lines read per file
- Adds a `counter` to track number of errored files