### PR TITLE
Removed the BatchableSpout trait as no longer needed

### DIFF
--- a/core/src/main/scala/com/raphtory/components/spout/BatchableSpout.scala
+++ b/core/src/main/scala/com/raphtory/components/spout/BatchableSpout.scala
@@ -1,6 +1,0 @@
-package com.raphtory.components.spout
-
-trait BatchableSpout[T] extends Spout[T] {
-  def hasNextIterator(): Boolean
-  def nextIterator(): Iterator[T]
-}

--- a/core/src/main/scala/com/raphtory/spouts/FileSpout.scala
+++ b/core/src/main/scala/com/raphtory/spouts/FileSpout.scala
@@ -1,6 +1,5 @@
 package com.raphtory.spouts
 
-import com.raphtory.components.spout.BatchableSpout
 import com.raphtory.components.spout.Spout
 import com.raphtory.deployment.Raphtory
 import com.typesafe.config.Config
@@ -55,7 +54,7 @@ class FileSpout[T: TypeTag](val path: String = "", val lineConverter: (String =>
     case None       => Iterator[String]()
   }
 
-  override def hasNext: Boolean = {
+  override def hasNext: Boolean =
     if (lines.hasNext)
       true
     else {
@@ -77,7 +76,6 @@ class FileSpout[T: TypeTag](val path: String = "", val lineConverter: (String =>
       else
         false
     }
-  }
 
   override def next(): T =
     try lineConverter(lines.next())

--- a/core/src/main/scala/com/raphtory/spouts/ResourceSpout.scala
+++ b/core/src/main/scala/com/raphtory/spouts/ResourceSpout.scala
@@ -1,10 +1,10 @@
 package com.raphtory.spouts
 
-import com.raphtory.components.spout.BatchableSpout
+import com.raphtory.components.spout.Spout
 
 import scala.io.Source
 
-case class ResourceSpout(resource: String) extends BatchableSpout[String] {
+case class ResourceSpout(resource: String) extends Spout[String] {
 
   val source = Source.fromResource(resource)
   val lines  = source.getLines()

--- a/core/src/main/scala/com/raphtory/spouts/StaticGraphSpout.scala
+++ b/core/src/main/scala/com/raphtory/spouts/StaticGraphSpout.scala
@@ -1,12 +1,12 @@
 package com.raphtory.spouts
 
-import com.raphtory.components.spout.BatchableSpout
+import com.raphtory.components.spout.Spout
 import com.typesafe.scalalogging.Logger
 import org.slf4j.LoggerFactory
 
 import scala.io.Source
 
-case class StaticGraphSpout(fileDataPath: String) extends BatchableSpout[String] {
+case class StaticGraphSpout(fileDataPath: String) extends Spout[String] {
   val logger: Logger = Logger(LoggerFactory.getLogger(this.getClass))
 
   val source = Source.fromFile(fileDataPath)


### PR DESCRIPTION
We previously created the BatchableSpout as a way of notifying the user that only certain spouts could be put into the batched graph. This is however not the case as all spouts now work with both interfaces.