### PR TITLE
Streamlining distributed service config

### DIFF
--- a/core/src/main/resources/application.conf
+++ b/core/src/main/resources/application.conf
@@ -221,14 +221,6 @@ raphtory {
     metrics {
       port = 9999
     }
-    namespaces {
-      spout         = "spout"
-      reader        = "reader"
-      writer        = "writer"
-      query         = "query"
-      storage       = "storage"
-      builder       = "graph_builder"
-    }
   }
 
   python {

--- a/core/src/main/scala/com/raphtory/config/ConfigHandler.scala
+++ b/core/src/main/scala/com/raphtory/config/ConfigHandler.scala
@@ -15,17 +15,15 @@ private[raphtory] class ConfigHandler {
   private lazy val defaults       = createConf()
   private lazy val logger: Logger = Logger(LoggerFactory.getLogger(this.getClass))
 
-  private lazy val deployedDistributed =
-    defaults.resolve().getBoolean("raphtory.deploy.distributed")
-  private val customConfigValues       = ArrayBuffer[(String, ConfigValue)]()
+  private val customConfigValues = ArrayBuffer[(String, ConfigValue)]()
 
   private var salt = Random.nextInt().abs
 
   def addCustomConfig(path: String, value: Any) =
     customConfigValues += ((path, ConfigValueFactory.fromAnyRef(value)))
 
-  def getConfig: Config =
-    if (deployedDistributed)
+  def getConfig(runningDistributed: Boolean): Config =
+    if (runningDistributed)
       distributed()
     else
       local()

--- a/core/src/main/scala/com/raphtory/config/telemetry/BuilderTelemetry.scala
+++ b/core/src/main/scala/com/raphtory/config/telemetry/BuilderTelemetry.scala
@@ -1,7 +1,5 @@
 package com.raphtory.config.telemetry
 
-import com.raphtory.deployment.Raphtory
-import com.typesafe.config.Config
 import io.prometheus.client.Counter
 
 /** Adds metrics for `GraphBuilder` using Prometheus Client
@@ -10,43 +8,42 @@ import io.prometheus.client.Counter
   * Statistics are made available on http://localhost:9999 on running tests and can be visualised using Grafana dashboards
   */
 object BuilderTelemetry {
-  private val raphtoryConfig: Config = Raphtory.getDefaultConfig()
 
-  def totalVertexAdds() =
+  def totalVertexAdds =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.builder"))
+      .namespace("graph_builder")
       .name("vertex_add")
       .help("Total vertices added by Graph Builder")
       .labelNames("raphtory_deploymentID")
       .register
 
-  def totalVertexDeletes() =
+  def totalVertexDeletes =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.builder"))
+      .namespace("graph_builder")
       .name("vertex_delete")
       .help("Total vertices deleted by Graph Builder")
       .labelNames("raphtory_deploymentID")
       .register
 
-  def totalEdgeAdds() =
+  def totalEdgeAdds =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.builder"))
+      .namespace("graph_builder")
       .name("edge_add")
       .help("Total edges added by Graph Builder")
       .labelNames("raphtory_deploymentID")
       .register
 
-  def totalEdgeDeletes() =
+  def totalEdgeDeletes =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.builder"))
+      .namespace("graph_builder")
       .name("edge_delete")
       .help("Total edges deleted by Graph Builder")
       .labelNames("raphtory_deploymentID")
       .register
 
-  def totalGraphBuilderUpdates() =
+  def totalGraphBuilderUpdates =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.builder"))
+      .namespace("graph_builder")
       .name("update")
       .help("Total Graph Builder updates")
       .labelNames("raphtory_deploymentID")

--- a/core/src/main/scala/com/raphtory/config/telemetry/ComponentTelemetryHandler.scala
+++ b/core/src/main/scala/com/raphtory/config/telemetry/ComponentTelemetryHandler.scala
@@ -9,42 +9,42 @@ private[raphtory] object ComponentTelemetryHandler {
   val fileLinesSent: Counter        = SpoutTelemetry.totalLinesSent
   val fileProcessingErrors: Counter = SpoutTelemetry.totalFileProcessingErrors
 
-  val vertexAddCounter: Counter           = BuilderTelemetry.totalVertexAdds()
-  val vertexDeleteCounter: Counter        = BuilderTelemetry.totalVertexDeletes()
-  val edgeAddCounter: Counter             = BuilderTelemetry.totalEdgeAdds()
-  val edgeDeleteCounter: Counter          = BuilderTelemetry.totalEdgeDeletes()
-  val graphBuilderUpdatesCounter: Counter = BuilderTelemetry.totalGraphBuilderUpdates()
+  val vertexAddCounter: Counter           = BuilderTelemetry.totalVertexAdds
+  val vertexDeleteCounter: Counter        = BuilderTelemetry.totalVertexDeletes
+  val edgeAddCounter: Counter             = BuilderTelemetry.totalEdgeAdds
+  val edgeDeleteCounter: Counter          = BuilderTelemetry.totalEdgeDeletes
+  val graphBuilderUpdatesCounter: Counter = BuilderTelemetry.totalGraphBuilderUpdates
 
-  val lastWatermarkProcessedCollector: Gauge       = PartitionTelemetry.lastWatermarkProcessed()
-  val queryExecutorCollector: Gauge                = PartitionTelemetry.queryExecutorCounter()
-  val batchWriterVertexAdditionsCollector: Counter = PartitionTelemetry.batchWriterVertexAdditions()
-  val batchWriterEdgeAdditionsCollector: Counter   = PartitionTelemetry.batchWriterEdgeAdditions()
-  val batchWriterEdgeDeletionsCollector: Counter   = PartitionTelemetry.batchWriterEdgeDeletions()
+  val lastWatermarkProcessedCollector: Gauge       = PartitionTelemetry.lastWatermarkProcessed
+  val queryExecutorCollector: Gauge                = PartitionTelemetry.queryExecutorCounter
+  val batchWriterVertexAdditionsCollector: Counter = PartitionTelemetry.batchWriterVertexAdditions
+  val batchWriterEdgeAdditionsCollector: Counter   = PartitionTelemetry.batchWriterEdgeAdditions
+  val batchWriterEdgeDeletionsCollector: Counter   = PartitionTelemetry.batchWriterEdgeDeletions
 
   val batchWriterRemoteEdgeAdditionsCollector: Counter =
-    PartitionTelemetry.batchWriterRemoteEdgeAdditions()
+    PartitionTelemetry.batchWriterRemoteEdgeAdditions
 
   val batchWriterRemoteEdgeDeletionsCollector: Counter =
-    PartitionTelemetry.batchWriterRemoteEdgeDeletions()
+    PartitionTelemetry.batchWriterRemoteEdgeDeletions
 
-  val vertexAddCollector: Counter                 = PartitionTelemetry.streamWriterVertexAdditions()
-  val streamWriterGraphUpdatesCollector: Counter  = PartitionTelemetry.streamWriterGraphUpdates()
-  val streamWriterEdgeAdditionsCollector: Counter = PartitionTelemetry.streamWriterEdgeAdditions()
-  val streamWriterEdgeDeletionsCollector: Counter = PartitionTelemetry.streamWriterEdgeDeletions()
+  val vertexAddCollector: Counter                 = PartitionTelemetry.streamWriterVertexAdditions
+  val streamWriterGraphUpdatesCollector: Counter  = PartitionTelemetry.streamWriterGraphUpdates
+  val streamWriterEdgeAdditionsCollector: Counter = PartitionTelemetry.streamWriterEdgeAdditions
+  val streamWriterEdgeDeletionsCollector: Counter = PartitionTelemetry.streamWriterEdgeDeletions
 
   val streamWriterVertexDeletionsCollector: Counter =
-    PartitionTelemetry.streamWriterVertexDeletions()
+    PartitionTelemetry.streamWriterVertexDeletions
 
   val totalSyncedStreamWriterUpdatesCollector: Counter =
-    PartitionTelemetry.totalSyncedStreamWriterUpdates()
+    PartitionTelemetry.totalSyncedStreamWriterUpdates
 
-  val receivedMessageCountCollector: Counter = QueryTelemetry.receivedMessageCount()
-  val totalSentMessageCount: Counter         = QueryTelemetry.sentMessageCount()
-  val totalPerspectivesProcessed: Counter    = QueryTelemetry.totalPerspectivesProcessed()
-  val totalGraphOperations: Counter          = QueryTelemetry.totalGraphOperations()
-  val totalTableOperations: Counter          = QueryTelemetry.totalTableOperations()
-  val globalWatermarkMin: Gauge              = QueryTelemetry.globalWatermarkMin()
-  val globalWatermarkMax: Gauge              = QueryTelemetry.globalWatermarkMax()
-  val totalQueriesSpawned: Counter           = QueryTelemetry.totalQueriesSpawned()
-  val graphSizeCollector: Counter            = StorageTelemetry.pojoLensGraphSize()
+  val receivedMessageCountCollector: Counter = QueryTelemetry.receivedMessageCount
+  val totalSentMessageCount: Counter         = QueryTelemetry.sentMessageCount
+  val totalPerspectivesProcessed: Counter    = QueryTelemetry.totalPerspectivesProcessed
+  val totalGraphOperations: Counter          = QueryTelemetry.totalGraphOperations
+  val totalTableOperations: Counter          = QueryTelemetry.totalTableOperations
+  val globalWatermarkMin: Gauge              = QueryTelemetry.globalWatermarkMin
+  val globalWatermarkMax: Gauge              = QueryTelemetry.globalWatermarkMax
+  val totalQueriesSpawned: Counter           = QueryTelemetry.totalQueriesSpawned
+  val graphSizeCollector: Counter            = StorageTelemetry.pojoLensGraphSize
 }

--- a/core/src/main/scala/com/raphtory/config/telemetry/PartitionTelemetry.scala
+++ b/core/src/main/scala/com/raphtory/config/telemetry/PartitionTelemetry.scala
@@ -1,8 +1,7 @@
 package com.raphtory.config.telemetry
 
-import com.raphtory.deployment.Raphtory
-import com.typesafe.config.Config
-import io.prometheus.client.{Counter, Gauge}
+import io.prometheus.client.Counter
+import io.prometheus.client.Gauge
 
 /** Adds metrics for partitions, i.e. `Reader`, `BatchWriter` and `StreamWriter` using Prometheus Client
   * Exposes Counter and Summary stats for tracking number of graph updates, watermarks created by reader, vertices and edges added and deleted by writers in Raphtory
@@ -10,117 +9,115 @@ import io.prometheus.client.{Counter, Gauge}
   */
 object PartitionTelemetry {
 
-  private val raphtoryConfig: Config = Raphtory.getDefaultConfig()
-
-  def lastWatermarkProcessed() =
+  def lastWatermarkProcessed =
     Gauge.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.reader"))
+      .namespace("writer")
       .name("last_watermark_processed")
       .help("Last watermark processed by Partition Reader")
       .labelNames("raphtory_partitionID", "raphtory_deploymentID")
       .register()
 
-  def queryExecutorCounter() =
+  def queryExecutorCounter =
     Gauge.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.reader"))
+      .namespace("writer")
       .name("query_executor_jobs_total")
       .help("Total query executors running in this partition")
       .labelNames("raphtory_partitionID", "raphtory_deploymentID")
       .register()
 
-  def batchWriterVertexAdditions() =
+  def batchWriterVertexAdditions =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.writer"))
+      .namespace("writer")
       .name("batch_vertex_adds")
       .help("Total vertex additions for Batch Writer")
       .labelNames("raphtory_partitionID")
       .register()
 
-  def batchWriterEdgeAdditions() =
+  def batchWriterEdgeAdditions =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.writer"))
+      .namespace("writer")
       .name("batch_edge_adds")
       .help("Total edge additions for Batch Writer")
       .labelNames("raphtory_partitionID")
       .register()
 
-  def batchWriterEdgeDeletions() =
+  def batchWriterEdgeDeletions =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.writer"))
+      .namespace("writer")
       .name("batch_edge_deletions")
       .help("Total edge deletions for Batch Writer")
       .labelNames("raphtory_partitionID")
       .register()
 
-  def batchWriterRemoteEdgeAdditions() =
+  def batchWriterRemoteEdgeAdditions =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.writer"))
+      .namespace("writer")
       .name("batch_remote_edge_adds")
       .help("Total remote edge additions for Batch Writer")
       .labelNames("raphtory_partitionID")
       .register()
 
-  def batchWriterRemoteEdgeDeletions() =
+  def batchWriterRemoteEdgeDeletions =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.writer"))
+      .namespace("writer")
       .name("batch_remote_edge_deletions")
       .help("Total remote edge deletions for Batch Writer")
       .labelNames("raphtory_partitionID")
       .register()
 
-  def streamWriterGraphUpdates() =
+  def streamWriterGraphUpdates =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.writer"))
+      .namespace("writer")
       .name("stream_graph_updates")
       .help("Total graph updates for Stream Writer")
       .labelNames("raphtory_partitionID", "raphtory_deploymentID")
       .register()
 
-  def totalSyncedStreamWriterUpdates() =
+  def totalSyncedStreamWriterUpdates =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.writer"))
+      .namespace("writer")
       .name("stream_synced_updates")
       .help("Total synced updates for Stream Writer")
       .labelNames("raphtory_partitionID", "raphtory_deploymentID")
       .register()
 
-  def streamWriterVertexAdditions() =
+  def streamWriterVertexAdditions =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.writer"))
+      .namespace("writer")
       .name("stream_vertex_adds")
       .help("Total vertex additions for Stream Writer")
       .labelNames("raphtory_partitionID", "raphtory_deploymentID")
       .register()
 
-  def streamWriterVertexDeletions(): Counter =
+  def streamWriterVertexDeletions: Counter =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.writer"))
+      .namespace("writer")
       .name("stream_vertex_deletes")
       .help("Total vertex deletions for Stream Writer")
       .labelNames("raphtory_partitionID", "raphtory_deploymentID")
       .register()
 
-  def streamWriterEdgeAdditions() =
+  def streamWriterEdgeAdditions =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.writer"))
+      .namespace("writer")
       .name("stream_edge_adds")
       .help("Total edge additions for Stream Writer")
       .labelNames("raphtory_partitionID", "raphtory_deploymentID")
       .register()
 
-  def streamWriterEdgeDeletions() =
+  def streamWriterEdgeDeletions =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.writer"))
+      .namespace("writer")
       .name("stream_edge_deletes")
       .help("Total edge deletions for Stream Writer")
       .labelNames("raphtory_partitionID", "raphtory_deploymentID")
       .register()
 
   //TODO: implement
-  def timeForIngestion() =
+  def timeForIngestion =
     Counter
       .build()
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.writer"))
+      .namespace("writer")
       .name("ingestion_time")
       .help("Time for ingestion of partition")
       .labelNames("raphtory_partitionID")

--- a/core/src/main/scala/com/raphtory/config/telemetry/QueryTelemetry.scala
+++ b/core/src/main/scala/com/raphtory/config/telemetry/QueryTelemetry.scala
@@ -1,8 +1,7 @@
 package com.raphtory.config.telemetry
 
-import com.raphtory.deployment.Raphtory
-import com.typesafe.config.Config
-import io.prometheus.client.{Counter, Gauge}
+import io.prometheus.client.Counter
+import io.prometheus.client.Gauge
 
 /** Adds metrics for `QueryHandler`, `QueryManager` and `QueryExecutor`  using Prometheus Client
   * Exposes Counter stats for tracking number of vertices, messages received and sent by `Query` handler, manager and executor
@@ -10,67 +9,65 @@ import io.prometheus.client.{Counter, Gauge}
   */
 object QueryTelemetry {
 
-  private val raphtoryConfig: Config = Raphtory.getDefaultConfig()
-
-  def receivedMessageCount(): Counter =
+  def receivedMessageCount: Counter =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.query"))
+      .namespace("query")
       .name("handler_received_messages")
       .help("Total received messages count in Query Handler")
       .labelNames("raphtory_jobID", "raphtory_deploymentID")
       .register
 
-  def sentMessageCount(): Counter =
+  def sentMessageCount: Counter =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.query"))
+      .namespace("query")
       .name("handler_sent_messages")
       .help("Total sent messages count in Query Handler")
       .labelNames("raphtory_jobID", "raphtory_deploymentID")
       .register
 
-  def globalWatermarkMin(): Gauge =
+  def globalWatermarkMin: Gauge =
     Gauge.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.query"))
+      .namespace("query")
       .name("manager_min_watermark_timestamp")
       .help("Minimum watermark for Query Manager")
       .labelNames("raphtory_deploymentID")
       .register
 
-  def globalWatermarkMax(): Gauge =
+  def globalWatermarkMax: Gauge =
     Gauge.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.query"))
+      .namespace("query")
       .name("manager_max_watermark_timestamp")
       .help("Maximum watermark for Query Manager")
       .labelNames("raphtory_deploymentID")
       .register
 
-  def totalGraphOperations(): Counter =
+  def totalGraphOperations: Counter =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.query"))
+      .namespace("query")
       .name("handler_graph_operations")
       .help("Total graph operations by Query Handler")
       .labelNames("raphtory_jobID", "raphtory_deploymentID")
       .register
 
-  def totalTableOperations(): Counter =
+  def totalTableOperations: Counter =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.query"))
+      .namespace("query")
       .name("handler_table_operations")
       .help("Total table operations by Query Handler")
       .labelNames("raphtory_jobID", "raphtory_deploymentID")
       .register
 
-  def totalPerspectivesProcessed(): Counter =
+  def totalPerspectivesProcessed: Counter =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.query"))
+      .namespace("query")
       .name("handler_perspectives_processed")
       .help("Total perspectives processed by Query Handler")
       .labelNames("raphtory_jobID", "raphtory_deploymentID")
       .register
 
-  def totalQueriesSpawned(): Counter =
+  def totalQueriesSpawned: Counter =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.query"))
+      .namespace("query")
       .name("manager_queries_spawned")
       .help("Total queries spawned by Query Manager")
       .labelNames("raphtory_deploymentID")

--- a/core/src/main/scala/com/raphtory/config/telemetry/SpoutTelemetry.scala
+++ b/core/src/main/scala/com/raphtory/config/telemetry/SpoutTelemetry.scala
@@ -1,8 +1,6 @@
 package com.raphtory.config.telemetry
 
 import io.prometheus.client.Counter
-import com.raphtory.deployment.Raphtory
-import com.typesafe.config.Config
 
 /** Adds metrics for `Spout` using Prometheus Client
   * Exposes Counter stats for tracking number of files processed, lines parsed, spout reschedules and processing errors
@@ -10,11 +8,9 @@ import com.typesafe.config.Config
   */
 object SpoutTelemetry {
 
-  private val raphtoryConfig: Config = Raphtory.getDefaultConfig()
-
   def totalFilesProcessed: Counter =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.spout"))
+      .namespace("spout")
       .name("file_processed_total")
       .help("Total files processed by spout")
       .labelNames("raphtory_deploymentID")
@@ -22,7 +18,7 @@ object SpoutTelemetry {
 
   def totalSpoutReschedules: Counter =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.spout"))
+      .namespace("spout")
       .name("reschedule_total")
       .help("Total spout reschedules")
       .labelNames("raphtory_deploymentID")
@@ -30,7 +26,7 @@ object SpoutTelemetry {
 
   def totalLinesSent: Counter =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.spout"))
+      .namespace("spout")
       .name("file_line_sent_total")
       .help("Total lines of file sent")
       .labelNames("raphtory_deploymentID")
@@ -38,7 +34,7 @@ object SpoutTelemetry {
 
   def totalFileProcessingErrors: Counter =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.spout"))
+      .namespace("spout")
       .name("file_processing_error_total")
       .help("Total file processing errors")
       .labelNames("raphtory_deploymentID")

--- a/core/src/main/scala/com/raphtory/config/telemetry/StorageTelemetry.scala
+++ b/core/src/main/scala/com/raphtory/config/telemetry/StorageTelemetry.scala
@@ -1,8 +1,5 @@
 package com.raphtory.config.telemetry
 
-import com.raphtory.config.ConfigHandler
-import com.raphtory.deployment.Raphtory
-import com.typesafe.config.Config
 import io.prometheus.client.Counter
 
 /** Adds metrics for Raphtory storage components including `GraphLens`, Vertex messaging and queue using Prometheus Client
@@ -11,11 +8,9 @@ import io.prometheus.client.Counter
   */
 object StorageTelemetry {
 
-  private val raphtoryConfig: Config = Raphtory.getDefaultConfig()
-
-  def pojoLensGraphSize(): Counter =
+  def pojoLensGraphSize: Counter =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.storage"))
+      .namespace("storage")
       .name("pojo_lens_graph_size")
       .help("Total graph size for Graph Lens")
       .labelNames("raphtory_jobID")

--- a/core/src/main/scala/com/raphtory/deployment/Raphtory.scala
+++ b/core/src/main/scala/com/raphtory/deployment/Raphtory.scala
@@ -91,7 +91,7 @@ object Raphtory {
     */
   def connect(customConfig: Map[String, Any] = Map()): TemporalGraphConnection = {
     val scheduler        = new MonixScheduler()
-    val conf             = confBuilder(customConfig)
+    val conf             = confBuilder(customConfig, true)
     javaPy4jGatewayServer.start(conf)
     startPrometheus(conf.getInt("raphtory.prometheus.metrics.port"))
     val topics           = PulsarTopicRepository(conf)
@@ -103,13 +103,13 @@ object Raphtory {
   /** Returns default config using `ConfigFactory` for initialising parameters for
     * running Raphtory components. This uses the default application parameters
     */
-  def getDefaultConfig(customConfig: Map[String, Any] = Map()): Config =
-    confBuilder(customConfig)
+  def getDefaultConfig(customConfig: Map[String, Any] = Map(), distributed: Boolean): Config =
+    confBuilder(customConfig, distributed)
 
-  private def confBuilder(customConfig: Map[String, Any] = Map()): Config = {
+  private def confBuilder(customConfig: Map[String, Any] = Map(), distributed: Boolean): Config = {
     val confHandler = new ConfigHandler()
     customConfig.foreach { case (key, value) => confHandler.addCustomConfig(key, value) }
-    confHandler.getConfig
+    confHandler.getConfig(distributed)
   }
 
   /** Creates `Spout` to read or ingest data from resources or files, sending messages to builder
@@ -118,7 +118,7 @@ object Raphtory {
     */
   private[raphtory] def createSpout[T](spout: Spout[T]): Unit = {
     val scheduler        = new MonixScheduler()
-    val conf             = confBuilder()
+    val conf             = confBuilder(distributed = true)
     startPrometheus(conf.getInt("raphtory.prometheus.metrics.port"))
     val topics           = PulsarTopicRepository(conf)
     val componentFactory = new ComponentFactory(conf, topics)
@@ -132,7 +132,7 @@ object Raphtory {
       builder: GraphBuilder[T]
   ): Unit = {
     val scheduler        = new MonixScheduler()
-    val conf             = confBuilder()
+    val conf             = confBuilder(distributed = true)
     startPrometheus(conf.getInt("raphtory.prometheus.metrics.port"))
     val topics           = PulsarTopicRepository(conf)
     val componentFactory = new ComponentFactory(conf, topics)
@@ -148,7 +148,7 @@ object Raphtory {
       graphBuilder: Option[GraphBuilder[T]] = None
   ): Unit = {
     val scheduler        = new MonixScheduler()
-    val conf             = confBuilder()
+    val conf             = confBuilder(distributed = true)
     startPrometheus(conf.getInt("raphtory.prometheus.metrics.port"))
     val topics           = PulsarTopicRepository(conf)
     val componentFactory = new ComponentFactory(conf, topics)
@@ -160,7 +160,7 @@ object Raphtory {
     */
   private[raphtory] def createQueryManager(): Unit = {
     val scheduler        = new MonixScheduler()
-    val conf             = confBuilder()
+    val conf             = confBuilder(distributed = true)
     startPrometheus(conf.getInt("raphtory.prometheus.metrics.port"))
     val topics           = PulsarTopicRepository(conf)
     val componentFactory = new ComponentFactory(conf, topics)
@@ -196,7 +196,7 @@ object Raphtory {
       batchLoading: Boolean
   ) = {
     val scheduler        = new MonixScheduler()
-    val conf             = confBuilder(customConfig)
+    val conf             = confBuilder(customConfig, distributed = false)
     javaPy4jGatewayServer.start(conf)
     startPrometheus(conf.getInt("raphtory.prometheus.metrics.port"))
     val topics           = PulsarAkkaTopicRepository(conf)

--- a/core/src/main/scala/com/raphtory/deployment/Raphtory.scala
+++ b/core/src/main/scala/com/raphtory/deployment/Raphtory.scala
@@ -103,7 +103,10 @@ object Raphtory {
   /** Returns default config using `ConfigFactory` for initialising parameters for
     * running Raphtory components. This uses the default application parameters
     */
-  def getDefaultConfig(customConfig: Map[String, Any] = Map(), distributed: Boolean): Config =
+  def getDefaultConfig(
+      customConfig: Map[String, Any] = Map(),
+      distributed: Boolean = false
+  ): Config =
     confBuilder(customConfig, distributed)
 
   private def confBuilder(customConfig: Map[String, Any] = Map(), distributed: Boolean): Config = {

--- a/core/src/main/scala/com/raphtory/deployment/RaphtoryService.scala
+++ b/core/src/main/scala/com/raphtory/deployment/RaphtoryService.scala
@@ -41,11 +41,11 @@ abstract class RaphtoryService[T: ClassTag] {
 
   def main(args: Array[String]): Unit =
     args(0) match {
-      case "spout"                   => spoutDeploy()
-      case "builder"                 => builderDeploy()
-      case "partitionmanager"        => partitionDeploy(false)
-      case "batchedPartitionmanager" => partitionDeploy(true)
-      case "querymanager"            => queryManagerDeploy()
+      case "spout"                 => spoutDeploy()
+      case "builder"               => builderDeploy()
+      case "partitionmanager"      => partitionDeploy(false)
+      case "batchpartitionmanager" => partitionDeploy(true)
+      case "querymanager"          => queryManagerDeploy()
     }
 
   /** Deploy spouts by using `SpoutExecutor` to ingest data from files and resources,

--- a/core/src/main/scala/com/raphtory/deployment/RaphtoryService.scala
+++ b/core/src/main/scala/com/raphtory/deployment/RaphtoryService.scala
@@ -39,14 +39,13 @@ abstract class RaphtoryService[T: ClassTag] {
   /** Initialise `GraphBuilder` for building graphs */
   def defineBuilder: GraphBuilder[T]
 
-  def batchIngestion(): Boolean
-
   def main(args: Array[String]): Unit =
     args(0) match {
-      case "spout"            => spoutDeploy()
-      case "builder"          => builderDeploy()
-      case "partitionmanager" => partitionDeploy()
-      case "querymanager"     => queryManagerDeploy()
+      case "spout"                   => spoutDeploy()
+      case "builder"                 => builderDeploy()
+      case "partitionmanager"        => partitionDeploy(false)
+      case "batchedPartitionmanager" => partitionDeploy(true)
+      case "querymanager"            => queryManagerDeploy()
     }
 
   /** Deploy spouts by using `SpoutExecutor` to ingest data from files and resources,
@@ -64,9 +63,9 @@ abstract class RaphtoryService[T: ClassTag] {
   /** Deploy partitions using Partition Manager for creating partitions as distributed
     * storage units with readers and writers. Uses Zookeeper to create partition IDs
     */
-  def partitionDeploy(): Unit =
+  def partitionDeploy(batched: Boolean): Unit =
     Raphtory.createPartitionManager[T](
-            batchLoading = batchIngestion(),
+            batchLoading = batched,
             spout = Some(defineSpout()),
             graphBuilder = Some(defineBuilder)
     )

--- a/core/src/main/scala/com/raphtory/deployment/kubernetes/components/Config.scala
+++ b/core/src/main/scala/com/raphtory/deployment/kubernetes/components/Config.scala
@@ -9,7 +9,7 @@ import com.typesafe.config
 /** Reads kubernetes configuration values from application.conf.
   */
 class Config {
-  val conf: config.Config          = Raphtory.getDefaultConfig()
+  val conf: config.Config          = Raphtory.getDefaultConfig(distributed = true)
   val raphtoryDeploymentId: String = conf.getString("raphtory.deploy.id")
 
   val raphtoryKubernetesNamespaceName: String =

--- a/core/src/main/scala/com/raphtory/spouts/FileSpout.scala
+++ b/core/src/main/scala/com/raphtory/spouts/FileSpout.scala
@@ -186,5 +186,9 @@ object FileSpout {
     new FileSpout[T](source, lineConverter, config)
 
   def apply(source: String = "") =
-    new FileSpout[String](source, lineConverter = s => s, Raphtory.getDefaultConfig())
+    new FileSpout[String](
+            source,
+            lineConverter = s => s,
+            Raphtory.getDefaultConfig(distributed = false)
+    )
 }

--- a/core/src/test/scala/com/raphtory/components/spout/LOTRGraphBuilderTest.scala
+++ b/core/src/test/scala/com/raphtory/components/spout/LOTRGraphBuilderTest.scala
@@ -30,11 +30,10 @@ class LOTRGraphBuilderTest extends AnyFunSuite with BeforeAndAfter {
   val config: Config = Raphtory.getDefaultConfig(
           Map[String, Any](
                   ("raphtory.spout.topic", test_producer_topic),
-                  ("raphtory.partitions.serverCount", 1),
-                  ("raphtory.partitions.countPerServer", 1),
                   ("raphtory.deploy.id", test_graph_builder_topic),
                   ("raphtory.deploy.id", test_graph_builder_topic)
-          )
+          ),
+          distributed = false
   )
 
   val admin: PulsarAdmin                           =

--- a/core/src/test/scala/com/raphtory/ethereumtest/EthereumDistributedTest.scala
+++ b/core/src/test/scala/com/raphtory/ethereumtest/EthereumDistributedTest.scala
@@ -7,9 +7,6 @@ import com.raphtory.spouts.FileSpout
 import org.apache.pulsar.client.api.Schema
 
 object EthereumDistributedTest extends RaphtoryService[String] {
-  override def defineSpout(): Spout[String] = FileSpout()
-
+  override def defineSpout(): Spout[String]        = FileSpout()
   override def defineBuilder: EthereumGraphBuilder = new EthereumGraphBuilder()
-
-  override def batchIngestion(): Boolean = true
 }

--- a/core/src/test/scala/com/raphtory/lotrtest/LOTRDistributedTest.scala
+++ b/core/src/test/scala/com/raphtory/lotrtest/LOTRDistributedTest.scala
@@ -9,10 +9,6 @@ import com.typesafe.config.Config
 import org.apache.pulsar.client.api.Schema
 
 object LOTRDistributedTest extends RaphtoryService[String] {
-  override def defineSpout(): Spout[String] = FileSpout()
-
+  override def defineSpout(): Spout[String]        = FileSpout()
   override def defineBuilder: GraphBuilder[String] = new LOTRGraphBuilder()
-
-  override def batchIngestion(): Boolean = false
-
 }

--- a/examples/raphtory-example-ethereum/src/main/scala/com/raphtory/ethereum/Distributed.scala
+++ b/examples/raphtory-example-ethereum/src/main/scala/com/raphtory/ethereum/Distributed.scala
@@ -13,9 +13,6 @@ object Distributed extends RaphtoryService[String] {
   val url  = "https://raw.githubusercontent.com/Raphtory/Data/main/etherscan_tags.csv"
   FileUtils.curlFile(path, url)
 
-  override def defineSpout(): Spout[String] = FileSpout("/tmp/etherscan_tags.csv")
-
+  override def defineSpout(): Spout[String]        = FileSpout("/tmp/etherscan_tags.csv")
   override def defineBuilder: EthereumGraphBuilder = new EthereumGraphBuilder()
-
-  override def batchIngestion(): Boolean = true
 }

--- a/examples/raphtory-example-facebook/src/main/scala/com.raphtory.examples.facebook/Runner.scala
+++ b/examples/raphtory-example-facebook/src/main/scala/com.raphtory.examples.facebook/Runner.scala
@@ -29,7 +29,6 @@ object Runner extends App {
         throw ex
     }
   }
-  val conf: config.Config = Raphtory.getDefaultConfig()
 
   val source: StaticGraphSpout = StaticGraphSpout("/tmp/facebook.csv")
   val builder                  = new FacebookGraphBuilder()

--- a/python/raphtoryclient/client.py
+++ b/python/raphtoryclient/client.py
@@ -116,7 +116,7 @@ class client:
             graph: raphtory client graph object
         '''
         print("Creating Raphtory java object...")
-        customConfig = {"raphtory.deploy.id": self._raphtory_deployment_id, "raphtory.deploy.distributed": True}
+        customConfig = {"raphtory.deploy.id": self._raphtory_deployment_id}
         mc_run_map_dict = MapConverter().convert(customConfig, self.gateway._gateway_client)
         jmap = self.gateway.jvm.PythonUtil.toScalaMap(mc_run_map_dict)
         graph = self.gateway.jvm.Raphtory.connect(jmap)


### PR DESCRIPTION
Through conversations with @felixcdr who is testing the distributed services of Raphtory several optimisations were proposed. This PR fixes two of these:

## Remove raphtory.deploy.distributed property

This property tells the `ConfigHandler` to add a random salt to the raphtory.deploy.id, in order to avoid conflicts between local deployments and their pulsar channels. However, this option will cause distributed services to not find each other in Pulsar due to the different hashes, while not throwing any useful errors. 

It seems the need for this salt comes exclusively for Raphtory components that are not created through the RaphtoryService or Raphtory client methods. If the code is restructured to explicitly request salted id or not, depending on the initial method calling the creation of the component, this configuration property can be safely removed.

Currently you need to always set the right value for the property, while it is not giving any flexibility.

### Solution

The `Raphtory.getDefaultConfig()` and `Raphtory.confBuilder()` functions now  take a `distributed:Boolean` argument which allows the components calling the function to specify the context within which they are running. As part of this change, I refactored the Prometheus Telemetrics to not use any conf - this is because I can't see any use in having custom name spaces and it was causing nightmares when having a global conf. 


## Replace batchIngestion() from the Service API with a different argument to start the service

Currently this property is set by the class extending the generic RaphtoryService, and if true it will cause Raphtory to instantiate the combo BatchLoadingSpoutBuilderPartitionManager with the `partitionmanager` argument. 

If a service implementation sets this property to true, there is no sense in  starting the service on `spout` or `builder` modes (not intuitive).

The intent however is not clear, it would be more explicit to define an additional option, `batchpartitionmanager` (good suggestions are welcome) that always implements the BLSBPM voltron, whereas `partitionmanager` will only create the partitionmanager. It is clearer this way, and will give more flexibility on how to deploy these services.

### Solution
The `batchIngestion()` function has been removed from the RaphtoryService. This has been replaced with an additional possible argument which specifies that the user wanted a `batchpartitionmanager` -- see below:
<img width="505" alt="image" src="https://user-images.githubusercontent.com/6665739/171047849-c8cdb8d2-f361-4be7-9654-02b3f69408b2.png">
