### PR TITLE
Make vertex id class tag available with import

### DIFF
--- a/core/src/main/scala/com/raphtory/algorithms/generic/AdjPlus.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/generic/AdjPlus.scala
@@ -6,7 +6,6 @@ import com.raphtory.algorithms.api.Row
 import com.raphtory.algorithms.api.Table
 
 import scala.math.Ordering.Implicits._
-import scala.reflect.ClassTag
 
 /**
   * {s}`AdjPlus()`
@@ -40,11 +39,10 @@ class AdjPlus extends GraphAlgorithm {
 
   override def apply(graph: GraphPerspective): GraphPerspective =
     graph.step(vertex => vertex.messageAllNeighbours((vertex.ID(), vertex.degree))).step { vertex =>
-      implicit val tag = ClassTag[vertex.IDType](vertex.ID().getClass)
-      import vertex.IDOrdering
-      val degree       = vertex.degree
+      import vertex._ // make ClassTag and Ordering for IDType available
+      val degree = vertex.degree
       //        Find set of neighbours with higher degree
-      val adj          = vertex
+      val adj    = vertex
         .messageQueue[(vertex.IDType, Int)]
         .filter(message =>
           degree < message._2 || (message._2 == degree && vertex.ID() < message._1)

--- a/core/src/main/scala/com/raphtory/algorithms/generic/dynamic/Node2VecWalk.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/generic/dynamic/Node2VecWalk.scala
@@ -71,10 +71,9 @@ class Node2VecWalk(walkLength: Int = 10, p: Double = 1.0, q: Double = 1.0) exten
   override def apply(graph: GraphPerspective): GraphPerspective =
     graph
       .step { vertex =>
-        implicit val tag: ClassTag[vertex.IDType] =
-          ClassTag[vertex.IDType](vertex.ID().getClass)
+        import vertex._
         vertex.setState("walk", ArrayBuffer[String](vertex.name()))
-        val neighbours                            = vertex.getOutNeighbours().toArray
+        val neighbours = vertex.getOutNeighbours().toArray
         if (neighbours.isEmpty)
           vertex.messageSelf(WalkMessage(vertex.ID(), vertex.ID(), neighbours))
         else
@@ -85,8 +84,7 @@ class Node2VecWalk(walkLength: Int = 10, p: Double = 1.0, q: Double = 1.0) exten
       }
       .iterate(
               { vertex =>
-                implicit val tag: ClassTag[vertex.IDType] =
-                  ClassTag[vertex.IDType](vertex.ID().getClass)
+                import vertex._
                 vertex.messageQueue[Messages[vertex.IDType]].foreach {
                   case WalkMessage(source, last, lastNeighbours) =>
                     vertex.messageVertex(source, StoreMessage(vertex.name()))
@@ -118,6 +116,7 @@ class Node2VecWalk(walkLength: Int = 10, p: Double = 1.0, q: Double = 1.0) exten
       ) // make iterate act on all vertices
       .step { vertex =>
 //        store last step of random walk
+        import vertex._
         vertex.messageQueue[Messages[vertex.IDType]].foreach {
           case StoreMessage(node)   => vertex.getState[ArrayBuffer[String]]("walk").append(node)
           case WalkMessage(_, _, _) =>

--- a/core/src/main/scala/com/raphtory/algorithms/generic/motif/ThreeNodeMotifs.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/generic/motif/ThreeNodeMotifs.scala
@@ -7,7 +7,6 @@ import com.raphtory.algorithms.api.Table
 import com.raphtory.graph.visitor.Vertex
 
 import scala.collection.mutable.ArrayBuffer
-import scala.reflect.ClassTag
 
 /**
   *  {s}`ThreeNodeMotifs()`
@@ -120,9 +119,9 @@ class ThreeNodeMotifs() extends GraphAlgorithm {
   override def apply(graph: GraphPerspective): GraphPerspective =
     graph
       .step { vertex =>
-        val motifCounts = ArrayBuffer.fill[Long](13)(0)
-
-        val neighbours                        = vertex.getAllNeighbours().toArray(ClassTag(vertex.ID().getClass))
+        import vertex._
+        val motifCounts                       = ArrayBuffer.fill[Long](13)(0)
+        val neighbours                        = vertex.getAllNeighbours().toArray
         val getEdgeType: vertex.IDType => Int = _getEdgeType(vertex)
 
         for (i <- neighbours.indices) {

--- a/core/src/main/scala/com/raphtory/graph/visitor/Vertex.scala
+++ b/core/src/main/scala/com/raphtory/graph/visitor/Vertex.scala
@@ -30,6 +30,9 @@ import scala.reflect.ClassTag
   * {s}`IDOrdering: Ordering[IDType]`
   *   : implicit ordering object for use when comparing vertex IDs
   *
+  * {s}`IDClassTag: ClassTag[IDType]`
+  *   : implicit ClassTag object for vertex IDType
+  *
   * ## Attributes
   *
   * {s}`ID(): IDType`
@@ -369,6 +372,7 @@ trait Vertex extends EntityVisitor {
   type Edge <: visitor.ConcreteEdge[IDType]
   type ExplodedEdge = visitor.ConcreteExplodedEdge[IDType]
   implicit val IDOrdering: Ordering[IDType]
+  implicit val IDClassTag: ClassTag[IDType] = ClassTag[IDType](ID().getClass)
 
   def ID(): IDType
 

--- a/core/src/test/scala/com/raphtory/lotrtest/LotrTest.scala
+++ b/core/src/test/scala/com/raphtory/lotrtest/LotrTest.scala
@@ -33,14 +33,12 @@ import scala.language.postfixOps
 import sys.process._
 
 class LotrTest extends BaseRaphtoryAlgoTest[String] {
-  val outputFormat: FileOutputFormat = FileOutputFormat(outputDirectory)
 
   override def batchLoading(): Boolean = false
 
   test("Graph State Test") {
     val result = algorithmTest(
             algorithm = GraphState(),
-            outputFormat = outputFormat,
             start = 1,
             end = 32674,
             increment = 10000,
@@ -56,7 +54,6 @@ class LotrTest extends BaseRaphtoryAlgoTest[String] {
     val result =
       algorithmTest(
               algorithm = new GlobalState(),
-              outputFormat = outputFormat,
               start = 1,
               end = 32674,
               increment = 10000,
@@ -71,7 +68,6 @@ class LotrTest extends BaseRaphtoryAlgoTest[String] {
   test("Degree Test") {
     val result = algorithmTest(
             algorithm = Degree(),
-            outputFormat = outputFormat,
             start = 1,
             end = 32674,
             increment = 10000,
@@ -85,7 +81,7 @@ class LotrTest extends BaseRaphtoryAlgoTest[String] {
 
 //  test("Distinctiveness Test") {
 //    //    TODO: Implement actual test as output is not deterministic due to floating point errors
-//    algorithmTest(Distinctiveness(), outputFormat, 1, 32674, 10000, List(500, 1000, 10000))
+//    algorithmTest(Distinctiveness(), 1, 32674, 10000, List(500, 1000, 10000))
 //    assert(true)
 //  }
 
@@ -93,7 +89,6 @@ class LotrTest extends BaseRaphtoryAlgoTest[String] {
     val result =
       algorithmTest(
               algorithm = AverageNeighbourDegree(),
-              outputFormat = outputFormat,
               start = 1,
               end = 32674,
               increment = 10000,
@@ -107,13 +102,13 @@ class LotrTest extends BaseRaphtoryAlgoTest[String] {
 
 //  test("PageRank Test") {
 //    //    TODO: Implement actual test as output is not deterministic due to floating point errors
-//    algorithmTest(PageRank(), outputFormat, 1, 32674, 10000, List(500, 1000, 10000))
+//    algorithmTest(PageRank(), 1, 32674, 10000, List(500, 1000, 10000))
 //    assert(true)
 //  }
 
 //  test("WeightedPageRank Test") {
 //    //    TODO: Implement actual test as output is not deterministic due to floating point errors
-//    algorithmTest(WeightedPageRank(), outputFormat, 1, 32674, 10000, List(500, 1000, 10000))
+//    algorithmTest(WeightedPageRank(), 1, 32674, 10000, List(500, 1000, 10000))
 //    assert(true)
 //  }
 
@@ -121,7 +116,6 @@ class LotrTest extends BaseRaphtoryAlgoTest[String] {
     val result =
       algorithmTest(
               algorithm = WeightedDegree[Long](),
-              outputFormat = outputFormat,
               start = 1,
               end = 32674,
               increment = 10000,
@@ -135,14 +129,14 @@ class LotrTest extends BaseRaphtoryAlgoTest[String] {
 
 //  test("LPA Test") {
 //    assert(
-//      algorithmTest(LPA[Int](seed=1234), outputFormat, 32674, 32674, 10000, List(10000))
+//      algorithmTest(LPA[Int](seed=1234), 32674, 32674, 10000, List(10000))
 //      equals "cf7bf559d634a0cf02739d9116b4d2f47c25679be724a896223c0917d55d2143"
 //    )
 //  }
 //
 //  test("SLPA Test") {
 //    assert(
-//      algorithmTest(SLPA(speakerRule = SLPA.ChooseRandom(seed=1234)), outputFormat, 32674, 32674, 10000, List(10000))
+//      algorithmTest(SLPA(speakerRule = SLPA.ChooseRandom(seed=1234)), 32674, 32674, 10000, List(10000))
 //      equals "a7c72dac767dc94d64d76e2c046c1dbe95154a8da7994d2133cf9e1b09b65570"
 //    )
 //  }
@@ -151,7 +145,6 @@ class LotrTest extends BaseRaphtoryAlgoTest[String] {
     val result =
       algorithmTest(
               algorithm = ConnectedComponents(),
-              outputFormat = outputFormat,
               start = 1,
               end = 32674,
               increment = 10000,
@@ -162,17 +155,16 @@ class LotrTest extends BaseRaphtoryAlgoTest[String] {
 
     result shouldEqual expected
   }
-
+//
 //  test("Random Walk Test") {
 ////    TODO: non-deterministic even with fixed seed, maybe message order is non-deterministic?
-//      algorithmTest(RandomWalk(seed=1234), outputFormat, 1, 32674, 10000, List(500, 1000, 10000))
+//    algorithmTest(RandomWalk(seed = 1234), 1, 32674, 10000, List(500, 1000, 10000))
 //    assert(true)
 //  }
 
   test("Watts Cascade Test") {
     val result = algorithmTest(
             algorithm = WattsCascade(infectedSeed = Array("Gandalf"), threshold = 0.1),
-            outputFormat = outputFormat,
             start = 1,
             end = 32674,
             increment = 10000,
@@ -186,7 +178,7 @@ class LotrTest extends BaseRaphtoryAlgoTest[String] {
 
 //  test("DiscreteSI test") {
 //    assert(
-//      algorithmTest(DiscreteSI(Set("Gandalf"), seed=1234), outputFormat, 1, 32674, 10000, List(500, 1000, 10000))
+//      algorithmTest(DiscreteSI(Set("Gandalf"), seed=1234), 1, 32674, 10000, List(500, 1000, 10000))
 //      equals "57191e340ef3e8268d255751b14fff76292087af2365048d961d59a5c0fbbc3f"
 //    )
 //  }
@@ -194,7 +186,6 @@ class LotrTest extends BaseRaphtoryAlgoTest[String] {
   test("Chain Test") {
     val result = algorithmTest(
             algorithm = TriangleCount() -> ConnectedComponents(),
-            outputFormat = outputFormat,
             start = 1,
             end = 32674,
             increment = 10000,
@@ -209,7 +200,6 @@ class LotrTest extends BaseRaphtoryAlgoTest[String] {
   test("Square counting test") {
     val result = algorithmTest(
             algorithm = SquareCount(),
-            outputFormat = outputFormat,
             start = 1,
             end = 32674,
             increment = 10000,
@@ -224,7 +214,6 @@ class LotrTest extends BaseRaphtoryAlgoTest[String] {
   test("Temporal Triangle Count") {
     val result = algorithmTest(
             algorithm = TriangleCount(),
-            outputFormat = outputFormat,
             start = 1,
             end = 32674,
             increment = 10000,
@@ -239,7 +228,6 @@ class LotrTest extends BaseRaphtoryAlgoTest[String] {
   test("Taint Tracking") {
     val result = algorithmTest(
             algorithm = GenericTaint(1, infectedNodes = Set("Bilbo"), stopNodes = Set("Aragorn")),
-            outputFormat = outputFormat,
             start = 1,
             end = 32674,
             increment = 10000,
@@ -254,7 +242,6 @@ class LotrTest extends BaseRaphtoryAlgoTest[String] {
   test("Weighted Random Walk") {
     algorithmPointTest(
             algorithm = WeightedRandomWalk[Int](),
-            outputFormat = outputFormat,
             timestamp = 32674
     )
 
@@ -264,7 +251,6 @@ class LotrTest extends BaseRaphtoryAlgoTest[String] {
   test("Ancestors Test") {
     val result   = algorithmTest(
             algorithm = Ancestors("Gandalf", 32674, strict = false),
-            outputFormat = outputFormat,
             start = 1,
             end = 32674,
             increment = 10000,
@@ -277,7 +263,6 @@ class LotrTest extends BaseRaphtoryAlgoTest[String] {
   test("Descendants Test") {
     val result   = algorithmTest(
             algorithm = Descendants("Gandalf", 1000, strict = false),
-            outputFormat = outputFormat,
             start = 1,
             end = 32674,
             increment = 10000,
@@ -290,7 +275,7 @@ class LotrTest extends BaseRaphtoryAlgoTest[String] {
   // TODO Re-enable with Seed to produce same result
 //  test("Binary Diffusion") {
 //    assert(
-//      algorithmTest(BinaryDiffusion(seed=1, reinfect=false),outputFormat,1, 32674, 10000, List(500, 1000, 10000))
+//      algorithmTest(BinaryDiffusion(seed=1, reinfect=false), 1, 32674, 10000, List(500, 1000, 10000))
 //        equals "dc7a2a28857913f03f3f955353cfe6701abbf4703441ae6bdf92ec454efdd46b"
 //    )
 //  }


### PR DESCRIPTION
With this change, it is now possible to use `import vertex.IDClassTag` to get an implicit class tag for the generic `IDType`