### PR TITLE
Clean up generic types and documentation

### DIFF
--- a/core/src/main/scala/com/raphtory/graph/visitor/ConcreteEdge.scala
+++ b/core/src/main/scala/com/raphtory/graph/visitor/ConcreteEdge.scala
@@ -1,0 +1,6 @@
+package com.raphtory.graph.visitor
+
+/** @DoNotDocument */
+trait ConcreteEdge[T] extends Edge {
+  override type IDType = T
+}

--- a/core/src/main/scala/com/raphtory/graph/visitor/ConcreteExplodedEdge.scala
+++ b/core/src/main/scala/com/raphtory/graph/visitor/ConcreteExplodedEdge.scala
@@ -1,0 +1,4 @@
+package com.raphtory.graph.visitor
+
+/** @DoNotDocument */
+trait ConcreteExplodedEdge[T] extends ExplodedEdge with ConcreteEdge[T]

--- a/core/src/main/scala/com/raphtory/graph/visitor/Edge.scala
+++ b/core/src/main/scala/com/raphtory/graph/visitor/Edge.scala
@@ -10,15 +10,24 @@ import com.raphtory.util.ExtendedNumeric.numericFromInt // implicit conversion f
   * For documentation of the property access and update history methods see the
   * [{s}`EntityVisitor` documentation](com.raphtory.graph.visitor.EntityVisitor).
   *
+  * ## Generic types
+  *
+  * {s}`IDType`
+  *   : type of vertex IDs for this edge
+  *
+  * {s}`ExplodedEdge`
+  *   : concrete type for exploded edge views of this edge which implements
+  *     [{s}`ExplodedEdge`](com.raphtory.graph.visitor.ExplodedEdge)
+  *
   * ## Attributes
   *
-  * {s}`ID: VertexID`
+  * {s}`ID: IDType`
   *  : Edge ID
   *
-  * {s}`src: VertexID`
+  * {s}`src: IDType`
   *  : ID of the source vertex of the edge
   *
-  * {s}`dst: VertexID`
+  * {s}`dst: IDType`
   *  : ID of the destination vertex of the edge
   *
   * ## Methods
@@ -65,13 +74,14 @@ import com.raphtory.util.ExtendedNumeric.numericFromInt // implicit conversion f
   * [](com.raphtory.graph.visitor.Vertex)
   * ```
   */
-trait Edge[VertexID] extends EntityVisitor {
-
+trait Edge extends EntityVisitor {
+  type IDType
+  type ExplodedEdge <: ConcreteExplodedEdge[IDType]
   //information about the edge meta data
-  def ID(): VertexID
-  def src(): VertexID
-  def dst(): VertexID
-  def explode(): List[ExplodedEdge[VertexID]]
+  def ID(): IDType
+  def src(): IDType
+  def dst(): IDType
+  def explode(): List[ExplodedEdge]
   def remove(): Unit
 
   def weight[A, B](

--- a/core/src/main/scala/com/raphtory/graph/visitor/ExplodedEdge.scala
+++ b/core/src/main/scala/com/raphtory/graph/visitor/ExplodedEdge.scala
@@ -6,43 +6,13 @@ import scala.runtime.RichLong
   * {s}`ExplodedEdge`
   *   : trait representing a view of an edge at a given point in time
   *
-  * ## Attributes
+  * An exploded edge represents an [{s}`Edge`](com.raphtory.graph.visitor.Edge) at a particular time point
+  * and combines the [{s}`Edge`](com.raphtory.graph.visitor.Edge) and
+  * [{s}`ExplodedEntityVisitor`](com.raphtory.graph.visitor.ExplodedEntityVisitor) traits.
   *
-  * {s}`Type(): String`
-  *   : type of the underlying edge
-  *
-  * {s}`ID(): Long`
-  *   : ID of the underlying edge
-  *
-  * {s}`src(): Long`
-  *   : ID of the source vertex of the edge
-  *
-  * {s}`dst(): Long`
-  *   : ID of the destination vertex of the edge
-  *
-  * {s}`timestamp(): Long`
-  *   : time point at which we are viewing the edge
-  *
-  * ## Methods
-  *
-  * {s}`getPropertySet(): List[String]`
-  *   : list available edge property names
-  *
-  * {s}`getPropertyValue[T](key: String): Option[T]`
-  *   : get value for edge property
-  *     {s}`T`
-  *       : value type of property
-  *
-  *     {s}`key: String`
-  *       : name of property
-  *
-  *     This method gets the value for the property {s}`key` at time {s}`timestamp()`
-  *     of the underlying edge.
-  *
-  * {s}`send(data: Any): Unit`
-  *   : send message to destination vertex of the edge
-  *
-  *     {s}`data: Any`
-  *       : message data to send
+  * ```{seealso}
+  * [](com.raphtory.graph.visitor.Edge),
+  * [](com.raphtory.graph.visitor.ExplodedEntityVisitor)
+  * ```
   */
-trait ExplodedEdge[VertexID] extends Edge[VertexID] with ExplodedEntityVisitor
+trait ExplodedEdge extends Edge with ExplodedEntityVisitor

--- a/core/src/main/scala/com/raphtory/graph/visitor/ExplodedVertex.scala
+++ b/core/src/main/scala/com/raphtory/graph/visitor/ExplodedVertex.scala
@@ -16,10 +16,15 @@ package com.raphtory.graph.visitor
   *
   * {s}`baseName(nameProperty: String): String`
   *   : use {s}`nameProperty` instead of {s}`"name"` to look up vertex name
+  *
+  * ```{seealso}
+  * [](com.raphtory.graph.visitor.Vertex),
+  * [](com.raphtory.graph.visitor.ExplodedEntityVisitor)
+  * ```
   */
 trait ExplodedVertex extends Vertex with ExplodedEntityVisitor {
   override type IDType = (Long, Long)
-  override type Edge <: ExplodedEdge
+  override type Edge <: ConcreteExplodedEdge[IDType]
   override def name(nameProperty: String): String = s"${super.name(nameProperty)}_$timestamp"
   def baseName: String                            = super.name()
   def baseName(nameProperty: String): String      = super.name(nameProperty)

--- a/core/src/main/scala/com/raphtory/graph/visitor/InterlayerEdge.scala
+++ b/core/src/main/scala/com/raphtory/graph/visitor/InterlayerEdge.scala
@@ -1,10 +1,10 @@
 package com.raphtory.graph.visitor
 
 /**
-  * {s}`InterlayerEdge(sourceTime: Long, dstTime: Long, properties: Map[String, Any] = Map.empty[String, Any]`)
+  * {s}`InterlayerEdge(srcTime: Long, dstTime: Long, properties: Map[String, Any] = Map.empty[String, Any])`
   *   : Class for representing interlayer edges
   *
-  *     {s}`sourceTime: Long`
+  *     {s}`srcTime: Long`
   *       : source time-stamp for the edge
   *
   *     {s}`dstTime: Long`
@@ -14,7 +14,7 @@ package com.raphtory.graph.visitor
   *       : properties that the interlayer edge should have
   */
 case class InterlayerEdge(
-    sourceTime: Long,
+    srcTime: Long,
     dstTime: Long,
     properties: Map[String, Any] = Map.empty[String, Any]
 ) extends EntityVisitor {
@@ -39,7 +39,7 @@ case class InterlayerEdge(
     properties.get(key) match {
       case None        => None
       case Some(value) =>
-        val actualTime = Seq(sourceTime, dstTime, after).min
+        val actualTime = Seq(srcTime, dstTime, after).min
         if (actualTime > before)
           Some(List.empty[(Long, T)])
         else
@@ -47,13 +47,13 @@ case class InterlayerEdge(
     }
 
   override def latestActivity(): HistoricEvent =
-    HistoricEvent(math.max(sourceTime, dstTime), event = false)
+    HistoricEvent(math.max(srcTime, dstTime), event = false)
 
   override def earliestActivity(): HistoricEvent =
-    HistoricEvent(math.min(sourceTime, dstTime), event = true)
+    HistoricEvent(math.min(srcTime, dstTime), event = true)
 
   override def getPropertyAt[T](key: String, time: Long): Option[T] =
-    if (time < math.min(sourceTime, dstTime) || time > math.max(sourceTime, dstTime))
+    if (time < math.min(srcTime, dstTime) || time > math.max(srcTime, dstTime))
       None
     else
       properties.get(key).map(_.asInstanceOf[T])

--- a/core/src/main/scala/com/raphtory/graph/visitor/PropertyMergeStrategy.scala
+++ b/core/src/main/scala/com/raphtory/graph/visitor/PropertyMergeStrategy.scala
@@ -11,28 +11,34 @@ import com.raphtory.util.Reduction._
   * [{s}`EntityVisitor`](com.raphtory.graph.visitor.EntityVisitor).
   * The general signature for a merge strategy is {s}`Seq[(Long, A)] => B`.
   *
+  * ## Generic types
+  *
+  * {s}`PropertyMerge[A, B] = Seq[(Long, A)] => B`
+  *   : Type of a merge strategy with return type {s}`B` for a property with value type {s}`A`
+  *
   * ## Methods
   *
-  * {s}`sum[T: Numeric](history: (history: Seq[(Long, T)]): T`
-  *  : Return the sum of property values
+  * {s}`sum[T: Numeric]: PropertyMerge[T, T]`
+  *  : Merge strategy that sums the property values
   *
-  * {s}`max[T: Numeric](history: (history: Seq[(Long, T)]): T`
-  *  : Return the maximum property value
+  * {s}`max[T: Numeric]: PropertyMerge[T, T]`
+  *  : Merge strategy that returns the maximum property value
   *
-  * {s}`min[T: Numeric](history: (history: Seq[(Long, T)]): T`
-  *  : Return the minimum property value
+  * {s}`min[T: Numeric]: PropertyMerge[T, T]`
+  *  : Merge strategy that returns the minimum property value
   *
-  * {s}`product[T: Numeric](history: (history: Seq[(Long, T)]): T`
-  *  : Return the product of property values
+  * {s}`product[T: Numeric]: PropertyMerge[T, T]`
+  *  : Merge strategy that returns the product of property values
   *
-  * {s}`average[T: Numeric](history: (history: Seq[(Long, T)]): Double`
-  *  : Return the average of property values
+  * {s}`average[T: Numeric]: PropertyMerge[T, Double]`
+  *  : Merge strategy that returns the average of property values
   *
-  * {s}`latest[T](history: (history: Seq[(Long, T)]): T`
-  *  : Return the latest property value (i.e. the value corresponding to the largest timestamp)
+  * {s}`latest[T]: PropertyMerge[T, T]`
+  *  : Merge strategy that returns the latest property value (i.e. the value corresponding to the largest timestamp)
+  *    This is the default merge strategy for property access in Raphtory.
   *
-  * {s}`earliest[T](history: (history: Seq[(Long, T)]): T`
-  *  : Return the earliest property value (i.e., the value corresponding to the smallest timestamp)
+  * {s}`earliest[T]: PropertyMerge[T, T]`
+  *  : Merge startegy that returns the earliest property value (i.e., the value corresponding to the smallest timestamp)
   *
   * ```{seealso}
   * [](com.raphtory.graph.visitor.EntityVisitor),

--- a/core/src/main/scala/com/raphtory/graph/visitor/Vertex.scala
+++ b/core/src/main/scala/com/raphtory/graph/visitor/Vertex.scala
@@ -11,17 +11,26 @@ import scala.reflect.ClassTag
   *   : Extends [{s}`EntityVisitor`](com.raphtory.graph.visitor.EntityVisitor) with vertex-specific functionality
   *
   * The {s}`Vertex` is the main entry point for exploring the graph using a
-  * [{s}`GraphAlgorithm](com.raphtory.algorithms.api.GraphAlgorithm) given the node-centric nature of Raphtory.
+  * [{s}`GraphAlgorithm`](com.raphtory.algorithms.api.GraphAlgorithm) given the node-centric nature of Raphtory.
   * It provides access to the edges of the graph and can send messages to and receive messages from other vertices.
   * A {s}`Vertex` can also store computational state.
   *
-  * ## Attributes
+  * ## Generic types
   *
-  * {s}`type IDType`
+  * {s}`IDType`
   *   : ID type of this vertex
   *
-  * {s}`implicit val IDOrdering: Ordering[IDType]`
-  *   : ordering to use with ID
+  * {s}`Edge`
+  *   : Concrete edge type for this vertex which implements [{s}`Edge`](com.raphtory.graph.visitor.Edge)
+  *
+  * {s}`ExplodedEdge`
+  *   : Concrete type for this vertex's exploded edges which implements
+  *     [{s}`ExplodedEdge`](com.raphtory.graph.visitor.ExplodedEdge)
+  *
+  * {s}`IDOrdering: Ordering[IDType]`
+  *   : implicit ordering object for use when comparing vertex IDs
+  *
+  * ## Attributes
   *
   * {s}`ID(): IDType`
   *   : vertex ID
@@ -357,10 +366,10 @@ import scala.reflect.ClassTag
   */
 trait Vertex extends EntityVisitor {
   type IDType
-  type Edge <: visitor.Edge[IDType]
+  type Edge <: visitor.ConcreteEdge[IDType]
+  type ExplodedEdge = visitor.ConcreteExplodedEdge[IDType]
   implicit val IDOrdering: Ordering[IDType]
 
-  type ExplodedEdge = visitor.ExplodedEdge[IDType]
   def ID(): IDType
 
   def name(nameProperty: String = "name"): String =

--- a/core/src/main/scala/com/raphtory/storage/pojograph/entities/external/PojoExEdge.scala
+++ b/core/src/main/scala/com/raphtory/storage/pojograph/entities/external/PojoExEdge.scala
@@ -3,6 +3,8 @@ package com.raphtory.storage.pojograph.entities.external
 import com.raphtory.components.querymanager.FilteredInEdgeMessage
 import com.raphtory.components.querymanager.FilteredOutEdgeMessage
 import com.raphtory.components.querymanager.VertexMessage
+import com.raphtory.graph.visitor.ConcreteEdge
+import com.raphtory.graph.visitor.ConcreteExplodedEdge
 import com.raphtory.graph.visitor.Edge
 import com.raphtory.graph.visitor.ExplodedEdge
 import com.raphtory.storage.pojograph.PojoGraphLens
@@ -12,8 +14,9 @@ import com.raphtory.storage.pojograph.entities.internal.SplitEdge
 /** @DoNotDocument */
 class PojoExEdge(val edge: PojoEdge, id: Long, val view: PojoGraphLens)
         extends PojoExEntity(edge, view)
-        with Edge[Long] {
+        with ConcreteEdge[Long] {
 
+  override type ExplodedEdge = PojoExplodedEdge
   def ID() = id
 
   def src() = edge.getSrcId
@@ -23,10 +26,10 @@ class PojoExEdge(val edge: PojoEdge, id: Long, val view: PojoGraphLens)
   def send(data: Any): Unit =
     view.sendMessage(VertexMessage(view.superStep + 1, id, data))
 
-  override def explode(): List[ExplodedEdge[Long]] =
+  override def explode(): List[ExplodedEdge] =
     history().collect { case event if event.event => PojoExplodedEdge.fromEdge(this, event.time) }
 
-  def isExternal: Boolean                          = edge.isInstanceOf[SplitEdge]
+  def isExternal: Boolean                    = edge.isInstanceOf[SplitEdge]
 
   override def remove(): Unit = {
     view.needsFiltering = true

--- a/core/src/main/scala/com/raphtory/storage/pojograph/entities/external/PojoExMultilayerEdge.scala
+++ b/core/src/main/scala/com/raphtory/storage/pojograph/entities/external/PojoExMultilayerEdge.scala
@@ -3,6 +3,7 @@ package com.raphtory.storage.pojograph.entities.external
 import com.raphtory.components.querymanager.FilteredInEdgeMessage
 import com.raphtory.components.querymanager.FilteredOutEdgeMessage
 import com.raphtory.components.querymanager.VertexMessage
+import com.raphtory.graph.visitor.ConcreteExplodedEdge
 import com.raphtory.graph.visitor.EntityVisitor
 import com.raphtory.graph.visitor.ExplodedEdge
 import com.raphtory.graph.visitor.HistoricEvent
@@ -15,8 +16,9 @@ class PojoExMultilayerEdge(
     override val dst: (Long, Long),
     protected val edge: EntityVisitor,
     protected val view: PojoGraphLens
-) extends ExplodedEdge[(Long, Long)] {
-  override def explode(): List[ExplodedEdge[(Long, Long)]] = List(this)
+) extends ConcreteExplodedEdge[(Long, Long)] {
+  override type ExplodedEdge = PojoExMultilayerEdge
+  override def explode(): List[ExplodedEdge] = List(this)
 
   override def send(data: Any): Unit = VertexMessage(view.superStep + 1, ID, data)
 

--- a/core/src/main/scala/com/raphtory/storage/pojograph/entities/external/PojoExVertex.scala
+++ b/core/src/main/scala/com/raphtory/storage/pojograph/entities/external/PojoExVertex.scala
@@ -84,14 +84,14 @@ class PojoExVertex(
     interlayerEdgeBuilder.foreach { builder =>
       if (interlayerEdges.nonEmpty)
         interlayerEdges.foreach { edge =>
-          exploded(edge.sourceTime).internalOutgoingEdges -= ((ID(), edge.dstTime))
-          exploded(edge.dstTime).internalIncomingEdges -= ((ID(), edge.sourceTime))
+          exploded(edge.srcTime).internalOutgoingEdges -= ((ID(), edge.dstTime))
+          exploded(edge.dstTime).internalIncomingEdges -= ((ID(), edge.srcTime))
         }
       interlayerEdges = builder(this)
       interlayerEdges.foreach { edge =>
-        val srcID = (ID(), edge.sourceTime)
+        val srcID = (ID(), edge.srcTime)
         val dstID = (ID(), edge.dstTime)
-        exploded(edge.sourceTime).internalOutgoingEdges += dstID -> new PojoExMultilayerEdge(
+        exploded(edge.srcTime).internalOutgoingEdges += dstID -> new PojoExMultilayerEdge(
                 edge.dstTime,
                 dstID,
                 srcID,
@@ -99,8 +99,8 @@ class PojoExVertex(
                 edge,
                 lens
         )
-        exploded(edge.dstTime).internalIncomingEdges += srcID    -> new PojoExMultilayerEdge(
-                edge.sourceTime,
+        exploded(edge.dstTime).internalIncomingEdges += srcID -> new PojoExMultilayerEdge(
+                edge.srcTime,
                 srcID,
                 srcID,
                 dstID,

--- a/core/src/main/scala/com/raphtory/storage/pojograph/entities/external/PojoExplodedEdge.scala
+++ b/core/src/main/scala/com/raphtory/storage/pojograph/entities/external/PojoExplodedEdge.scala
@@ -3,6 +3,7 @@ package com.raphtory.storage.pojograph.entities.external
 import com.raphtory.components.querymanager.FilteredInEdgeMessage
 import com.raphtory.components.querymanager.FilteredOutEdgeMessage
 import com.raphtory.components.querymanager.VertexMessage
+import com.raphtory.graph.visitor.ConcreteExplodedEdge
 import com.raphtory.graph.visitor.ExplodedEdge
 import com.raphtory.graph.visitor.HistoricEvent
 import com.raphtory.storage.pojograph.PojoGraphLens
@@ -17,11 +18,11 @@ class PojoExplodedEdge(
     val dst: Long,
     override val timestamp: Long
 ) extends PojoExEntity(objectEdge, view)
-        with ExplodedEdge[Long] {
-
+        with ConcreteExplodedEdge[Long] {
+  override type ExplodedEdge = PojoExplodedEdge
   override def ID(): Long = id
 
-  override def explode(): List[PojoExplodedEdge] = List(this)
+  override def explode(): List[ExplodedEdge] = List(this)
 
   override def send(data: Any): Unit = view.sendMessage(VertexMessage(view.superStep + 1, id, data))
 


### PR DESCRIPTION
- `Edge` and `ExplodedEdge` now have an abstract type member rather than taking type parameters
  * this is going to make things like writing generic edge filters much neater as we do no longer have to worry about type parameters
  * implemented intermediate trait (not user-facing) to turn abstract type into type parameter for passing along `IDType` from vertex
- cleaned up the documentation