### PR TITLE
Changed firstActivityAfter and lastActivityBefore to return options

### DIFF
--- a/core/src/main/scala/com/raphtory/algorithms/temporal/Ancestors.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/temporal/Ancestors.scala
@@ -47,7 +47,7 @@ class Ancestors(seed: String, time: Long, delta: Long = Long.MaxValue, directed:
         if (vertex.name() == seed) {
           (if (directed) vertex.getInEdges() else vertex.getEdges())
             .foreach(e =>
-              e.lastActivityBefore(time) match {
+              e.lastActivityBefore(time, false) match {
                 case Some(event) =>
                   if (event.time > time - delta)
                     vertex.messageVertex(e.ID(), event.time)
@@ -63,7 +63,7 @@ class Ancestors(seed: String, time: Long, delta: Long = Long.MaxValue, directed:
                 vertex.setState("ancestor", true)
                 (if (directed) vertex.getInEdges() else vertex.getEdges())
                   .foreach(e =>
-                    e.lastActivityBefore(time) match {
+                    e.lastActivityBefore(time, false) match {
                       case Some(event) =>
                         if (event.time > time - delta)
                           vertex.messageVertex(e.ID(), event.time)

--- a/core/src/main/scala/com/raphtory/algorithms/temporal/Ancestors.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/temporal/Ancestors.scala
@@ -22,10 +22,14 @@ import com.raphtory.algorithms.api.Table
   *    : The time of interest
   *
   *  {s}`delta: Long = Long.MaxValue`
-  *    : The maximum timespan for the temporal path
+  *    : The maximum timespan for the temporal path. This is currently exclusive of the oldest time
+  *       i.e. if looking back a minute it will not include events that happen exactly 1 minute ago.
   *
   *  {s}`directed: Boolean = true`
   *    : whether to treat the network as directed
+  *
+  *  {s}`strict: Boolean = true`
+  *    : Whether lastActivityBefore is strict in its following of paths that happen exactly at the given time. True will not follow, False will.
   *
   * ## States
   *
@@ -38,8 +42,13 @@ import com.raphtory.algorithms.api.Table
   *  | ----------------- | ---------------------- |
   *  | {s}`name: String` | {s}`ancestor: Boolean` |
   */
-class Ancestors(seed: String, time: Long, delta: Long = Long.MaxValue, directed: Boolean = true)
-        extends GraphAlgorithm {
+class Ancestors(
+    seed: String,
+    time: Long,
+    delta: Long = Long.MaxValue,
+    directed: Boolean = true,
+    strict: Boolean = true
+) extends GraphAlgorithm {
 
   override def apply(graph: GraphPerspective): GraphPerspective =
     graph
@@ -47,7 +56,7 @@ class Ancestors(seed: String, time: Long, delta: Long = Long.MaxValue, directed:
         if (vertex.name() == seed) {
           (if (directed) vertex.getInEdges() else vertex.getEdges())
             .foreach(e =>
-              e.lastActivityBefore(time, false) match {
+              e.lastActivityBefore(time, strict) match {
                 case Some(event) =>
                   if (event.time > time - delta)
                     vertex.messageVertex(e.ID(), event.time)
@@ -63,7 +72,7 @@ class Ancestors(seed: String, time: Long, delta: Long = Long.MaxValue, directed:
                 vertex.setState("ancestor", true)
                 (if (directed) vertex.getInEdges() else vertex.getEdges())
                   .foreach(e =>
-                    e.lastActivityBefore(time, false) match {
+                    e.lastActivityBefore(time, strict) match {
                       case Some(event) =>
                         if (event.time > time - delta)
                           vertex.messageVertex(e.ID(), event.time)
@@ -82,6 +91,12 @@ class Ancestors(seed: String, time: Long, delta: Long = Long.MaxValue, directed:
 
 object Ancestors {
 
-  def apply(seed: String, time: Long, delta: Long = Long.MaxValue, directed: Boolean = true) =
-    new Ancestors(seed, time, delta, directed)
+  def apply(
+      seed: String,
+      time: Long,
+      delta: Long = Long.MaxValue,
+      directed: Boolean = true,
+      strict: Boolean = true
+  ) =
+    new Ancestors(seed, time, delta, directed, strict)
 }

--- a/core/src/main/scala/com/raphtory/algorithms/temporal/Ancestors.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/temporal/Ancestors.scala
@@ -47,8 +47,18 @@ class Ancestors(seed: String, time: Long, delta: Long = Long.MaxValue, directed:
         if (vertex.name() == seed) {
           val edges = (if (directed) vertex.getInEdges() else vertex.getEdges())
             .filter(e => e.earliestActivity().time < time)
-            .filter(e => e.lastActivityBefore(time).time > time - delta)
-          edges.foreach(e => vertex.messageVertex(e.ID(), e.lastActivityBefore(time).time))
+            .filter(e =>
+              e.lastActivityBefore(time) match {
+                case Some(event) => event.time > time - delta
+                case None        => false
+              }
+            )
+          edges.foreach(e =>
+            e.lastActivityBefore(time) match {
+              case Some(event) => vertex.messageVertex(e.ID(), event.time)
+              case None        =>
+            }
+          )
           vertex.setState("ancestor", false)
         }
       }
@@ -58,9 +68,19 @@ class Ancestors(seed: String, time: Long, delta: Long = Long.MaxValue, directed:
                 vertex.setState("ancestor", true)
                 val inEdges    = (if (directed) vertex.getInEdges() else vertex.getEdges())
                   .filter(e => e.earliestActivity().time < latestTime)
-                  .filter(e => e.lastActivityBefore(time).time > latestTime - delta)
+                  .filter(e =>
+                    e.lastActivityBefore(time) match {
+                      case Some(event) => event.time > time - delta
+                      case None        => false
+                    }
+                  )
                 inEdges
-                  .foreach(e => vertex.messageVertex(e.ID(), e.lastActivityBefore(latestTime).time))
+                  .foreach(e =>
+                    e.lastActivityBefore(time) match {
+                      case Some(event) => vertex.messageVertex(e.ID(), event.time)
+                      case None        =>
+                    }
+                  )
               },
               executeMessagedOnly = true,
               iterations = 100

--- a/core/src/main/scala/com/raphtory/algorithms/temporal/Descendants.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/temporal/Descendants.scala
@@ -47,8 +47,18 @@ class Descendants(seed: String, time: Long, delta: Long = Long.MaxValue, directe
         if (vertex.name() == seed) {
           val edges = (if (directed) vertex.getOutEdges() else vertex.getEdges())
             .filter(e => e.latestActivity().time > time)
-            .filter(e => e.firstActivityAfter(time).time < time + delta)
-          edges.foreach(e => vertex.messageVertex(e.ID(), e.firstActivityAfter(time).time))
+            .filter(e =>
+              e.firstActivityAfter(time) match {
+                case Some(event) => event.time < time + delta
+                case None        => false
+              }
+            )
+          edges.foreach(e =>
+            e.firstActivityAfter(time) match {
+              case Some(event) => vertex.messageVertex(e.ID(), event.time)
+              case None        =>
+            }
+          )
           vertex.setState("descendant", false)
         }
       }
@@ -58,9 +68,17 @@ class Descendants(seed: String, time: Long, delta: Long = Long.MaxValue, directe
                 vertex.setState("descendant", true)
                 val outEdges     = (if (directed) vertex.getOutEdges() else vertex.getEdges())
                   .filter(e => e.latestActivity().time > earliestTime)
-                  .filter(e => e.firstActivityAfter(earliestTime).time < earliestTime + delta)
+                  .filter(e =>
+                    e.firstActivityAfter(time) match {
+                      case Some(event) => event.time < time + delta
+                      case None        => false
+                    }
+                  )
                 outEdges.foreach(e =>
-                  vertex.messageVertex(e.ID(), e.firstActivityAfter(earliestTime).time)
+                  e.firstActivityAfter(time) match {
+                    case Some(event) => vertex.messageVertex(e.ID(), event.time)
+                    case None        =>
+                  }
                 )
               },
               executeMessagedOnly = true,

--- a/core/src/main/scala/com/raphtory/algorithms/temporal/Descendants.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/temporal/Descendants.scala
@@ -47,7 +47,7 @@ class Descendants(seed: String, time: Long, delta: Long = Long.MaxValue, directe
         if (vertex.name() == seed) {
           (if (directed) vertex.getOutEdges() else vertex.getEdges())
             .foreach(e =>
-              e.firstActivityAfter(time) match {
+              e.firstActivityAfter(time, false) match {
                 case Some(event) =>
                   if (event.time < time + delta) vertex.messageVertex(e.ID(), event.time)
                 case None        =>
@@ -62,7 +62,7 @@ class Descendants(seed: String, time: Long, delta: Long = Long.MaxValue, directe
                 vertex.setState("descendant", true)
                 (if (directed) vertex.getOutEdges() else vertex.getEdges())
                   .foreach(e =>
-                    e.firstActivityAfter(time) match {
+                    e.firstActivityAfter(time, false) match {
                       case Some(event) =>
                         if (event.time < time + delta)
                           vertex.messageVertex(e.ID(), event.time)

--- a/core/src/main/scala/com/raphtory/graph/visitor/EntityVisitor.scala
+++ b/core/src/main/scala/com/raphtory/graph/visitor/EntityVisitor.scala
@@ -216,8 +216,8 @@ abstract class EntityVisitor {
 
   def Type(): String
 
-  def firstActivityAfter(time: Long): HistoricEvent
-  def lastActivityBefore(time: Long): HistoricEvent
+  def firstActivityAfter(time: Long): Option[HistoricEvent]
+  def lastActivityBefore(time: Long): Option[HistoricEvent]
   def latestActivity(): HistoricEvent
   def earliestActivity(): HistoricEvent
 

--- a/core/src/main/scala/com/raphtory/graph/visitor/EntityVisitor.scala
+++ b/core/src/main/scala/com/raphtory/graph/visitor/EntityVisitor.scala
@@ -42,13 +42,15 @@ import io.sqooba.oss.timeseries.immutable.TSEntry
   *    If a value for {s}`window` is given, the entity is considered as having been deleted if more
   *    than {s}`window` time has passed since the last addition event.
   *
-  * {s}`firstActivityAfter(time: Long): HistoricEvent`
+  * {s}`firstActivityAfter(time: Long): Option[HistoricEvent]`
   *  : Return next event (addition or deletion) after timestamp {s}`time` as an
-  *    [{s}`HistoricEvent`](com.raphtory.graph.visitor.HistoricEvent)
+  *    [{s}`HistoricEvent`](com.raphtory.graph.visitor.HistoricEvent). This is wrapped in an option as
+  *    it is possible that no activity occurred after the given time.
   *
-  * {s}`lastActivityBefore(time: Long): HistoricEvent`
-  *  : Return the last event (addition or deltion) before timestamp {s}`time` as an
-  *    [{s}`HistoricEvent`](com.raphtory.graph.visitor.HistoricEvent)
+  * {s}`lastActivityBefore(time: Long): Option[HistoricEvent]`
+  *  : Return the last event (addition or deletion) before timestamp {s}`time` as an
+  *    [{s}`HistoricEvent`](com.raphtory.graph.visitor.HistoricEvent). This is wrapped in an option as
+  *    it is possible that no activity occurred before the given time.
   *
   * {s}`latestActivity(): HistoricEvent`
   *  : Return the most recent event (addition or deletion) in the current view as an

--- a/core/src/main/scala/com/raphtory/graph/visitor/EntityVisitor.scala
+++ b/core/src/main/scala/com/raphtory/graph/visitor/EntityVisitor.scala
@@ -218,8 +218,8 @@ abstract class EntityVisitor {
 
   def Type(): String
 
-  def firstActivityAfter(time: Long): Option[HistoricEvent]
-  def lastActivityBefore(time: Long): Option[HistoricEvent]
+  def firstActivityAfter(time: Long, strict: Boolean = true): Option[HistoricEvent]
+  def lastActivityBefore(time: Long, strict: Boolean = true): Option[HistoricEvent]
   def latestActivity(): HistoricEvent
   def earliestActivity(): HistoricEvent
 

--- a/core/src/main/scala/com/raphtory/graph/visitor/EntityVisitor.scala
+++ b/core/src/main/scala/com/raphtory/graph/visitor/EntityVisitor.scala
@@ -45,12 +45,14 @@ import io.sqooba.oss.timeseries.immutable.TSEntry
   * {s}`firstActivityAfter(time: Long): Option[HistoricEvent]`
   *  : Return next event (addition or deletion) after timestamp {s}`time` as an
   *    [{s}`HistoricEvent`](com.raphtory.graph.visitor.HistoricEvent). This is wrapped in an option as
-  *    it is possible that no activity occurred after the given time.
+  *    it is possible that no activity occurred after the given time. An optional {s}`strict` Boolean argument is also
+  *     available which allows events exactly at the given time to be returned if set to `false`.
   *
   * {s}`lastActivityBefore(time: Long): Option[HistoricEvent]`
   *  : Return the last event (addition or deletion) before timestamp {s}`time` as an
-  *    [{s}`HistoricEvent`](com.raphtory.graph.visitor.HistoricEvent). This is wrapped in an option as
-  *    it is possible that no activity occurred before the given time.
+  *    [{s}`HistoricEvent`](com.raphtory.graph.visitor.HistoricEvent).  The result is wrapped in an option as it is
+  *     possible that no activity occurred before the given time. An optional {s}`strict` Boolean argument is also
+  *     available which allows events exactly at the given time to be returned if set to `false`.
   *
   * {s}`latestActivity(): HistoricEvent`
   *  : Return the most recent event (addition or deletion) in the current view as an

--- a/core/src/main/scala/com/raphtory/graph/visitor/ExplodedEntityVisitor.scala
+++ b/core/src/main/scala/com/raphtory/graph/visitor/ExplodedEntityVisitor.scala
@@ -12,8 +12,8 @@ import com.raphtory.graph.visitor.PropertyMergeStrategy.PropertyMerge
 trait ExplodedEntityVisitor extends EntityVisitor {
   def timestamp: Long
 
-  def firstActivityAfter(time: Long = timestamp): HistoricEvent
-  def lastActivityBefore(time: Long = timestamp): HistoricEvent
+  def firstActivityAfter(time: Long = timestamp): Option[HistoricEvent]
+  def lastActivityBefore(time: Long = timestamp): Option[HistoricEvent]
 
   override def getPropertyValues[T](
       key: String,

--- a/core/src/main/scala/com/raphtory/graph/visitor/ExplodedEntityVisitor.scala
+++ b/core/src/main/scala/com/raphtory/graph/visitor/ExplodedEntityVisitor.scala
@@ -12,8 +12,8 @@ import com.raphtory.graph.visitor.PropertyMergeStrategy.PropertyMerge
 trait ExplodedEntityVisitor extends EntityVisitor {
   def timestamp: Long
 
-  def firstActivityAfter(time: Long = timestamp): Option[HistoricEvent]
-  def lastActivityBefore(time: Long = timestamp): Option[HistoricEvent]
+  def firstActivityAfter(time: Long = timestamp, strict: Boolean = true): Option[HistoricEvent]
+  def lastActivityBefore(time: Long = timestamp, strict: Boolean = true): Option[HistoricEvent]
 
   override def getPropertyValues[T](
       key: String,

--- a/core/src/main/scala/com/raphtory/graph/visitor/InterlayerEdge.scala
+++ b/core/src/main/scala/com/raphtory/graph/visitor/InterlayerEdge.scala
@@ -25,9 +25,9 @@ case class InterlayerEdge(
       case None        => ""
     }
 
-  override def firstActivityAfter(time: Long): HistoricEvent = ???
+  override def firstActivityAfter(time: Long): Option[HistoricEvent] = ???
 
-  override def lastActivityBefore(time: Long): HistoricEvent = ???
+  override def lastActivityBefore(time: Long): Option[HistoricEvent] = ???
 
   override def getPropertySet(): List[String] = properties.keys.toList
 

--- a/core/src/main/scala/com/raphtory/graph/visitor/InterlayerEdge.scala
+++ b/core/src/main/scala/com/raphtory/graph/visitor/InterlayerEdge.scala
@@ -25,9 +25,9 @@ case class InterlayerEdge(
       case None        => ""
     }
 
-  override def firstActivityAfter(time: Long, strict: Boolean): Option[HistoricEvent] = ???
+  override def firstActivityAfter(time: Long, strict: Boolean): Option[HistoricEvent] = None
 
-  override def lastActivityBefore(time: Long, strict: Boolean): Option[HistoricEvent] = ???
+  override def lastActivityBefore(time: Long, strict: Boolean): Option[HistoricEvent] = None
 
   override def getPropertySet(): List[String] = properties.keys.toList
 

--- a/core/src/main/scala/com/raphtory/graph/visitor/InterlayerEdge.scala
+++ b/core/src/main/scala/com/raphtory/graph/visitor/InterlayerEdge.scala
@@ -25,9 +25,9 @@ case class InterlayerEdge(
       case None        => ""
     }
 
-  override def firstActivityAfter(time: Long): Option[HistoricEvent] = ???
+  override def firstActivityAfter(time: Long, strict: Boolean): Option[HistoricEvent] = ???
 
-  override def lastActivityBefore(time: Long): Option[HistoricEvent] = ???
+  override def lastActivityBefore(time: Long, strict: Boolean): Option[HistoricEvent] = ???
 
   override def getPropertySet(): List[String] = properties.keys.toList
 

--- a/core/src/main/scala/com/raphtory/storage/pojograph/entities/external/PojoExEntity.scala
+++ b/core/src/main/scala/com/raphtory/storage/pojograph/entities/external/PojoExEntity.scala
@@ -11,11 +11,19 @@ import scala.reflect.ClassTag
 abstract class PojoExEntity(entity: PojoEntity, view: PojoGraphLens) extends EntityVisitor {
   def Type(): String = entity.getType
 
-  def firstActivityAfter(time: Long): HistoricEvent =
-    history().filter(k => k.time >= time).minBy(x => x.time)
+  def firstActivityAfter(time: Long): Option[HistoricEvent] = {
+    val activitiesAfter = history().filter(k => k.time >= time)
+    if (activitiesAfter.nonEmpty)
+      Some(activitiesAfter.minBy(x => x.time))
+    else None
+  }
 
-  def lastActivityBefore(time: Long): HistoricEvent =
-    history().filter(k => k.time <= time).maxBy(x => x.time)
+  def lastActivityBefore(time: Long): Option[HistoricEvent] = {
+    val activitiesBefore = history().filter(k => k.time <= time)
+    if (activitiesBefore.nonEmpty)
+      Some(activitiesBefore.maxBy(x => x.time))
+    else None
+  }
 
   def latestActivity(): HistoricEvent = history().head
 

--- a/core/src/main/scala/com/raphtory/storage/pojograph/entities/external/PojoExMultilayerEdge.scala
+++ b/core/src/main/scala/com/raphtory/storage/pojograph/entities/external/PojoExMultilayerEdge.scala
@@ -24,10 +24,11 @@ class PojoExMultilayerEdge(
 
   override def Type(): String = edge.Type()
 
-  override def firstActivityAfter(time: Long): Option[HistoricEvent] = edge.firstActivityAfter(time)
+  override def firstActivityAfter(time: Long, strict: Boolean): Option[HistoricEvent] =
+    edge.firstActivityAfter(time, strict)
 
-  override def lastActivityBefore(time: Long): Option[HistoricEvent] =
-    edge.lastActivityBefore(time)
+  override def lastActivityBefore(time: Long, strict: Boolean): Option[HistoricEvent] =
+    edge.lastActivityBefore(time, strict)
 
   override def latestActivity(): HistoricEvent = edge.latestActivity()
 

--- a/core/src/main/scala/com/raphtory/storage/pojograph/entities/external/PojoExMultilayerEdge.scala
+++ b/core/src/main/scala/com/raphtory/storage/pojograph/entities/external/PojoExMultilayerEdge.scala
@@ -24,9 +24,10 @@ class PojoExMultilayerEdge(
 
   override def Type(): String = edge.Type()
 
-  override def firstActivityAfter(time: Long): HistoricEvent = edge.firstActivityAfter(time)
+  override def firstActivityAfter(time: Long): Option[HistoricEvent] = edge.firstActivityAfter(time)
 
-  override def lastActivityBefore(time: Long): HistoricEvent = edge.lastActivityBefore(time)
+  override def lastActivityBefore(time: Long): Option[HistoricEvent] =
+    edge.lastActivityBefore(time)
 
   override def latestActivity(): HistoricEvent = edge.latestActivity()
 

--- a/core/src/main/scala/com/raphtory/storage/pojograph/entities/external/PojoExplodedVertex.scala
+++ b/core/src/main/scala/com/raphtory/storage/pojograph/entities/external/PojoExplodedVertex.scala
@@ -28,11 +28,11 @@ class PojoExplodedVertex(
 
   override def Type(): String = vertex.Type()
 
-  override def firstActivityAfter(time: Long = timestamp): Option[HistoricEvent] =
-    vertex.firstActivityAfter(time)
+  override def firstActivityAfter(time: Long = timestamp, strict: Boolean): Option[HistoricEvent] =
+    vertex.firstActivityAfter(time, strict)
 
-  override def lastActivityBefore(time: Long = timestamp): Option[HistoricEvent] =
-    vertex.lastActivityBefore(time)
+  override def lastActivityBefore(time: Long = timestamp, strict: Boolean): Option[HistoricEvent] =
+    vertex.lastActivityBefore(time, strict)
 
   override def getPropertySet(): List[String] = vertex.getPropertySet()
 

--- a/core/src/main/scala/com/raphtory/storage/pojograph/entities/external/PojoExplodedVertex.scala
+++ b/core/src/main/scala/com/raphtory/storage/pojograph/entities/external/PojoExplodedVertex.scala
@@ -28,10 +28,10 @@ class PojoExplodedVertex(
 
   override def Type(): String = vertex.Type()
 
-  override def firstActivityAfter(time: Long = timestamp): HistoricEvent =
+  override def firstActivityAfter(time: Long = timestamp): Option[HistoricEvent] =
     vertex.firstActivityAfter(time)
 
-  override def lastActivityBefore(time: Long = timestamp): HistoricEvent =
+  override def lastActivityBefore(time: Long = timestamp): Option[HistoricEvent] =
     vertex.lastActivityBefore(time)
 
   override def getPropertySet(): List[String] = vertex.getPropertySet()

--- a/core/src/main/scala/com/raphtory/storage/pojograph/entities/internal/PojoEntity.scala
+++ b/core/src/main/scala/com/raphtory/storage/pojograph/entities/internal/PojoEntity.scala
@@ -40,7 +40,6 @@ abstract class PojoEntity(val creationTime: Long, isInitialValue: Boolean) {
 
   // History of that entity
   def removeList: List[Long] = deletions.toList
-  //.filter(f => if(!f._2) f._1).toList
 
   def setType(newType: Option[String]): Unit =
     newType match {
@@ -51,21 +50,15 @@ abstract class PojoEntity(val creationTime: Long, isInitialValue: Boolean) {
   def getType: String = entityType
 
   def revive(msgTime: Long): Unit = {
-    checkOldestTime(msgTime)
     history sortedAppend ((msgTime, true))
     toClean = true
   }
 
   def kill(msgTime: Long): Unit = {
-    checkOldestTime(msgTime)
     history sortedAppend ((msgTime, false))
     deletions sortedAppend msgTime
     toClean = true
   }
-
-  def checkOldestTime(msgTime: Long) =
-    if (oldestPoint > msgTime) //check if the current point in history is the oldest
-      oldestPoint = msgTime
 
   // override the apply method so that we can do edge/vertex("key") to easily retrieve properties
   def apply(property: String): Property = properties(property)

--- a/core/src/main/scala/com/raphtory/storage/pojograph/entities/internal/PojoEntity.scala
+++ b/core/src/main/scala/com/raphtory/storage/pojograph/entities/internal/PojoEntity.scala
@@ -35,7 +35,8 @@ abstract class PojoEntity(val creationTime: Long, isInitialValue: Boolean) {
       toClean = false
     }
 
-  var oldestPoint: Long = creationTime
+  def oldestPoint(): Long = history(0)._1
+  def latestPoint(): Long = history(history.length - 1)._1
 
   // History of that entity
   def removeList: List[Long] = deletions.toList

--- a/core/src/test/scala/com/raphtory/lotrtest/LotrTest.scala
+++ b/core/src/test/scala/com/raphtory/lotrtest/LotrTest.scala
@@ -19,15 +19,16 @@ import com.raphtory.algorithms.generic.dynamic.WattsCascade
 import com.raphtory.algorithms.generic.dynamic.WeightedRandomWalk
 import com.raphtory.algorithms.generic.motif.SquareCount
 import com.raphtory.algorithms.generic.motif.TriangleCount
+import com.raphtory.algorithms.temporal.Ancestors
+import com.raphtory.algorithms.temporal.Descendants
 import com.raphtory.algorithms.temporal.dynamic.GenericTaint
 import com.raphtory.components.spout.Spout
 import com.raphtory.components.graphbuilder.GraphBuilder
 import com.raphtory.deployment.Raphtory
 import com.raphtory.output.FileOutputFormat
-
 import com.raphtory.spouts.FileSpout
-import java.io.File
 
+import java.io.File
 import scala.language.postfixOps
 import sys.process._
 
@@ -258,6 +259,32 @@ class LotrTest extends BaseRaphtoryAlgoTest[String] {
     )
 
     assert(true)
+  }
+
+  test("Ancestors Test") {
+    val result   = algorithmTest(
+            algorithm = Ancestors("Gandalf", 32674),
+            outputFormat = outputFormat,
+            start = 1,
+            end = 32674,
+            increment = 10000,
+            windows = List(500, 1000, 10000)
+    )
+    val expected = "5f7055f9493d2b328f8e4e13239e683276f48ab3e44d7f3a13a61347405b35a7"
+    result shouldEqual expected
+  }
+
+  test("Descendants Test") {
+    val result   = algorithmTest(
+            algorithm = Descendants("Gandalf", 1000),
+            outputFormat = outputFormat,
+            start = 1,
+            end = 32674,
+            increment = 10000,
+            windows = List(500, 1000, 10000)
+    )
+    val expected = "3d31b8b47bd25d919993680eed78c51fb991cb062f863025d2e795ecac999873"
+    result shouldEqual expected
   }
 
   // TODO Re-enable with Seed to produce same result

--- a/core/src/test/scala/com/raphtory/lotrtest/LotrTest.scala
+++ b/core/src/test/scala/com/raphtory/lotrtest/LotrTest.scala
@@ -263,7 +263,7 @@ class LotrTest extends BaseRaphtoryAlgoTest[String] {
 
   test("Ancestors Test") {
     val result   = algorithmTest(
-            algorithm = Ancestors("Gandalf", 32674),
+            algorithm = Ancestors("Gandalf", 32674, strict = false),
             outputFormat = outputFormat,
             start = 1,
             end = 32674,
@@ -276,7 +276,7 @@ class LotrTest extends BaseRaphtoryAlgoTest[String] {
 
   test("Descendants Test") {
     val result   = algorithmTest(
-            algorithm = Descendants("Gandalf", 1000),
+            algorithm = Descendants("Gandalf", 1000, strict = false),
             outputFormat = outputFormat,
             start = 1,
             end = 32674,


### PR DESCRIPTION
Problem:
Depending on the time, no further activity may exist for a Vertex/Edge. This is currently not handled correctly and will result in exceptions if called with values of time outside of the range.

Solution:
I have changed the `firstActivityAfter` and `lastActivityBefore` functions inside of the Entity to return an Option[HistoricEvent] instead of just HistoricEvent. I have updated the algorithms which use these accordingly.