### PR TITLE
bug/edge_not_found_fix

### DIFF
--- a/src/main/scala/com/raphtory/core/components/partition/Reader.scala
+++ b/src/main/scala/com/raphtory/core/components/partition/Reader.scala
@@ -72,7 +72,6 @@ class Reader(
   def createWatermark(): Unit = {
     if (!storage.currentyBatchIngesting()) {
       val newestTime              = storage.newestTime
-      val oldestTime              = storage.oldestTime
       val blockingEdgeAdditions   = storage.blockingEdgeAdditions.nonEmpty
       val blockingEdgeDeletions   = storage.blockingEdgeDeletions.nonEmpty
       val blockingVertexDeletions = storage.blockingVertexDeletions.nonEmpty

--- a/src/main/scala/com/raphtory/core/components/partition/Reader.scala
+++ b/src/main/scala/com/raphtory/core/components/partition/Reader.scala
@@ -72,6 +72,7 @@ class Reader(
   def createWatermark(): Unit = {
     if (!storage.currentyBatchIngesting()) {
       val newestTime              = storage.newestTime
+      val oldestTime              = storage.oldestTime
       val blockingEdgeAdditions   = storage.blockingEdgeAdditions.nonEmpty
       val blockingEdgeDeletions   = storage.blockingEdgeDeletions.nonEmpty
       val blockingVertexDeletions = storage.blockingVertexDeletions.nonEmpty


### PR DESCRIPTION
- Based on the issues noted in #298 I have updated the PojoBasedPartition to deal with out of order edge sync messages. This means the partition should no longer throw an error if an edge is meant to exist (but doesn't) or overwriting the state if it already exists (but shouldn't).

- I have additionally added some debug messages inside of all edge sync functions so if there is some out of order shenanigans you will be able to see these reported. 

