### PR TITLE
Fix tests calling graph.stop() twice

### DIFF
--- a/core/src/test/scala/com/raphtory/BaseCorrectnessTest.scala
+++ b/core/src/test/scala/com/raphtory/BaseCorrectnessTest.scala
@@ -23,6 +23,10 @@ abstract class BaseCorrectnessTest extends BaseRaphtoryAlgoTest[String] {
     finally source.close()
   }
 
+  override def beforeAll(): Unit = setup()
+
+  override def afterAll(): Unit = {}
+
   private def correctResultsHash(rows: IterableOnce[String]): String =
     resultsHash(rows)
 


### PR DESCRIPTION
After refactoring, the correctness tests were calling `graph.stop()` twice which now that we clean up consumers correctly causes an exception