### PR TITLE
update readthedocs.yml to mamba

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.9"
+    python: "mambaforge-4.10"
 
 conda:
   environment: .environment.yml


### PR DESCRIPTION
use mambaforge to force readthedocs to use conda environments  issue from https://github.com/readthedocs/readthedocs.org/issues/8595