### PR TITLE
Altered Raphtory deployment function names to clarify their purpose

### DIFF
--- a/core/src/main/scala/com/raphtory/algorithms/api/TemporalGraphConnection.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/api/TemporalGraphConnection.scala
@@ -7,7 +7,7 @@ import com.raphtory.config.MonixScheduler
 import com.typesafe.config.Config
 
 /**  `TemporalGraphConnection` is a wrapper for the `TemporalGraph` class normally used to interact with Raphtory graphs.
-  *  This is returned from the `deployedGraph` function on the Raphtory Object and has an additional `disconnect()`
+  *  This is returned from the `connect` function on the Raphtory Object and has an additional `disconnect()`
   *  function which allows the user to clean up the resources (scheduler/topic repo/connections etc.) used to connect to a deployment.
   *
   * @see

--- a/core/src/main/scala/com/raphtory/components/querytracker/QueryProgressTracker.scala
+++ b/core/src/main/scala/com/raphtory/components/querytracker/QueryProgressTracker.scala
@@ -28,7 +28,7 @@ import scala.concurrent.duration.Duration
   * import com.raphtory.GraphState
   * import com.raphtory.output.FileOutputFormat
   *
-  * val graph = Raphtory.batchLoadGraph(ResourceSpout("resource"), LOTRGraphBuilder())
+  * val graph = Raphtory.load(ResourceSpout("resource"), LOTRGraphBuilder())
   * val queryProgressTracker = graph.rangeQuery(GraphState(),FileOutputFormat("/test_dir"),1, 32674, 10000, List(500, 1000, 10000))
   * val jobId                = queryProgressTracker.getJobId()
   * queryProgressTracker.waitForJob()

--- a/core/src/test/scala/com/raphtory/BaseRaphtoryAlgoTest.scala
+++ b/core/src/test/scala/com/raphtory/BaseRaphtoryAlgoTest.scala
@@ -53,7 +53,7 @@ abstract class BaseRaphtoryAlgoTest[T: ClassTag: TypeTag](deleteResultAfterFinis
     val graphBuilder: GraphBuilder[T] = setGraphBuilder()
 
     graph = Option
-      .when(batchLoading())(Raphtory.batchLoad[T](spout, graphBuilder))
+      .when(batchLoading())(Raphtory.load[T](spout, graphBuilder))
       .fold(Raphtory.stream[T](spout, graphBuilder))(identity)
   }
 

--- a/core/src/test/scala/com/raphtory/algorithms/api/RaphtoryGraphTest.scala
+++ b/core/src/test/scala/com/raphtory/algorithms/api/RaphtoryGraphTest.scala
@@ -8,7 +8,7 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class RaphtoryGraphTest extends AnyFunSuite {
   test("Test overall pipeline syntax for RaphtoryGraph class and related hierarchy") {
-    val graph = Raphtory.deployedGraph()
+    val graph = Raphtory.connect()
     val table = graph
       .from(100)
       .until(500)
@@ -41,7 +41,7 @@ class RaphtoryGraphTest extends AnyFunSuite {
   }
 
   test("Test timestamp format without milliseconds") {
-    val graph = Raphtory.deployedGraph()
+    val graph = Raphtory.connect()
     val query = graph
       .from("2020-02-25 23:12:08")
       .query
@@ -52,7 +52,7 @@ class RaphtoryGraphTest extends AnyFunSuite {
   }
 
   test("Test timestamp format with milliseconds") {
-    val graph = Raphtory.deployedGraph()
+    val graph = Raphtory.connect()
     val query = graph
       .from("2020-02-25 23:12:08.567")
       .query
@@ -63,7 +63,7 @@ class RaphtoryGraphTest extends AnyFunSuite {
   }
 
   test("Test timestamp format with date") {
-    val graph = Raphtory.deployedGraph()
+    val graph = Raphtory.connect()
     val query = graph
       .from("2020-02-25")
       .query
@@ -75,7 +75,7 @@ class RaphtoryGraphTest extends AnyFunSuite {
 
   test("Test timestamp format with custom configuration for 2 digit milliseconds") {
     val conf  = Map("raphtory.query.timeFormat" -> "yyyy-MM-dd HH:mm:ss[.SS]")
-    val graph = Raphtory.deployedGraph(conf)
+    val graph = Raphtory.connect(conf)
     val query = graph
       .from("2020-02-25 23:12:08.56")
       .query
@@ -87,7 +87,7 @@ class RaphtoryGraphTest extends AnyFunSuite {
 
   test("Test timestamp format with custom configuration for hours and minutes") {
     val conf  = Map("raphtory.query.timeFormat" -> "yyyy-MM-dd HH:mm")
-    val graph = Raphtory.deployedGraph(conf)
+    val graph = Raphtory.connect(conf)
     val query = graph
       .from("2020-02-25 12:23")
       .query

--- a/core/src/test/scala/com/raphtory/lotrtest/Runner.scala
+++ b/core/src/test/scala/com/raphtory/lotrtest/Runner.scala
@@ -11,7 +11,7 @@ object Runner extends App {
 
   val spout        = FileSpout("/tmp")
   val graphBuilder = new LOTRGraphBuilder()
-  val graph        = Raphtory.batchLoad(spout, graphBuilder)
+  val graph        = Raphtory.load(spout, graphBuilder)
 
   graph.deployment.stop()
   println("should finish here but these threads are still alive")

--- a/docs/source/Analysis/queries.md
+++ b/docs/source/Analysis/queries.md
@@ -3,7 +3,7 @@
 To run your implemented algorithm or any of the algorithms included in Raphtory (both [Generic](com.raphtory.algorithms.generic) and [Temporal](com.raphtory.algorithms.temporal)), you must submit them to the graph. We can again use the [Lord of the Rings
 graph](../Ingestion/sprouter.md) and the [degrees of separation algorithm](LOTR_six_degrees.md) to illustrate the query API.
 
-When running queries, our starting point is always the {scaladoc}`com.raphtory.algorithms.api.TemporalGraph` created from a call to `Raphtory.batchLoad()` or `Raphtory.stream()`. This contains the full history of your data over its lifetime. From this point, the overall process to get things done is as follows: 
+When running queries, our starting point is always the {scaladoc}`com.raphtory.algorithms.api.TemporalGraph` created from a call to `Raphtory.load()` or `Raphtory.stream()`. This contains the full history of your data over its lifetime. From this point, the overall process to get things done is as follows: 
 
 * First, you can filter the timeline to the segment you are interested in. 
 * Secondly, you can create a collection of perspectives over the selected timeline.

--- a/docs/source/Deployment/baremetalsingle.md
+++ b/docs/source/Deployment/baremetalsingle.md
@@ -1,6 +1,6 @@
 # Bare metal
 
-The difference between the two from an analysis perspective is that `batchLoad` will block any submitted queries until the data has finished ingesting - allowing it to handle completely out of order data. On the other hand when using `stream` it is assumed new data is continuously arriving (in roughly chronological order) which Raphtory handles with a watermarking heuristic to decide what time is safe to analyse across all the partitions. Therefore, queries where the perspective time   fully ingested and synchronised allowed to progress and which should be blocked until the time they are set to run at has arrived and has been synchronised.
+The difference between the two from an analysis perspective is that `load` will block any submitted queries until the data has finished ingesting - allowing it to handle completely out of order data. On the other hand when using `stream` it is assumed new data is continuously arriving (in roughly chronological order) which Raphtory handles with a watermarking heuristic to decide what time is safe to analyse across all the partitions. Therefore, queries where the perspective time   fully ingested and synchronised allowed to progress and which should be blocked until the time they are set to run at has arrived and has been synchronised.
 
 
 ## Bare metal single node
@@ -18,20 +18,13 @@ To run Raphtory locally on a macbook/laptop there are several ways this can be a
 
 ## Using Raphtory as a client
 
-Finally, if you have a graph deployed somewhere else and want to submit new queries to it you can do this via the `deployedGraph(customConfig)` method in the `Raphtory` object. The `customConfig` here is to provide the appropriate configuration to locate the graph (i.e. the akka/pulsar address). If the graph is deployed in the same machine using the default Raphtory configuration you can omit this configuration parameter:
+Finally, if you have a graph deployed somewhere else and want to submit new queries to it you can do this via the `connect(customConfig)` method in the `Raphtory` object. The `customConfig` here is to provide the appropriate configuration to locate the graph (i.e. the akka/pulsar address). If the graph is deployed in the same machine using the default Raphtory configuration you can omit this configuration parameter:
 
 ```scala
-val graph = Raphtory.deployedGraph()
+val graph = Raphtory.connect()
 ```
 
 From this point, you can keep working with your graph as we have done so far.
-
-Additionally, you still have access to the `RaphtoryClient` class provided in previous releases of Raphtory. This is, however, deprecated and will be removed in later versions:
-
-```scala
-val client = Raphtory.createClient()
-client.pointQuery(ConnectedComponents(), output, 10000)
-```
 
 ## Bare metal distributed -- Raphtory services
 

--- a/docs/source/Ingestion/sprouter.md
+++ b/docs/source/Ingestion/sprouter.md
@@ -7,7 +7,7 @@ Two classes help with this:
 - `Spouts` connect to the outside world, reading the data files and outputting individual tuples.
 - `Graph builders`, as the name suggests, convert these tuples into updates, building the graph.
 
-Once these classes are defined, they can be passed to the `stream()` or `batchLoad()` methods on the {scaladoc}`com.raphtory.deployment.Raphtory` object, which will use both components to build the {scaladoc}`com.raphtory.algorithms.TemporalGraph`. The difference here is that `stream()` will launch the full pipeline on top of [Apache Pulsar](https://pulsar.apache.org) (which you will see later in the tutorial) and assume new data can continuously arrive. `batchLoad()` on the other hand will compress the Spout and Graph Builder functions together, running as fast as possible, but only on a static dataset which does not change. For these initial examples we will only run `batchLoad()` as the data is static and we can set it going out of the box!
+Once these classes are defined, they can be passed to the `stream()` or `load()` methods on the {scaladoc}`com.raphtory.deployment.Raphtory` object, which will use both components to build the {scaladoc}`com.raphtory.algorithms.TemporalGraph`. The difference here is that `stream()` will launch the full pipeline on top of [Apache Pulsar](https://pulsar.apache.org) (which you will see later in the tutorial) and assume new data can continuously arrive. `load()` on the other hand will compress the Spout and Graph Builder functions together, running as fast as possible, but only on a static dataset which does not change. For these initial examples we will only run `load()` as the data is static and we can set it going out of the box!
 
 If you have the LOTR example already set up from the installation guide previously ([raphtory-example-lotr](https://github.com/Raphtory/Raphtory/tree/master/examples/raphtory-example-lotr)) then please continue. If not, YOU SHALL NOT PASS! Please return there and complete this step first.  
 
@@ -29,7 +29,7 @@ Gollum,Bilbo,308
 Also, in the examples folder you will find `LOTRGraphBuilder.scala`, `DegreesSeparation.scala` and `FileOutputRunner.scala` which we will go through in detail. 
 
 ## Local Deployment
-First lets open `FileOutputRunner.scala`, which is our `main` class i.e. the file which we actually run. To do this we have made our class a scala app via `extends App`. This is a short hand for creating your runnable main class (if you come from a Java background) or can be viewed as a script if you are more comfortable with Python. Inside of this we can create spout and graphbuilder objects and combine them into a {scaladoc}`com.raphtory.algorithms.TemporalGraph` (via `batchLoad()`), which can be used to make queries:
+First lets open `FileOutputRunner.scala`, which is our `main` class i.e. the file which we actually run. To do this we have made our class a scala app via `extends App`. This is a short hand for creating your runnable main class (if you come from a Java background) or can be viewed as a script if you are more comfortable with Python. Inside of this we can create spout and graphbuilder objects and combine them into a {scaladoc}`com.raphtory.algorithms.TemporalGraph` (via `load()`), which can be used to make queries:
 
 ````scala
 object FileOutputRunner extends App {
@@ -40,7 +40,7 @@ object FileOutputRunner extends App {
 
   val source  = FileSpout(path)
   val builder = new LOTRGraphBuilder()
-  val graph   = Raphtory.batchLoad(spout = source, graphBuilder = builder)
+  val graph   = Raphtory.load(spout = source, graphBuilder = builder)
   val output  = FileOutputFormat("/tmp/raphtory")
 
   val queryHandler = graph
@@ -53,7 +53,7 @@ object FileOutputRunner extends App {
 }
 ````
 
-**Note:** Once `Raphtory.batchLoad` is called, we can start submitting queries to it - which can be seen in the snippet above. Don't worry about this yet as we will dive into it in the next section.
+**Note:** Once `Raphtory.load` is called, we can start submitting queries to it - which can be seen in the snippet above. Don't worry about this yet as we will dive into it in the next section.
 
 ## Spout
 

--- a/examples/raphtory-example-ethereum/src/main/scala/com/raphtory/ethereum/LocalRunner.scala
+++ b/examples/raphtory-example-ethereum/src/main/scala/com/raphtory/ethereum/LocalRunner.scala
@@ -28,7 +28,7 @@ object LocalRunner extends App {
   // create graph
   val source  = FileSpout("/tmp/etherscan_tags.csv")
   val builder = new EthereumGraphBuilder()
-  val graph   = Raphtory.batchLoad(source, builder)
+  val graph   = Raphtory.load(source, builder)
 
   // setup ethereum vars
   val startTime = 1574814233

--- a/examples/raphtory-example-facebook/src/main/scala/com.raphtory.examples.facebook/Runner.scala
+++ b/examples/raphtory-example-facebook/src/main/scala/com.raphtory.examples.facebook/Runner.scala
@@ -33,7 +33,7 @@ object Runner extends App {
 
   val source: StaticGraphSpout = StaticGraphSpout("/tmp/facebook.csv")
   val builder                  = new FacebookGraphBuilder()
-  val graph                    = Raphtory.batchLoad(spout = source, graphBuilder = builder)
+  val graph                    = Raphtory.load(spout = source, graphBuilder = builder)
   Thread.sleep(20000)
   graph.at(88234).past().execute(EdgeList()).writeTo(PulsarOutputFormat("EdgeList"))
   graph

--- a/examples/raphtory-example-lotr/src/main/scala/com/raphtory/examples/lotrTopic/FileOutputRunner.scala
+++ b/examples/raphtory-example-lotr/src/main/scala/com/raphtory/examples/lotrTopic/FileOutputRunner.scala
@@ -25,7 +25,7 @@ object FileOutputRunner extends App {
 
   val source  = FileSpout(path)
   val builder = new LOTRGraphBuilder()
-  val graph   = Raphtory.batchLoad(spout = source, graphBuilder = builder)
+  val graph   = Raphtory.load(spout = source, graphBuilder = builder)
   val output  = FileOutputFormat("/tmp/raphtory")
 
   val queryHandler = graph

--- a/examples/raphtory-example-lotr/src/main/scala/com/raphtory/examples/lotrTopic/PulsarOutputRunner.scala
+++ b/examples/raphtory-example-lotr/src/main/scala/com/raphtory/examples/lotrTopic/PulsarOutputRunner.scala
@@ -20,7 +20,7 @@ object PulsarOutputRunner extends App {
   // Create Graph
   val source  = FileSpout(path)
   val builder = new LOTRGraphBuilder()
-  val graph   = Raphtory.batchLoad(spout = source, graphBuilder = builder)
+  val graph   = Raphtory.load(spout = source, graphBuilder = builder)
 
   // Run algorithms
   graph

--- a/python/raphtoryclient/client.py
+++ b/python/raphtoryclient/client.py
@@ -119,7 +119,7 @@ class client:
         customConfig = {"raphtory.deploy.id": self._raphtory_deployment_id, "raphtory.deploy.distributed": True}
         mc_run_map_dict = MapConverter().convert(customConfig, self.gateway._gateway_client)
         jmap = self.gateway.jvm.PythonUtil.toScalaMap(mc_run_map_dict)
-        graph = self.gateway.jvm.Raphtory.deployedGraph(jmap)
+        graph = self.gateway.jvm.Raphtory.connect(jmap)
         print("Created Raphtory java object.")
         return graph
 


### PR DESCRIPTION
After a couple of discussions we have decided to update the function names of the `Raphtory` object to clarify what they are actually doing. These changes are the following:

- `Raphtory.stream()` will remain the same as its fairly clear what this is doing.
- `Raphtory.batchLoad()` has been updated to `.load()` as the batch component was deemed confusing. This was also to make it clearer in the tutorial the we are just loading a graph off of disk.
- `Raphtory.deployedGraph()` has been updated to `.connect()` as deployedGraph didn't sound like an action -- and to match the `disconnect` function used to close the connection.

All component construction functions have also been privatised as there is no need for them to be accessible by the end user.

All documentation and examples have been updated accordingly (I hope 😄) 