### PR TITLE
Thread-safe watermarking

### DIFF
--- a/core/src/main/resources/application.conf
+++ b/core/src/main/resources/application.conf
@@ -221,14 +221,6 @@ raphtory {
     metrics {
       port = 9999
     }
-    namespaces {
-      spout         = "spout"
-      reader        = "reader"
-      writer        = "writer"
-      query         = "query"
-      storage       = "storage"
-      builder       = "graph_builder"
-    }
   }
 
   python {

--- a/core/src/main/scala/com/raphtory/algorithms/api/TemporalGraphConnection.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/api/TemporalGraphConnection.scala
@@ -7,7 +7,7 @@ import com.raphtory.config.MonixScheduler
 import com.typesafe.config.Config
 
 /**  `TemporalGraphConnection` is a wrapper for the `TemporalGraph` class normally used to interact with Raphtory graphs.
-  *  This is returned from the `deployedGraph` function on the Raphtory Object and has an additional `disconnect()`
+  *  This is returned from the `connect` function on the Raphtory Object and has an additional `disconnect()`
   *  function which allows the user to clean up the resources (scheduler/topic repo/connections etc.) used to connect to a deployment.
   *
   * @see

--- a/core/src/main/scala/com/raphtory/components/querymanager/QueryManager.scala
+++ b/core/src/main/scala/com/raphtory/components/querymanager/QueryManager.scala
@@ -7,6 +7,7 @@ import com.typesafe.config.Config
 import com.typesafe.scalalogging.Logger
 import org.slf4j.LoggerFactory
 
+import scala.collection.concurrent._
 import scala.collection.mutable
 
 /** @note DoNotDocument */
@@ -15,8 +16,9 @@ class QueryManager(scheduler: MonixScheduler, conf: Config, topics: TopicReposit
   private val logger: Logger = Logger(LoggerFactory.getLogger(this.getClass))
 
   private val currentQueries = mutable.Map[String, QueryHandler]()
+
   //private val watermarkGlobal                           = pulsarController.globalwatermarkPublisher() TODO: turn back on when needed
-  private val watermarks     = mutable.Map[Int, WatermarkTime]()
+  private val watermarks: Map[Int, WatermarkTime] = new TrieMap[Int, WatermarkTime]()
 
   private val listener = topics
     .registerListener(
@@ -87,6 +89,7 @@ class QueryManager(scheduler: MonixScheduler, conf: Config, topics: TopicReposit
       var safe    = true
       var minTime = Long.MaxValue
       var maxTime = Long.MinValue
+
       watermarks.foreach {
         case (key, watermark) =>
           safe = watermark.safe && safe

--- a/core/src/main/scala/com/raphtory/components/querytracker/QueryProgressTracker.scala
+++ b/core/src/main/scala/com/raphtory/components/querytracker/QueryProgressTracker.scala
@@ -28,7 +28,7 @@ import scala.concurrent.duration.Duration
   * import com.raphtory.GraphState
   * import com.raphtory.output.FileOutputFormat
   *
-  * val graph = Raphtory.batchLoadGraph(ResourceSpout("resource"), LOTRGraphBuilder())
+  * val graph = Raphtory.load(ResourceSpout("resource"), LOTRGraphBuilder())
   * val queryProgressTracker = graph.rangeQuery(GraphState(),FileOutputFormat("/test_dir"),1, 32674, 10000, List(500, 1000, 10000))
   * val jobId                = queryProgressTracker.getJobId()
   * queryProgressTracker.waitForJob()

--- a/core/src/main/scala/com/raphtory/config/ConfigHandler.scala
+++ b/core/src/main/scala/com/raphtory/config/ConfigHandler.scala
@@ -15,17 +15,15 @@ private[raphtory] class ConfigHandler {
   private lazy val defaults       = createConf()
   private lazy val logger: Logger = Logger(LoggerFactory.getLogger(this.getClass))
 
-  private lazy val deployedDistributed =
-    defaults.resolve().getBoolean("raphtory.deploy.distributed")
-  private val customConfigValues       = ArrayBuffer[(String, ConfigValue)]()
+  private val customConfigValues = ArrayBuffer[(String, ConfigValue)]()
 
   private var salt = Random.nextInt().abs
 
   def addCustomConfig(path: String, value: Any) =
     customConfigValues += ((path, ConfigValueFactory.fromAnyRef(value)))
 
-  def getConfig: Config =
-    if (deployedDistributed)
+  def getConfig(runningDistributed: Boolean): Config =
+    if (runningDistributed)
       distributed()
     else
       local()

--- a/core/src/main/scala/com/raphtory/config/telemetry/BuilderTelemetry.scala
+++ b/core/src/main/scala/com/raphtory/config/telemetry/BuilderTelemetry.scala
@@ -1,7 +1,5 @@
 package com.raphtory.config.telemetry
 
-import com.raphtory.deployment.Raphtory
-import com.typesafe.config.Config
 import io.prometheus.client.Counter
 
 /** Adds metrics for `GraphBuilder` using Prometheus Client
@@ -10,43 +8,42 @@ import io.prometheus.client.Counter
   * Statistics are made available on http://localhost:9999 on running tests and can be visualised using Grafana dashboards
   */
 object BuilderTelemetry {
-  private val raphtoryConfig: Config = Raphtory.getDefaultConfig()
 
-  def totalVertexAdds() =
+  def totalVertexAdds =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.builder"))
+      .namespace("graph_builder")
       .name("vertex_add")
       .help("Total vertices added by Graph Builder")
       .labelNames("raphtory_deploymentID")
       .register
 
-  def totalVertexDeletes() =
+  def totalVertexDeletes =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.builder"))
+      .namespace("graph_builder")
       .name("vertex_delete")
       .help("Total vertices deleted by Graph Builder")
       .labelNames("raphtory_deploymentID")
       .register
 
-  def totalEdgeAdds() =
+  def totalEdgeAdds =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.builder"))
+      .namespace("graph_builder")
       .name("edge_add")
       .help("Total edges added by Graph Builder")
       .labelNames("raphtory_deploymentID")
       .register
 
-  def totalEdgeDeletes() =
+  def totalEdgeDeletes =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.builder"))
+      .namespace("graph_builder")
       .name("edge_delete")
       .help("Total edges deleted by Graph Builder")
       .labelNames("raphtory_deploymentID")
       .register
 
-  def totalGraphBuilderUpdates() =
+  def totalGraphBuilderUpdates =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.builder"))
+      .namespace("graph_builder")
       .name("update")
       .help("Total Graph Builder updates")
       .labelNames("raphtory_deploymentID")

--- a/core/src/main/scala/com/raphtory/config/telemetry/ComponentTelemetryHandler.scala
+++ b/core/src/main/scala/com/raphtory/config/telemetry/ComponentTelemetryHandler.scala
@@ -9,42 +9,42 @@ private[raphtory] object ComponentTelemetryHandler {
   val fileLinesSent: Counter        = SpoutTelemetry.totalLinesSent
   val fileProcessingErrors: Counter = SpoutTelemetry.totalFileProcessingErrors
 
-  val vertexAddCounter: Counter           = BuilderTelemetry.totalVertexAdds()
-  val vertexDeleteCounter: Counter        = BuilderTelemetry.totalVertexDeletes()
-  val edgeAddCounter: Counter             = BuilderTelemetry.totalEdgeAdds()
-  val edgeDeleteCounter: Counter          = BuilderTelemetry.totalEdgeDeletes()
-  val graphBuilderUpdatesCounter: Counter = BuilderTelemetry.totalGraphBuilderUpdates()
+  val vertexAddCounter: Counter           = BuilderTelemetry.totalVertexAdds
+  val vertexDeleteCounter: Counter        = BuilderTelemetry.totalVertexDeletes
+  val edgeAddCounter: Counter             = BuilderTelemetry.totalEdgeAdds
+  val edgeDeleteCounter: Counter          = BuilderTelemetry.totalEdgeDeletes
+  val graphBuilderUpdatesCounter: Counter = BuilderTelemetry.totalGraphBuilderUpdates
 
-  val lastWatermarkProcessedCollector: Gauge       = PartitionTelemetry.lastWatermarkProcessed()
-  val queryExecutorCollector: Gauge                = PartitionTelemetry.queryExecutorCounter()
-  val batchWriterVertexAdditionsCollector: Counter = PartitionTelemetry.batchWriterVertexAdditions()
-  val batchWriterEdgeAdditionsCollector: Counter   = PartitionTelemetry.batchWriterEdgeAdditions()
-  val batchWriterEdgeDeletionsCollector: Counter   = PartitionTelemetry.batchWriterEdgeDeletions()
+  val lastWatermarkProcessedCollector: Gauge       = PartitionTelemetry.lastWatermarkProcessed
+  val queryExecutorCollector: Gauge                = PartitionTelemetry.queryExecutorCounter
+  val batchWriterVertexAdditionsCollector: Counter = PartitionTelemetry.batchWriterVertexAdditions
+  val batchWriterEdgeAdditionsCollector: Counter   = PartitionTelemetry.batchWriterEdgeAdditions
+  val batchWriterEdgeDeletionsCollector: Counter   = PartitionTelemetry.batchWriterEdgeDeletions
 
   val batchWriterRemoteEdgeAdditionsCollector: Counter =
-    PartitionTelemetry.batchWriterRemoteEdgeAdditions()
+    PartitionTelemetry.batchWriterRemoteEdgeAdditions
 
   val batchWriterRemoteEdgeDeletionsCollector: Counter =
-    PartitionTelemetry.batchWriterRemoteEdgeDeletions()
+    PartitionTelemetry.batchWriterRemoteEdgeDeletions
 
-  val vertexAddCollector: Counter                 = PartitionTelemetry.streamWriterVertexAdditions()
-  val streamWriterGraphUpdatesCollector: Counter  = PartitionTelemetry.streamWriterGraphUpdates()
-  val streamWriterEdgeAdditionsCollector: Counter = PartitionTelemetry.streamWriterEdgeAdditions()
-  val streamWriterEdgeDeletionsCollector: Counter = PartitionTelemetry.streamWriterEdgeDeletions()
+  val vertexAddCollector: Counter                 = PartitionTelemetry.streamWriterVertexAdditions
+  val streamWriterGraphUpdatesCollector: Counter  = PartitionTelemetry.streamWriterGraphUpdates
+  val streamWriterEdgeAdditionsCollector: Counter = PartitionTelemetry.streamWriterEdgeAdditions
+  val streamWriterEdgeDeletionsCollector: Counter = PartitionTelemetry.streamWriterEdgeDeletions
 
   val streamWriterVertexDeletionsCollector: Counter =
-    PartitionTelemetry.streamWriterVertexDeletions()
+    PartitionTelemetry.streamWriterVertexDeletions
 
   val totalSyncedStreamWriterUpdatesCollector: Counter =
-    PartitionTelemetry.totalSyncedStreamWriterUpdates()
+    PartitionTelemetry.totalSyncedStreamWriterUpdates
 
-  val receivedMessageCountCollector: Counter = QueryTelemetry.receivedMessageCount()
-  val totalSentMessageCount: Counter         = QueryTelemetry.sentMessageCount()
-  val totalPerspectivesProcessed: Counter    = QueryTelemetry.totalPerspectivesProcessed()
-  val totalGraphOperations: Counter          = QueryTelemetry.totalGraphOperations()
-  val totalTableOperations: Counter          = QueryTelemetry.totalTableOperations()
-  val globalWatermarkMin: Gauge              = QueryTelemetry.globalWatermarkMin()
-  val globalWatermarkMax: Gauge              = QueryTelemetry.globalWatermarkMax()
-  val totalQueriesSpawned: Counter           = QueryTelemetry.totalQueriesSpawned()
-  val graphSizeCollector: Counter            = StorageTelemetry.pojoLensGraphSize()
+  val receivedMessageCountCollector: Counter = QueryTelemetry.receivedMessageCount
+  val totalSentMessageCount: Counter         = QueryTelemetry.sentMessageCount
+  val totalPerspectivesProcessed: Counter    = QueryTelemetry.totalPerspectivesProcessed
+  val totalGraphOperations: Counter          = QueryTelemetry.totalGraphOperations
+  val totalTableOperations: Counter          = QueryTelemetry.totalTableOperations
+  val globalWatermarkMin: Gauge              = QueryTelemetry.globalWatermarkMin
+  val globalWatermarkMax: Gauge              = QueryTelemetry.globalWatermarkMax
+  val totalQueriesSpawned: Counter           = QueryTelemetry.totalQueriesSpawned
+  val graphSizeCollector: Counter            = StorageTelemetry.pojoLensGraphSize
 }

--- a/core/src/main/scala/com/raphtory/config/telemetry/PartitionTelemetry.scala
+++ b/core/src/main/scala/com/raphtory/config/telemetry/PartitionTelemetry.scala
@@ -1,8 +1,7 @@
 package com.raphtory.config.telemetry
 
-import com.raphtory.deployment.Raphtory
-import com.typesafe.config.Config
-import io.prometheus.client.{Counter, Gauge}
+import io.prometheus.client.Counter
+import io.prometheus.client.Gauge
 
 /** Adds metrics for partitions, i.e. `Reader`, `BatchWriter` and `StreamWriter` using Prometheus Client
   * Exposes Counter and Summary stats for tracking number of graph updates, watermarks created by reader, vertices and edges added and deleted by writers in Raphtory
@@ -10,117 +9,115 @@ import io.prometheus.client.{Counter, Gauge}
   */
 object PartitionTelemetry {
 
-  private val raphtoryConfig: Config = Raphtory.getDefaultConfig()
-
-  def lastWatermarkProcessed() =
+  def lastWatermarkProcessed =
     Gauge.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.reader"))
+      .namespace("writer")
       .name("last_watermark_processed")
       .help("Last watermark processed by Partition Reader")
       .labelNames("raphtory_partitionID", "raphtory_deploymentID")
       .register()
 
-  def queryExecutorCounter() =
+  def queryExecutorCounter =
     Gauge.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.reader"))
+      .namespace("writer")
       .name("query_executor_jobs_total")
       .help("Total query executors running in this partition")
       .labelNames("raphtory_partitionID", "raphtory_deploymentID")
       .register()
 
-  def batchWriterVertexAdditions() =
+  def batchWriterVertexAdditions =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.writer"))
+      .namespace("writer")
       .name("batch_vertex_adds")
       .help("Total vertex additions for Batch Writer")
       .labelNames("raphtory_partitionID")
       .register()
 
-  def batchWriterEdgeAdditions() =
+  def batchWriterEdgeAdditions =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.writer"))
+      .namespace("writer")
       .name("batch_edge_adds")
       .help("Total edge additions for Batch Writer")
       .labelNames("raphtory_partitionID")
       .register()
 
-  def batchWriterEdgeDeletions() =
+  def batchWriterEdgeDeletions =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.writer"))
+      .namespace("writer")
       .name("batch_edge_deletions")
       .help("Total edge deletions for Batch Writer")
       .labelNames("raphtory_partitionID")
       .register()
 
-  def batchWriterRemoteEdgeAdditions() =
+  def batchWriterRemoteEdgeAdditions =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.writer"))
+      .namespace("writer")
       .name("batch_remote_edge_adds")
       .help("Total remote edge additions for Batch Writer")
       .labelNames("raphtory_partitionID")
       .register()
 
-  def batchWriterRemoteEdgeDeletions() =
+  def batchWriterRemoteEdgeDeletions =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.writer"))
+      .namespace("writer")
       .name("batch_remote_edge_deletions")
       .help("Total remote edge deletions for Batch Writer")
       .labelNames("raphtory_partitionID")
       .register()
 
-  def streamWriterGraphUpdates() =
+  def streamWriterGraphUpdates =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.writer"))
+      .namespace("writer")
       .name("stream_graph_updates")
       .help("Total graph updates for Stream Writer")
       .labelNames("raphtory_partitionID", "raphtory_deploymentID")
       .register()
 
-  def totalSyncedStreamWriterUpdates() =
+  def totalSyncedStreamWriterUpdates =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.writer"))
+      .namespace("writer")
       .name("stream_synced_updates")
       .help("Total synced updates for Stream Writer")
       .labelNames("raphtory_partitionID", "raphtory_deploymentID")
       .register()
 
-  def streamWriterVertexAdditions() =
+  def streamWriterVertexAdditions =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.writer"))
+      .namespace("writer")
       .name("stream_vertex_adds")
       .help("Total vertex additions for Stream Writer")
       .labelNames("raphtory_partitionID", "raphtory_deploymentID")
       .register()
 
-  def streamWriterVertexDeletions(): Counter =
+  def streamWriterVertexDeletions: Counter =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.writer"))
+      .namespace("writer")
       .name("stream_vertex_deletes")
       .help("Total vertex deletions for Stream Writer")
       .labelNames("raphtory_partitionID", "raphtory_deploymentID")
       .register()
 
-  def streamWriterEdgeAdditions() =
+  def streamWriterEdgeAdditions =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.writer"))
+      .namespace("writer")
       .name("stream_edge_adds")
       .help("Total edge additions for Stream Writer")
       .labelNames("raphtory_partitionID", "raphtory_deploymentID")
       .register()
 
-  def streamWriterEdgeDeletions() =
+  def streamWriterEdgeDeletions =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.writer"))
+      .namespace("writer")
       .name("stream_edge_deletes")
       .help("Total edge deletions for Stream Writer")
       .labelNames("raphtory_partitionID", "raphtory_deploymentID")
       .register()
 
   //TODO: implement
-  def timeForIngestion() =
+  def timeForIngestion =
     Counter
       .build()
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.writer"))
+      .namespace("writer")
       .name("ingestion_time")
       .help("Time for ingestion of partition")
       .labelNames("raphtory_partitionID")

--- a/core/src/main/scala/com/raphtory/config/telemetry/QueryTelemetry.scala
+++ b/core/src/main/scala/com/raphtory/config/telemetry/QueryTelemetry.scala
@@ -1,8 +1,7 @@
 package com.raphtory.config.telemetry
 
-import com.raphtory.deployment.Raphtory
-import com.typesafe.config.Config
-import io.prometheus.client.{Counter, Gauge}
+import io.prometheus.client.Counter
+import io.prometheus.client.Gauge
 
 /** Adds metrics for `QueryHandler`, `QueryManager` and `QueryExecutor`  using Prometheus Client
   * Exposes Counter stats for tracking number of vertices, messages received and sent by `Query` handler, manager and executor
@@ -10,67 +9,65 @@ import io.prometheus.client.{Counter, Gauge}
   */
 object QueryTelemetry {
 
-  private val raphtoryConfig: Config = Raphtory.getDefaultConfig()
-
-  def receivedMessageCount(): Counter =
+  def receivedMessageCount: Counter =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.query"))
+      .namespace("query")
       .name("handler_received_messages")
       .help("Total received messages count in Query Handler")
       .labelNames("raphtory_jobID", "raphtory_deploymentID")
       .register
 
-  def sentMessageCount(): Counter =
+  def sentMessageCount: Counter =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.query"))
+      .namespace("query")
       .name("handler_sent_messages")
       .help("Total sent messages count in Query Handler")
       .labelNames("raphtory_jobID", "raphtory_deploymentID")
       .register
 
-  def globalWatermarkMin(): Gauge =
+  def globalWatermarkMin: Gauge =
     Gauge.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.query"))
+      .namespace("query")
       .name("manager_min_watermark_timestamp")
       .help("Minimum watermark for Query Manager")
       .labelNames("raphtory_deploymentID")
       .register
 
-  def globalWatermarkMax(): Gauge =
+  def globalWatermarkMax: Gauge =
     Gauge.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.query"))
+      .namespace("query")
       .name("manager_max_watermark_timestamp")
       .help("Maximum watermark for Query Manager")
       .labelNames("raphtory_deploymentID")
       .register
 
-  def totalGraphOperations(): Counter =
+  def totalGraphOperations: Counter =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.query"))
+      .namespace("query")
       .name("handler_graph_operations")
       .help("Total graph operations by Query Handler")
       .labelNames("raphtory_jobID", "raphtory_deploymentID")
       .register
 
-  def totalTableOperations(): Counter =
+  def totalTableOperations: Counter =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.query"))
+      .namespace("query")
       .name("handler_table_operations")
       .help("Total table operations by Query Handler")
       .labelNames("raphtory_jobID", "raphtory_deploymentID")
       .register
 
-  def totalPerspectivesProcessed(): Counter =
+  def totalPerspectivesProcessed: Counter =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.query"))
+      .namespace("query")
       .name("handler_perspectives_processed")
       .help("Total perspectives processed by Query Handler")
       .labelNames("raphtory_jobID", "raphtory_deploymentID")
       .register
 
-  def totalQueriesSpawned(): Counter =
+  def totalQueriesSpawned: Counter =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.query"))
+      .namespace("query")
       .name("manager_queries_spawned")
       .help("Total queries spawned by Query Manager")
       .labelNames("raphtory_deploymentID")

--- a/core/src/main/scala/com/raphtory/config/telemetry/SpoutTelemetry.scala
+++ b/core/src/main/scala/com/raphtory/config/telemetry/SpoutTelemetry.scala
@@ -1,8 +1,6 @@
 package com.raphtory.config.telemetry
 
 import io.prometheus.client.Counter
-import com.raphtory.deployment.Raphtory
-import com.typesafe.config.Config
 
 /** Adds metrics for `Spout` using Prometheus Client
   * Exposes Counter stats for tracking number of files processed, lines parsed, spout reschedules and processing errors
@@ -10,11 +8,9 @@ import com.typesafe.config.Config
   */
 object SpoutTelemetry {
 
-  private val raphtoryConfig: Config = Raphtory.getDefaultConfig()
-
   def totalFilesProcessed: Counter =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.spout"))
+      .namespace("spout")
       .name("file_processed_total")
       .help("Total files processed by spout")
       .labelNames("raphtory_deploymentID")
@@ -22,7 +18,7 @@ object SpoutTelemetry {
 
   def totalSpoutReschedules: Counter =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.spout"))
+      .namespace("spout")
       .name("reschedule_total")
       .help("Total spout reschedules")
       .labelNames("raphtory_deploymentID")
@@ -30,7 +26,7 @@ object SpoutTelemetry {
 
   def totalLinesSent: Counter =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.spout"))
+      .namespace("spout")
       .name("file_line_sent_total")
       .help("Total lines of file sent")
       .labelNames("raphtory_deploymentID")
@@ -38,7 +34,7 @@ object SpoutTelemetry {
 
   def totalFileProcessingErrors: Counter =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.spout"))
+      .namespace("spout")
       .name("file_processing_error_total")
       .help("Total file processing errors")
       .labelNames("raphtory_deploymentID")

--- a/core/src/main/scala/com/raphtory/config/telemetry/StorageTelemetry.scala
+++ b/core/src/main/scala/com/raphtory/config/telemetry/StorageTelemetry.scala
@@ -1,8 +1,5 @@
 package com.raphtory.config.telemetry
 
-import com.raphtory.config.ConfigHandler
-import com.raphtory.deployment.Raphtory
-import com.typesafe.config.Config
 import io.prometheus.client.Counter
 
 /** Adds metrics for Raphtory storage components including `GraphLens`, Vertex messaging and queue using Prometheus Client
@@ -11,11 +8,9 @@ import io.prometheus.client.Counter
   */
 object StorageTelemetry {
 
-  private val raphtoryConfig: Config = Raphtory.getDefaultConfig()
-
-  def pojoLensGraphSize(): Counter =
+  def pojoLensGraphSize: Counter =
     Counter.build
-      .namespace(raphtoryConfig.getString("raphtory.prometheus.namespaces.storage"))
+      .namespace("storage")
       .name("pojo_lens_graph_size")
       .help("Total graph size for Graph Lens")
       .labelNames("raphtory_jobID")

--- a/core/src/main/scala/com/raphtory/deployment/Raphtory.scala
+++ b/core/src/main/scala/com/raphtory/deployment/Raphtory.scala
@@ -91,7 +91,7 @@ object Raphtory {
     */
   def connect(customConfig: Map[String, Any] = Map()): TemporalGraphConnection = {
     val scheduler        = new MonixScheduler()
-    val conf             = confBuilder(customConfig)
+    val conf             = confBuilder(customConfig, true)
     javaPy4jGatewayServer.start(conf)
     startPrometheus(conf.getInt("raphtory.prometheus.metrics.port"))
     val topics           = PulsarTopicRepository(conf)
@@ -103,13 +103,13 @@ object Raphtory {
   /** Returns default config using `ConfigFactory` for initialising parameters for
     * running Raphtory components. This uses the default application parameters
     */
-  def getDefaultConfig(customConfig: Map[String, Any] = Map()): Config =
-    confBuilder(customConfig)
+  def getDefaultConfig(customConfig: Map[String, Any] = Map(), distributed: Boolean): Config =
+    confBuilder(customConfig, distributed)
 
-  private def confBuilder(customConfig: Map[String, Any] = Map()): Config = {
+  private def confBuilder(customConfig: Map[String, Any] = Map(), distributed: Boolean): Config = {
     val confHandler = new ConfigHandler()
     customConfig.foreach { case (key, value) => confHandler.addCustomConfig(key, value) }
-    confHandler.getConfig
+    confHandler.getConfig(distributed)
   }
 
   /** Creates `Spout` to read or ingest data from resources or files, sending messages to builder
@@ -118,7 +118,7 @@ object Raphtory {
     */
   private[raphtory] def createSpout[T](spout: Spout[T]): Unit = {
     val scheduler        = new MonixScheduler()
-    val conf             = confBuilder()
+    val conf             = confBuilder(distributed = true)
     startPrometheus(conf.getInt("raphtory.prometheus.metrics.port"))
     val topics           = PulsarTopicRepository(conf)
     val componentFactory = new ComponentFactory(conf, topics)
@@ -132,7 +132,7 @@ object Raphtory {
       builder: GraphBuilder[T]
   ): Unit = {
     val scheduler        = new MonixScheduler()
-    val conf             = confBuilder()
+    val conf             = confBuilder(distributed = true)
     startPrometheus(conf.getInt("raphtory.prometheus.metrics.port"))
     val topics           = PulsarTopicRepository(conf)
     val componentFactory = new ComponentFactory(conf, topics)
@@ -148,7 +148,7 @@ object Raphtory {
       graphBuilder: Option[GraphBuilder[T]] = None
   ): Unit = {
     val scheduler        = new MonixScheduler()
-    val conf             = confBuilder()
+    val conf             = confBuilder(distributed = true)
     startPrometheus(conf.getInt("raphtory.prometheus.metrics.port"))
     val topics           = PulsarTopicRepository(conf)
     val componentFactory = new ComponentFactory(conf, topics)
@@ -160,7 +160,7 @@ object Raphtory {
     */
   private[raphtory] def createQueryManager(): Unit = {
     val scheduler        = new MonixScheduler()
-    val conf             = confBuilder()
+    val conf             = confBuilder(distributed = true)
     startPrometheus(conf.getInt("raphtory.prometheus.metrics.port"))
     val topics           = PulsarTopicRepository(conf)
     val componentFactory = new ComponentFactory(conf, topics)
@@ -196,7 +196,7 @@ object Raphtory {
       batchLoading: Boolean
   ) = {
     val scheduler        = new MonixScheduler()
-    val conf             = confBuilder(customConfig)
+    val conf             = confBuilder(customConfig, distributed = false)
     javaPy4jGatewayServer.start(conf)
     startPrometheus(conf.getInt("raphtory.prometheus.metrics.port"))
     val topics           = PulsarAkkaTopicRepository(conf)

--- a/core/src/main/scala/com/raphtory/deployment/Raphtory.scala
+++ b/core/src/main/scala/com/raphtory/deployment/Raphtory.scala
@@ -103,7 +103,10 @@ object Raphtory {
   /** Returns default config using `ConfigFactory` for initialising parameters for
     * running Raphtory components. This uses the default application parameters
     */
-  def getDefaultConfig(customConfig: Map[String, Any] = Map(), distributed: Boolean): Config =
+  def getDefaultConfig(
+      customConfig: Map[String, Any] = Map(),
+      distributed: Boolean = false
+  ): Config =
     confBuilder(customConfig, distributed)
 
   private def confBuilder(customConfig: Map[String, Any] = Map(), distributed: Boolean): Config = {

--- a/core/src/main/scala/com/raphtory/deployment/RaphtoryService.scala
+++ b/core/src/main/scala/com/raphtory/deployment/RaphtoryService.scala
@@ -41,11 +41,11 @@ abstract class RaphtoryService[T: ClassTag] {
 
   def main(args: Array[String]): Unit =
     args(0) match {
-      case "spout"                   => spoutDeploy()
-      case "builder"                 => builderDeploy()
-      case "partitionmanager"        => partitionDeploy(false)
-      case "batchedPartitionmanager" => partitionDeploy(true)
-      case "querymanager"            => queryManagerDeploy()
+      case "spout"                 => spoutDeploy()
+      case "builder"               => builderDeploy()
+      case "partitionmanager"      => partitionDeploy(false)
+      case "batchpartitionmanager" => partitionDeploy(true)
+      case "querymanager"          => queryManagerDeploy()
     }
 
   /** Deploy spouts by using `SpoutExecutor` to ingest data from files and resources,

--- a/core/src/main/scala/com/raphtory/deployment/RaphtoryService.scala
+++ b/core/src/main/scala/com/raphtory/deployment/RaphtoryService.scala
@@ -39,14 +39,13 @@ abstract class RaphtoryService[T: ClassTag] {
   /** Initialise `GraphBuilder` for building graphs */
   def defineBuilder: GraphBuilder[T]
 
-  def batchIngestion(): Boolean
-
   def main(args: Array[String]): Unit =
     args(0) match {
-      case "spout"            => spoutDeploy()
-      case "builder"          => builderDeploy()
-      case "partitionmanager" => partitionDeploy()
-      case "querymanager"     => queryManagerDeploy()
+      case "spout"                   => spoutDeploy()
+      case "builder"                 => builderDeploy()
+      case "partitionmanager"        => partitionDeploy(false)
+      case "batchedPartitionmanager" => partitionDeploy(true)
+      case "querymanager"            => queryManagerDeploy()
     }
 
   /** Deploy spouts by using `SpoutExecutor` to ingest data from files and resources,
@@ -64,9 +63,9 @@ abstract class RaphtoryService[T: ClassTag] {
   /** Deploy partitions using Partition Manager for creating partitions as distributed
     * storage units with readers and writers. Uses Zookeeper to create partition IDs
     */
-  def partitionDeploy(): Unit =
+  def partitionDeploy(batched: Boolean): Unit =
     Raphtory.createPartitionManager[T](
-            batchLoading = batchIngestion(),
+            batchLoading = batched,
             spout = Some(defineSpout()),
             graphBuilder = Some(defineBuilder)
     )

--- a/core/src/main/scala/com/raphtory/deployment/kubernetes/components/Config.scala
+++ b/core/src/main/scala/com/raphtory/deployment/kubernetes/components/Config.scala
@@ -9,7 +9,7 @@ import com.typesafe.config
 /** Reads kubernetes configuration values from application.conf.
   */
 class Config {
-  val conf: config.Config          = Raphtory.getDefaultConfig()
+  val conf: config.Config          = Raphtory.getDefaultConfig(distributed = true)
   val raphtoryDeploymentId: String = conf.getString("raphtory.deploy.id")
 
   val raphtoryKubernetesNamespaceName: String =

--- a/core/src/main/scala/com/raphtory/spouts/FileSpout.scala
+++ b/core/src/main/scala/com/raphtory/spouts/FileSpout.scala
@@ -186,5 +186,9 @@ object FileSpout {
     new FileSpout[T](source, lineConverter, config)
 
   def apply(source: String = "") =
-    new FileSpout[String](source, lineConverter = s => s, Raphtory.getDefaultConfig())
+    new FileSpout[String](
+            source,
+            lineConverter = s => s,
+            Raphtory.getDefaultConfig(distributed = false)
+    )
 }

--- a/core/src/test/scala/com/raphtory/BaseRaphtoryAlgoTest.scala
+++ b/core/src/test/scala/com/raphtory/BaseRaphtoryAlgoTest.scala
@@ -53,7 +53,7 @@ abstract class BaseRaphtoryAlgoTest[T: ClassTag: TypeTag](deleteResultAfterFinis
     val graphBuilder: GraphBuilder[T] = setGraphBuilder()
 
     graph = Option
-      .when(batchLoading())(Raphtory.batchLoad[T](spout, graphBuilder))
+      .when(batchLoading())(Raphtory.load[T](spout, graphBuilder))
       .fold(Raphtory.stream[T](spout, graphBuilder))(identity)
   }
 

--- a/core/src/test/scala/com/raphtory/algorithms/api/RaphtoryGraphTest.scala
+++ b/core/src/test/scala/com/raphtory/algorithms/api/RaphtoryGraphTest.scala
@@ -8,7 +8,7 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class RaphtoryGraphTest extends AnyFunSuite {
   test("Test overall pipeline syntax for RaphtoryGraph class and related hierarchy") {
-    val graph = Raphtory.deployedGraph()
+    val graph = Raphtory.connect()
     val table = graph
       .from(100)
       .until(500)
@@ -41,7 +41,7 @@ class RaphtoryGraphTest extends AnyFunSuite {
   }
 
   test("Test timestamp format without milliseconds") {
-    val graph = Raphtory.deployedGraph()
+    val graph = Raphtory.connect()
     val query = graph
       .from("2020-02-25 23:12:08")
       .query
@@ -52,7 +52,7 @@ class RaphtoryGraphTest extends AnyFunSuite {
   }
 
   test("Test timestamp format with milliseconds") {
-    val graph = Raphtory.deployedGraph()
+    val graph = Raphtory.connect()
     val query = graph
       .from("2020-02-25 23:12:08.567")
       .query
@@ -63,7 +63,7 @@ class RaphtoryGraphTest extends AnyFunSuite {
   }
 
   test("Test timestamp format with date") {
-    val graph = Raphtory.deployedGraph()
+    val graph = Raphtory.connect()
     val query = graph
       .from("2020-02-25")
       .query
@@ -75,7 +75,7 @@ class RaphtoryGraphTest extends AnyFunSuite {
 
   test("Test timestamp format with custom configuration for 2 digit milliseconds") {
     val conf  = Map("raphtory.query.timeFormat" -> "yyyy-MM-dd HH:mm:ss[.SS]")
-    val graph = Raphtory.deployedGraph(conf)
+    val graph = Raphtory.connect(conf)
     val query = graph
       .from("2020-02-25 23:12:08.56")
       .query
@@ -87,7 +87,7 @@ class RaphtoryGraphTest extends AnyFunSuite {
 
   test("Test timestamp format with custom configuration for hours and minutes") {
     val conf  = Map("raphtory.query.timeFormat" -> "yyyy-MM-dd HH:mm")
-    val graph = Raphtory.deployedGraph(conf)
+    val graph = Raphtory.connect(conf)
     val query = graph
       .from("2020-02-25 12:23")
       .query

--- a/core/src/test/scala/com/raphtory/components/spout/LOTRGraphBuilderTest.scala
+++ b/core/src/test/scala/com/raphtory/components/spout/LOTRGraphBuilderTest.scala
@@ -30,11 +30,10 @@ class LOTRGraphBuilderTest extends AnyFunSuite with BeforeAndAfter {
   val config: Config = Raphtory.getDefaultConfig(
           Map[String, Any](
                   ("raphtory.spout.topic", test_producer_topic),
-                  ("raphtory.partitions.serverCount", 1),
-                  ("raphtory.partitions.countPerServer", 1),
                   ("raphtory.deploy.id", test_graph_builder_topic),
                   ("raphtory.deploy.id", test_graph_builder_topic)
-          )
+          ),
+          distributed = false
   )
 
   val admin: PulsarAdmin                           =

--- a/core/src/test/scala/com/raphtory/ethereumtest/EthereumDistributedTest.scala
+++ b/core/src/test/scala/com/raphtory/ethereumtest/EthereumDistributedTest.scala
@@ -7,9 +7,6 @@ import com.raphtory.spouts.FileSpout
 import org.apache.pulsar.client.api.Schema
 
 object EthereumDistributedTest extends RaphtoryService[String] {
-  override def defineSpout(): Spout[String] = FileSpout()
-
+  override def defineSpout(): Spout[String]        = FileSpout()
   override def defineBuilder: EthereumGraphBuilder = new EthereumGraphBuilder()
-
-  override def batchIngestion(): Boolean = true
 }

--- a/core/src/test/scala/com/raphtory/lotrtest/LOTRDistributedTest.scala
+++ b/core/src/test/scala/com/raphtory/lotrtest/LOTRDistributedTest.scala
@@ -9,10 +9,6 @@ import com.typesafe.config.Config
 import org.apache.pulsar.client.api.Schema
 
 object LOTRDistributedTest extends RaphtoryService[String] {
-  override def defineSpout(): Spout[String] = FileSpout()
-
+  override def defineSpout(): Spout[String]        = FileSpout()
   override def defineBuilder: GraphBuilder[String] = new LOTRGraphBuilder()
-
-  override def batchIngestion(): Boolean = false
-
 }

--- a/core/src/test/scala/com/raphtory/lotrtest/Runner.scala
+++ b/core/src/test/scala/com/raphtory/lotrtest/Runner.scala
@@ -11,7 +11,7 @@ object Runner extends App {
 
   val spout        = FileSpout("/tmp")
   val graphBuilder = new LOTRGraphBuilder()
-  val graph        = Raphtory.batchLoad(spout, graphBuilder)
+  val graph        = Raphtory.load(spout, graphBuilder)
 
   graph.deployment.stop()
   println("should finish here but these threads are still alive")

--- a/docs/source/Analysis/queries.md
+++ b/docs/source/Analysis/queries.md
@@ -3,7 +3,7 @@
 To run your implemented algorithm or any of the algorithms included in Raphtory (both [Generic](com.raphtory.algorithms.generic) and [Temporal](com.raphtory.algorithms.temporal)), you must submit them to the graph. We can again use the [Lord of the Rings
 graph](../Ingestion/sprouter.md) and the [degrees of separation algorithm](LOTR_six_degrees.md) to illustrate the query API.
 
-When running queries, our starting point is always the {scaladoc}`com.raphtory.algorithms.api.TemporalGraph` created from a call to `Raphtory.batchLoad()` or `Raphtory.stream()`. This contains the full history of your data over its lifetime. From this point, the overall process to get things done is as follows: 
+When running queries, our starting point is always the {scaladoc}`com.raphtory.algorithms.api.TemporalGraph` created from a call to `Raphtory.load()` or `Raphtory.stream()`. This contains the full history of your data over its lifetime. From this point, the overall process to get things done is as follows: 
 
 * First, you can filter the timeline to the segment you are interested in. 
 * Secondly, you can create a collection of perspectives over the selected timeline.

--- a/docs/source/Deployment/baremetalsingle.md
+++ b/docs/source/Deployment/baremetalsingle.md
@@ -1,6 +1,6 @@
 # Bare metal
 
-The difference between the two from an analysis perspective is that `batchLoad` will block any submitted queries until the data has finished ingesting - allowing it to handle completely out of order data. On the other hand when using `stream` it is assumed new data is continuously arriving (in roughly chronological order) which Raphtory handles with a watermarking heuristic to decide what time is safe to analyse across all the partitions. Therefore, queries where the perspective time   fully ingested and synchronised allowed to progress and which should be blocked until the time they are set to run at has arrived and has been synchronised.
+The difference between the two from an analysis perspective is that `load` will block any submitted queries until the data has finished ingesting - allowing it to handle completely out of order data. On the other hand when using `stream` it is assumed new data is continuously arriving (in roughly chronological order) which Raphtory handles with a watermarking heuristic to decide what time is safe to analyse across all the partitions. Therefore, queries where the perspective time   fully ingested and synchronised allowed to progress and which should be blocked until the time they are set to run at has arrived and has been synchronised.
 
 
 ## Bare metal single node
@@ -18,20 +18,13 @@ To run Raphtory locally on a macbook/laptop there are several ways this can be a
 
 ## Using Raphtory as a client
 
-Finally, if you have a graph deployed somewhere else and want to submit new queries to it you can do this via the `deployedGraph(customConfig)` method in the `Raphtory` object. The `customConfig` here is to provide the appropriate configuration to locate the graph (i.e. the akka/pulsar address). If the graph is deployed in the same machine using the default Raphtory configuration you can omit this configuration parameter:
+Finally, if you have a graph deployed somewhere else and want to submit new queries to it you can do this via the `connect(customConfig)` method in the `Raphtory` object. The `customConfig` here is to provide the appropriate configuration to locate the graph (i.e. the akka/pulsar address). If the graph is deployed in the same machine using the default Raphtory configuration you can omit this configuration parameter:
 
 ```scala
-val graph = Raphtory.deployedGraph()
+val graph = Raphtory.connect()
 ```
 
 From this point, you can keep working with your graph as we have done so far.
-
-Additionally, you still have access to the `RaphtoryClient` class provided in previous releases of Raphtory. This is, however, deprecated and will be removed in later versions:
-
-```scala
-val client = Raphtory.createClient()
-client.pointQuery(ConnectedComponents(), output, 10000)
-```
 
 ## Bare metal distributed -- Raphtory services
 

--- a/docs/source/Ingestion/sprouter.md
+++ b/docs/source/Ingestion/sprouter.md
@@ -7,7 +7,7 @@ Two classes help with this:
 - `Spouts` connect to the outside world, reading the data files and outputting individual tuples.
 - `Graph builders`, as the name suggests, convert these tuples into updates, building the graph.
 
-Once these classes are defined, they can be passed to the `stream()` or `batchLoad()` methods on the {scaladoc}`com.raphtory.deployment.Raphtory` object, which will use both components to build the {scaladoc}`com.raphtory.algorithms.TemporalGraph`. The difference here is that `stream()` will launch the full pipeline on top of [Apache Pulsar](https://pulsar.apache.org) (which you will see later in the tutorial) and assume new data can continuously arrive. `batchLoad()` on the other hand will compress the Spout and Graph Builder functions together, running as fast as possible, but only on a static dataset which does not change. For these initial examples we will only run `batchLoad()` as the data is static and we can set it going out of the box!
+Once these classes are defined, they can be passed to the `stream()` or `load()` methods on the {scaladoc}`com.raphtory.deployment.Raphtory` object, which will use both components to build the {scaladoc}`com.raphtory.algorithms.TemporalGraph`. The difference here is that `stream()` will launch the full pipeline on top of [Apache Pulsar](https://pulsar.apache.org) (which you will see later in the tutorial) and assume new data can continuously arrive. `load()` on the other hand will compress the Spout and Graph Builder functions together, running as fast as possible, but only on a static dataset which does not change. For these initial examples we will only run `load()` as the data is static and we can set it going out of the box!
 
 If you have the LOTR example already set up from the installation guide previously ([raphtory-example-lotr](https://github.com/Raphtory/Raphtory/tree/master/examples/raphtory-example-lotr)) then please continue. If not, YOU SHALL NOT PASS! Please return there and complete this step first.  
 
@@ -29,7 +29,7 @@ Gollum,Bilbo,308
 Also, in the examples folder you will find `LOTRGraphBuilder.scala`, `DegreesSeparation.scala` and `FileOutputRunner.scala` which we will go through in detail. 
 
 ## Local Deployment
-First lets open `FileOutputRunner.scala`, which is our `main` class i.e. the file which we actually run. To do this we have made our class a scala app via `extends App`. This is a short hand for creating your runnable main class (if you come from a Java background) or can be viewed as a script if you are more comfortable with Python. Inside of this we can create spout and graphbuilder objects and combine them into a {scaladoc}`com.raphtory.algorithms.TemporalGraph` (via `batchLoad()`), which can be used to make queries:
+First lets open `FileOutputRunner.scala`, which is our `main` class i.e. the file which we actually run. To do this we have made our class a scala app via `extends App`. This is a short hand for creating your runnable main class (if you come from a Java background) or can be viewed as a script if you are more comfortable with Python. Inside of this we can create spout and graphbuilder objects and combine them into a {scaladoc}`com.raphtory.algorithms.TemporalGraph` (via `load()`), which can be used to make queries:
 
 ````scala
 object FileOutputRunner extends App {
@@ -40,7 +40,7 @@ object FileOutputRunner extends App {
 
   val source  = FileSpout(path)
   val builder = new LOTRGraphBuilder()
-  val graph   = Raphtory.batchLoad(spout = source, graphBuilder = builder)
+  val graph   = Raphtory.load(spout = source, graphBuilder = builder)
   val output  = FileOutputFormat("/tmp/raphtory")
 
   val queryHandler = graph
@@ -53,7 +53,7 @@ object FileOutputRunner extends App {
 }
 ````
 
-**Note:** Once `Raphtory.batchLoad` is called, we can start submitting queries to it - which can be seen in the snippet above. Don't worry about this yet as we will dive into it in the next section.
+**Note:** Once `Raphtory.load` is called, we can start submitting queries to it - which can be seen in the snippet above. Don't worry about this yet as we will dive into it in the next section.
 
 ## Spout
 

--- a/examples/raphtory-example-ethereum/src/main/scala/com/raphtory/ethereum/Distributed.scala
+++ b/examples/raphtory-example-ethereum/src/main/scala/com/raphtory/ethereum/Distributed.scala
@@ -13,9 +13,6 @@ object Distributed extends RaphtoryService[String] {
   val url  = "https://raw.githubusercontent.com/Raphtory/Data/main/etherscan_tags.csv"
   FileUtils.curlFile(path, url)
 
-  override def defineSpout(): Spout[String] = FileSpout("/tmp/etherscan_tags.csv")
-
+  override def defineSpout(): Spout[String]        = FileSpout("/tmp/etherscan_tags.csv")
   override def defineBuilder: EthereumGraphBuilder = new EthereumGraphBuilder()
-
-  override def batchIngestion(): Boolean = true
 }

--- a/examples/raphtory-example-ethereum/src/main/scala/com/raphtory/ethereum/LocalRunner.scala
+++ b/examples/raphtory-example-ethereum/src/main/scala/com/raphtory/ethereum/LocalRunner.scala
@@ -28,7 +28,7 @@ object LocalRunner extends App {
   // create graph
   val source  = FileSpout("/tmp/etherscan_tags.csv")
   val builder = new EthereumGraphBuilder()
-  val graph   = Raphtory.batchLoad(source, builder)
+  val graph   = Raphtory.load(source, builder)
 
   // setup ethereum vars
   val startTime = 1574814233

--- a/examples/raphtory-example-facebook/src/main/scala/com.raphtory.examples.facebook/Runner.scala
+++ b/examples/raphtory-example-facebook/src/main/scala/com.raphtory.examples.facebook/Runner.scala
@@ -33,7 +33,7 @@ object Runner extends App {
 
   val source: StaticGraphSpout = StaticGraphSpout("/tmp/facebook.csv")
   val builder                  = new FacebookGraphBuilder()
-  val graph                    = Raphtory.batchLoad(spout = source, graphBuilder = builder)
+  val graph                    = Raphtory.load(spout = source, graphBuilder = builder)
   Thread.sleep(20000)
   graph.at(88234).past().execute(EdgeList()).writeTo(PulsarOutputFormat("EdgeList"))
   graph

--- a/examples/raphtory-example-facebook/src/main/scala/com.raphtory.examples.facebook/Runner.scala
+++ b/examples/raphtory-example-facebook/src/main/scala/com.raphtory.examples.facebook/Runner.scala
@@ -29,7 +29,6 @@ object Runner extends App {
         throw ex
     }
   }
-  val conf: config.Config = Raphtory.getDefaultConfig()
 
   val source: StaticGraphSpout = StaticGraphSpout("/tmp/facebook.csv")
   val builder                  = new FacebookGraphBuilder()

--- a/examples/raphtory-example-lotr/src/main/scala/com/raphtory/examples/lotrTopic/FileOutputRunner.scala
+++ b/examples/raphtory-example-lotr/src/main/scala/com/raphtory/examples/lotrTopic/FileOutputRunner.scala
@@ -25,7 +25,7 @@ object FileOutputRunner extends App {
 
   val source  = FileSpout(path)
   val builder = new LOTRGraphBuilder()
-  val graph   = Raphtory.batchLoad(spout = source, graphBuilder = builder)
+  val graph   = Raphtory.load(spout = source, graphBuilder = builder)
   val output  = FileOutputFormat("/tmp/raphtory")
 
   val queryHandler = graph

--- a/examples/raphtory-example-lotr/src/main/scala/com/raphtory/examples/lotrTopic/PulsarOutputRunner.scala
+++ b/examples/raphtory-example-lotr/src/main/scala/com/raphtory/examples/lotrTopic/PulsarOutputRunner.scala
@@ -20,7 +20,7 @@ object PulsarOutputRunner extends App {
   // Create Graph
   val source  = FileSpout(path)
   val builder = new LOTRGraphBuilder()
-  val graph   = Raphtory.batchLoad(spout = source, graphBuilder = builder)
+  val graph   = Raphtory.load(spout = source, graphBuilder = builder)
 
   // Run algorithms
   graph

--- a/python/raphtoryclient/client.py
+++ b/python/raphtoryclient/client.py
@@ -119,7 +119,7 @@ class client:
         customConfig = {"raphtory.deploy.id": self._raphtory_deployment_id, "raphtory.deploy.distributed": True}
         mc_run_map_dict = MapConverter().convert(customConfig, self.gateway._gateway_client)
         jmap = self.gateway.jvm.PythonUtil.toScalaMap(mc_run_map_dict)
-        graph = self.gateway.jvm.Raphtory.deployedGraph(jmap)
+        graph = self.gateway.jvm.Raphtory.connect(jmap)
         print("Created Raphtory java object.")
         return graph
 

--- a/python/raphtoryclient/client.py
+++ b/python/raphtoryclient/client.py
@@ -116,7 +116,7 @@ class client:
             graph: raphtory client graph object
         '''
         print("Creating Raphtory java object...")
-        customConfig = {"raphtory.deploy.id": self._raphtory_deployment_id, "raphtory.deploy.distributed": True}
+        customConfig = {"raphtory.deploy.id": self._raphtory_deployment_id}
         mc_run_map_dict = MapConverter().convert(customConfig, self.gateway._gateway_client)
         jmap = self.gateway.jvm.PythonUtil.toScalaMap(mc_run_map_dict)
         graph = self.gateway.jvm.Raphtory.connect(jmap)


### PR DESCRIPTION
The Watermarker inside of the `QueryManager` has been causing some issues recently as it is accessed in parallel from spawned `QueryHandlers` - this can cause Errors to be thrown as well as the Handlers just hanging forever. 

Whilst this is going to be redesigned soon as a stopgap I have swapped the Watermark map to a concurrent `TrieMap` which should be fine to be updated by the `Query Manager` alongside the reading inside the `QueryHandlers`