### PR TITLE
Fix/log4j cleanup inline with 0.5.0 package structure

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -140,20 +140,22 @@ lazy val dependencies = new {
 
   val pulsarAdmin =
     "org.apache.pulsar" % "pulsar-client-admin-original" % pulsarVersion excludeAll excludePulsarBinding
-  val pulsarApi        = "org.apache.pulsar"            % "pulsar-client-api"              % pulsarVersion
-  val pulsarCommon     = "org.apache.pulsar"            % "pulsar-common"                  % pulsarVersion
-  val pulsarCrypto     = "org.apache.pulsar"            % "pulsar-client-messagecrypto-bc" % pulsarVersion
-  val pulsarOriginal   = "org.apache.pulsar"            % "pulsar-client-original"         % pulsarVersion
-  val scalaLogging     = "com.typesafe.scala-logging"  %% "scala-logging"                  % scalaLoggingVersion
-  val scalaTest        = "org.scalatest"               %% "scalatest"                      % scalatestVersion % Test
-  val scalaTestCompile = "org.scalatest"               %% "scalatest"                      % scalatestVersion
-  val slf4j            = "org.slf4j"                    % "slf4j-api"                      % slf4jVersion
-  val sprayJson        = "io.spray"                    %% "spray-json"                     % sprayJsonVersion
-  val timeSeries       = "io.sqooba.oss"               %% "scala-timeseries-lib"           % timeSeriesVersion
-  val twitterChill     = "com.twitter"                 %% "chill"                          % chillVersion
-  val twittered        = "io.github.redouane59.twitter" % "twittered"                      % twitteredVersion
-  val typesafeConfig   = "com.typesafe"                 % "config"                         % typesafeConfigVersion
-  val zookeeper        = "org.apache.zookeeper"         % "zookeeper"                      % zookeeperVersion
+  val pulsarApi        = "org.apache.pulsar"           % "pulsar-client-api"              % pulsarVersion
+  val pulsarCommon     = "org.apache.pulsar"           % "pulsar-common"                  % pulsarVersion
+  val pulsarCrypto     = "org.apache.pulsar"           % "pulsar-client-messagecrypto-bc" % pulsarVersion
+  val pulsarOriginal   = "org.apache.pulsar"           % "pulsar-client-original"         % pulsarVersion
+  val scalaLogging     = "com.typesafe.scala-logging" %% "scala-logging"                  % scalaLoggingVersion
+  val scalaTest        = "org.scalatest"              %% "scalatest"                      % scalatestVersion % Test
+  val scalaTestCompile = "org.scalatest"              %% "scalatest"                      % scalatestVersion
+  val slf4j            = "org.slf4j"                   % "slf4j-api"                      % slf4jVersion
+  val sprayJson        = "io.spray"                   %% "spray-json"                     % sprayJsonVersion
+
+  val timeSeries       =
+    "io.sqooba.oss" %% "scala-timeseries-lib" % timeSeriesVersion excludeAll (excludeLog4j, excludeSlf4j)
+  val twitterChill   = "com.twitter"                 %% "chill"     % chillVersion
+  val twittered      = "io.github.redouane59.twitter" % "twittered" % twitteredVersion
+  val typesafeConfig = "com.typesafe"                 % "config"    % typesafeConfigVersion
+  val zookeeper      = "org.apache.zookeeper"         % "zookeeper" % zookeeperVersion
 }
 
 // ASSEMBLY SETTINGS

--- a/core/src/main/resources/log4j2.xml
+++ b/core/src/main/resources/log4j2.xml
@@ -6,10 +6,8 @@
         </Console>
     </Appenders>
     <Loggers>
+        <!-- LOGGERS FOR UNDERLYING PACKAGES -->
         <Logger name="org.hibernate.SQL" level="${env:SQL_LOG:-INFO}">
-            <AppenderRef ref="Console"/>
-        </Logger>
-        <Logger name="org.hibernate.type.descriptor.sql" level="${env:SQL_LOG:-INFO}">
             <AppenderRef ref="Console"/>
         </Logger>
         <Logger name="org.hibernate.type.descriptor.sql" level="${env:SQL_LOG:-INFO}">
@@ -21,28 +19,52 @@
         </Logger>
         <Logger name="org.apache" level="${env:APACHE_LOG:-off}">
         </Logger>
-        <Logger name="com.raphtory.deployment" level="${env:DEPLOY_LOG:-INFO}">
+
+        <!-- LOGGER FOR RAPHTORY CORE -->
+        <Logger name="com.raphtory" level="${env:RAPHTORY_CORE_LOG:-INFO}">
         </Logger>
+
+        <!-- LOGGERS FOR RAPHTORY PACKAGES -->
+        <Logger name="com.raphtory.algorithms" level="${env:RAPHTORY_ALGORITHMS_LOG:-INFO}">
+        </Logger>
+        <Logger name="com.raphtory.client" level="${env:RAPHTORY_CLIENT_LOG:-INFO}">
+        </Logger>
+        <Logger name="com.raphtory.config" level="${env:RAPHTORY_CONFIG_LOG:-INFO}">
+        </Logger>
+        <Logger name="com.raphtory.deployment" level="${env:RAPHTORY_DEPLOYMENT_LOG:-INFO}">
+        </Logger>
+        <Logger name="com.raphtory.graph" level="${env:RAPHTORY_GRAPH_LOG:-INFO}">
+        </Logger>
+        <Logger name="com.raphtory.output" level="${env:RAPHTORY_OUTPUT_LOG:-INFO}">
+        </Logger>
+        <Logger name="com.raphtory.serialisers" level="${env:RAPHTORY_SERIALISERS_LOG:-INFO}">
+        </Logger>
+        <Logger name="com.raphtory.spouts" level="${env:RAPHTORY_SPOUTS_LOG:-INFO}">
+        </Logger>
+        <Logger name="com.raphtory.storage" level="${env:RAPHTORY_STORAGE_LOG:-INFO}">
+        </Logger>
+        <Logger name="com.raphtory.time" level="${env:RAPHTORY_TIME_LOG:-INFO}">
+        </Logger>
+        <Logger name="com.raphtory.util" level="${env:RAPHTORY_UTIL_LOG:-INFO}">
+        </Logger>
+
+        <!-- LOGGERS FOR RAPHTORY COMPONENTS -->
+        <Logger name="com.raphtory.components" level="${env:RAPHTORY_COMPONENTS_LOG:-INFO}">
+        </Logger>
+        <Logger name="com.raphtory.components.graphbuilder" level="${env:RAPHTORY_COMPONENTS_GRAPHBUILDER_LOG:-INFO}">
+        </Logger>
+        <Logger name="com.raphtory.components.partition" level="${env:RAPHTORY_COMPONENTS_PARTITION_LOG:-INFO}">
+        </Logger>
+        <Logger name="com.raphtory.components.querymanager" level="${env:RAPHTORY_COMPONENTS_QUERYMANAGER_LOG:-INFO}">
+        </Logger>
+        <Logger name="com.raphtory.components.querytracker" level="${env:RAPHTORY_COMPONENTS_QUERYTRACKER_LOG:-INFO}">
+        </Logger>
+        <Logger name="com.raphtory.components.spout" level="${env:RAPHTORY_COMPONENTS_SPOUT_LOG:-INFO}">
+        </Logger>
+
+        <!-- LOGGER FOR RAPHTORY DEVELOPMENT WHEN IT IS IN USE -->
         <Logger name="com.raphtory.develop" level="${env:DEVELOP_LOG:-INFO}">
         </Logger>
-        <Logger name="com.raphtory.core" level="${env:CORE_LOG:-INFO}">
-        </Logger>
-        <Logger name="com.raphtory.components.querymanager" level="INFO">
-        </Logger>
-        <Logger name="com.raphtory.components.partition.QueryExecutor" level="INFO">
-        </Logger>
-        <Logger name="com.raphtory.components.querytracker.QueryProgressTracker" level="INFO">
-        </Logger>
-        <Logger name="com.raphtory.components.querymanager.QueryManager" level="INFO">
-        </Logger>
-
-        <Logger name="com.raphtory.components.partition" level="INFO">
-        </Logger>
-        <Logger name="com.raphtory.components.graphbuilder" level="INFO">
-        </Logger>
-        <Logger name="com.raphtory.components.spout" level="INFO">
-        </Logger>
-
 
         <Root level="info">
             <AppenderRef ref="Console"/>

--- a/core/src/main/resources/log4j2.xml
+++ b/core/src/main/resources/log4j2.xml
@@ -7,17 +7,14 @@
     </Appenders>
     <Loggers>
         <!-- LOGGERS FOR UNDERLYING PACKAGES -->
-        <Logger name="org.hibernate.SQL" level="${env:SQL_LOG:-INFO}">
+        <Logger name="org.hibernate" level="${env:RAPHTORY_SQL_LOG:-off}">
             <AppenderRef ref="Console"/>
         </Logger>
-        <Logger name="org.hibernate.type.descriptor.sql" level="${env:SQL_LOG:-INFO}">
-            <AppenderRef ref="Console"/>
+        <Logger name="com.scurrilous.circe.checksum.Crc32cIntChecksum" level="${env:RAPHTORY_CHECKSUM_LOG:-off}">
         </Logger>
-        <Logger name="com.scurrilous.circe.checksum.Crc32cIntChecksum" level="${env:CHECKSUM_LOG:-off}">
+        <Logger name="io.netty" level="${env:RAPHTORY_NETTY_LOG:-off}">
         </Logger>
-        <Logger name="io.netty" level="${env:NETTY_LOG:-off}">
-        </Logger>
-        <Logger name="org.apache" level="${env:APACHE_LOG:-off}">
+        <Logger name="org.apache" level="${env:RAPHTORY_APACHE_LOG:-off}">
         </Logger>
 
         <!-- LOGGER FOR RAPHTORY CORE -->

--- a/core/src/test/scala/com/raphtory/algorithms/TimeSeriesTest.scala
+++ b/core/src/test/scala/com/raphtory/algorithms/TimeSeriesTest.scala
@@ -1,5 +1,6 @@
 package com.raphtory.algorithms
 
+import com.raphtory.BaseCorrectnessTest
 import com.raphtory.TimeSeriesGraphState
 
 class TimeSeriesTest extends BaseCorrectnessTest {


### PR DESCRIPTION
- I have tidied up the log4j file to fit the new 0.5.0 project structure. 
- I have added env vars to a variety of useful packages including core, develop, all components and all core packages.
- I have fixed a bug where the new time series library was blocking the logger from outputting anything.
- I have fixed a compile issue from where I merged in #354 . 