### PR TITLE
Add nodeCount to GraphState

### DIFF
--- a/core/src/main/scala/com/raphtory/algorithms/generic/MaxFlow.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/generic/MaxFlow.scala
@@ -69,11 +69,10 @@ class MaxFlow[T](
 )(implicit numeric: Numeric[T])
         extends Generic {
 
-  override def apply(graph: GraphPerspective): graph.Graph = {
-    val n =
-      1 // graph.nodeCount().toDouble TODO: nodeCount() is not available anymore, needs a solution
+  override def apply(graph: GraphPerspective): graph.Graph =
     graph
-      .step { vertex =>
+      .step { (vertex, graphState) =>
+        val n = graphState.nodeCount
         if (vertex.name() == source) {
           val flow = mutable.Map[vertex.IDType, T]()
           vertex.setState("distanceLabel", n)
@@ -166,7 +165,6 @@ class MaxFlow[T](
               maxIterations,
               executeMessagedOnly = true
       )
-  }
 
   override def tabularise(graph: GraphPerspective): Table =
     graph.explodeSelect(vertex =>

--- a/core/src/main/scala/com/raphtory/api/analysis/algorithm/BaseAlgorithm.scala
+++ b/core/src/main/scala/com/raphtory/api/analysis/algorithm/BaseAlgorithm.scala
@@ -29,7 +29,10 @@ private[api] trait BaseAlgorithm extends Serializable {
   private[raphtory] def run(graph: In): Table = tabularise(apply(graph))
 
   /** The name of the algorithm (returns the simple class name by default) */
-  def name: String = getClass.getSimpleName
+  def name: String = {
+    val name = getClass.getSimpleName
+    name.stripSuffix("$")
+  }
 
   /** Create a new algorithm which runs this algorithm first before
     *  running the other algorithm.

--- a/core/src/main/scala/com/raphtory/api/analysis/graphstate/GraphState.scala
+++ b/core/src/main/scala/com/raphtory/api/analysis/graphstate/GraphState.scala
@@ -225,6 +225,9 @@ abstract class GraphState {
     */
   def newAny(name: String, retainState: Boolean = false): Unit
 
+  /** Get the number of nodes in the graph */
+  def nodeCount: Int
+
   /** Retrieve accumulator
     * $iType
     * $vType

--- a/core/src/main/scala/com/raphtory/api/analysis/graphstate/GraphStateImplementation.scala
+++ b/core/src/main/scala/com/raphtory/api/analysis/graphstate/GraphStateImplementation.scala
@@ -119,7 +119,7 @@ private object HistogramAccumulatorImplementation {
     new HistogramAccumulatorImplementation[T](noBins, minValue, maxValue, retainState)
 }
 
-private[raphtory] class GraphStateImplementation extends GraphState {
+private[raphtory] class GraphStateImplementation(override val nodeCount: Int) extends GraphState {
   private val accumulatorState = mutable.Map.empty[String, AccumulatorImplementation[Any, Any]]
   private val histogramState   = mutable.Map.empty[String, HistogramImplementation[Any]]
 
@@ -207,6 +207,6 @@ private[raphtory] class GraphStateImplementation extends GraphState {
 }
 
 private[raphtory] object GraphStateImplementation {
-  def apply() = new GraphStateImplementation
-  val empty   = new GraphStateImplementation
+  def apply(nodeCount: Int) = new GraphStateImplementation(nodeCount)
+  val empty                 = new GraphStateImplementation(0)
 }

--- a/core/src/main/scala/com/raphtory/api/analysis/visitor/Edge.scala
+++ b/core/src/main/scala/com/raphtory/api/analysis/visitor/Edge.scala
@@ -118,7 +118,7 @@ trait Edge extends EntityVisitor {
     *                 property is not found.
     */
   def weight[A: Numeric](default: A): A =
-    weight("weight", PropertyMergeStrategy.sum[A], default)
+    weight("weight", default)
 
   /** Compute the weight of the edge by sum
     *
@@ -126,14 +126,14 @@ trait Edge extends EntityVisitor {
     * @param weightProperty  edge property to use for computing edge weight
     */
   def weight[A: Numeric](weightProperty: String): A =
-    weight(weightProperty, PropertyMergeStrategy.sum[A], 1: A)
+    weight(weightProperty, 1: A)
 
   /** Compute the weight of the edge by sum
     *
     * @tparam A value type for the edge weight property (if `mergeStrategy` is not given, this needs to be a numeric type)
     */
   def weight[A: Numeric](): A =
-    weight("weight", PropertyMergeStrategy.sum[A], 1: A)
+    weight("weight", 1: A)
 
   //send a message to the vertex on the other end of the edge
   /** Send a message to the destination vertex of the edge

--- a/core/src/main/scala/com/raphtory/api/analysis/visitor/ExplodedEdge.scala
+++ b/core/src/main/scala/com/raphtory/api/analysis/visitor/ExplodedEdge.scala
@@ -8,4 +8,8 @@ package com.raphtory.api.analysis.visitor
   *
   * @see [[Edge]] [[ExplodedEntityVisitor]]
   */
-trait ExplodedEdge extends Edge with ExplodedEntityVisitor
+trait ExplodedEdge extends Edge with ExplodedEntityVisitor {
+
+  override def weight[A: Numeric](weightProperty: String, default: A): A =
+    weight(weightProperty, PropertyMergeStrategy.latest[A], default)
+}

--- a/core/src/main/scala/com/raphtory/internals/components/querymanager/QueryHandler.scala
+++ b/core/src/main/scala/com/raphtory/internals/components/querymanager/QueryHandler.scala
@@ -189,7 +189,7 @@ class QueryHandler(
       case StartGraph                                                                         =>
         graphFunctions = mutable.Queue.from(query.graphFunctions)
         tableFunctions = mutable.Queue.from(query.tableFunctions)
-        graphState = GraphStateImplementation()
+        graphState = GraphStateImplementation(vertexCount)
         val startingGraphTime = System.currentTimeMillis() - timeTaken
         logger.debug(
                 s"Job '$jobID': Sending self GraphStart took ${startingGraphTime}ms. Executing next graph operation."
@@ -373,7 +373,8 @@ class QueryHandler(
         logTotalTimeTaken(perspective)
         messagetoAllJobWorkers(CreatePerspective(currentPerspectiveID, perspective))
         currentPerspective = perspective
-        graphState = GraphStateImplementation()
+        graphState = GraphStateImplementation.empty
+        vertexCount = 0
         graphFunctions = null
         tableFunctions = null
         val localPerspectiveSetupTime = System.currentTimeMillis() - timeTaken

--- a/core/src/main/scala/com/raphtory/internals/storage/pojograph/PojoBasedPartition.scala
+++ b/core/src/main/scala/com/raphtory/internals/storage/pojograph/PojoBasedPartition.scala
@@ -333,6 +333,7 @@ class PojoBasedPartition(partition: Int, conf: Config)
         logger.trace(s"Added properties: $properties to edge")
       case None       =>
         val edge = new SplitEdge(msgTime, srcId, dstId, initialValue = true)
+        addProperties(msgTime, edge, properties)
         dstVertex addIncomingEdge edge //add the edge to the associated edges of the destination node
     }
   }

--- a/core/src/test/scala/com/raphtory/BaseCorrectnessTest.scala
+++ b/core/src/test/scala/com/raphtory/BaseCorrectnessTest.scala
@@ -36,7 +36,7 @@ abstract class BaseCorrectnessTest extends BaseRaphtoryAlgoTest[String] {
       resultsResource: String,
       lastTimestamp: Int
   ): Boolean = {
-    graph = Raphtory.stream(ResourceSpout(graphResource), setGraphBuilder())
+    graph = Raphtory.load(ResourceSpout(graphResource), setGraphBuilder())
 
     val res = algorithmPointTest(
             algorithm,
@@ -54,7 +54,7 @@ abstract class BaseCorrectnessTest extends BaseRaphtoryAlgoTest[String] {
       results: Seq[String],
       lastTimestamp: Int
   ): Boolean = {
-    graph = Raphtory.stream(SequenceSpout(graphEdges: _*), setGraphBuilder())
+    graph = Raphtory.load(SequenceSpout(graphEdges: _*), setGraphBuilder())
     val res = algorithmPointTest(
             algorithm,
             lastTimestamp

--- a/core/src/test/scala/com/raphtory/BaseRaphtoryAlgoTest.scala
+++ b/core/src/test/scala/com/raphtory/BaseRaphtoryAlgoTest.scala
@@ -103,7 +103,7 @@ abstract class BaseRaphtoryAlgoTest[T: ClassTag: TypeTag](deleteResultAfterFinis
 
     queryProgressTracker.waitForJob()
 
-    generateTestHash(outputDirectory + s"/$jobId")
+    generateTestHash(jobId)
   }
 
   def algorithmPointTest(
@@ -122,7 +122,7 @@ abstract class BaseRaphtoryAlgoTest[T: ClassTag: TypeTag](deleteResultAfterFinis
 
     queryProgressTracker.waitForJob()
 
-    generateTestHash(outputDirectory + s"/$jobId")
+    generateTestHash(jobId)
   }
 
   def resultsHash(results: IterableOnce[String]): String =
@@ -131,12 +131,12 @@ abstract class BaseRaphtoryAlgoTest[T: ClassTag: TypeTag](deleteResultAfterFinis
       .hashString(results.iterator.toSeq.sorted.mkString, StandardCharsets.UTF_8)
       .toString
 
-  private def generateTestHash(outputPath: String): String = {
-    val files = new File(outputPath)
+  def getResults(jobID: String = jobId): Iterator[String] = {
+    val files = new File(outputDirectory + "/" + jobID)
       .listFiles()
       .filter(_.isFile)
 
-    val results = files.iterator.flatMap { file =>
+    files.iterator.flatMap { file =>
       val source = scala.io.Source.fromFile(file)
       try source.getLines().toList
       catch {
@@ -144,8 +144,11 @@ abstract class BaseRaphtoryAlgoTest[T: ClassTag: TypeTag](deleteResultAfterFinis
       }
       finally source.close()
     }
+  }
 
-    val hash = resultsHash(results)
+  private def generateTestHash(jobId: String = jobId): String = {
+    val results = getResults(jobId)
+    val hash    = resultsHash(results)
     logger.info(s"Generated hash code: '$hash'.")
 
     hash

--- a/core/src/test/scala/com/raphtory/BaseRaphtoryAlgoTest.scala
+++ b/core/src/test/scala/com/raphtory/BaseRaphtoryAlgoTest.scala
@@ -63,7 +63,7 @@ abstract class BaseRaphtoryAlgoTest[T: ClassTag: TypeTag](deleteResultAfterFinis
     super.withFixture(test) match {
       case failed: Failed =>
         info(s"The test '${test.name}' failed. Keeping test results for inspection.")
-        info(getResults(jobId).take(100).mkString("\n"))
+        info("Results (first 100 rows):\n" + getResults(jobId).take(100).mkString("\n"))
         failed
       case other          =>
         if (deleteResultAfterFinish)
@@ -80,7 +80,7 @@ abstract class BaseRaphtoryAlgoTest[T: ClassTag: TypeTag](deleteResultAfterFinis
 
   def setSpout(): Spout[T]
   def setGraphBuilder(): GraphBuilder[T]
-  def batchLoading(): Boolean                                               = false
+  def batchLoading(): Boolean                                               = true
   def setup(): Unit = {}
 
   def receiveMessage(consumer: Consumer[Array[Byte]]): Message[Array[Byte]] =

--- a/core/src/test/scala/com/raphtory/BaseRaphtoryAlgoTest.scala
+++ b/core/src/test/scala/com/raphtory/BaseRaphtoryAlgoTest.scala
@@ -63,6 +63,7 @@ abstract class BaseRaphtoryAlgoTest[T: ClassTag: TypeTag](deleteResultAfterFinis
     super.withFixture(test) match {
       case failed: Failed =>
         info(s"The test '${test.name}' failed. Keeping test results for inspection.")
+        info(getResults(jobId).take(100).mkString("\n"))
         failed
       case other          =>
         if (deleteResultAfterFinish)

--- a/core/src/test/scala/com/raphtory/api/analysis/graphstate/AccumulatorTest.scala
+++ b/core/src/test/scala/com/raphtory/api/analysis/graphstate/AccumulatorTest.scala
@@ -1,14 +1,18 @@
-package com.raphtory.api
+package com.raphtory.api.analysis.graphstate
 
 import com.raphtory.BaseCorrectnessTest
+import com.raphtory.BasicGraphBuilder
+import com.raphtory.Raphtory
 import com.raphtory.api.analysis.algorithm.Generic
 import com.raphtory.api.analysis.graphstate.GraphState
+import com.raphtory.api.analysis.graphview.Alignment
 import com.raphtory.api.analysis.graphview.GraphPerspective
 import com.raphtory.api.analysis.table.Row
 import com.raphtory.api.analysis.table.Table
 import com.raphtory.api.analysis.visitor.Vertex
+import com.raphtory.spouts.ResourceSpout
 
-class CountNodes extends Generic {
+object CountNodes extends Generic {
 
   override def apply(graph: GraphPerspective): graph.Graph =
     graph
@@ -25,11 +29,7 @@ class CountNodes extends Generic {
 
 }
 
-object CountNodes {
-  def apply() = new CountNodes
-}
-
-class CountNodesTwice extends Generic {
+object CountNodesTwice extends Generic {
 
   override def apply(graph: GraphPerspective): graph.Graph =
     graph
@@ -51,21 +51,29 @@ class CountNodesTwice extends Generic {
       .globalSelect { graphState: GraphState =>
         Row(graphState("nodeCount").value, graphState("nodeCountDoubled").value)
       }
-
 }
 
-object CountNodesTwice {
-  def apply() = new CountNodesTwice
+object CheckNodeCount extends Generic {
+
+  override def apply(graph: GraphPerspective): graph.Graph =
+    CountNodes(graph)
+
+  override def tabularise(graph: GraphPerspective): Table =
+    graph.globalSelect { graphState =>
+      val n: Int = graphState("nodeCount").value
+      Row(graphState.nodeCount == n)
+    }
 }
 
 class AccumulatorTest extends BaseCorrectnessTest {
+
   test("Test accumulators by counting nodes") {
-    assert(correctnessTest(CountNodes(), "MotifCount/motiftest.csv", "Accumulator/results.csv", 23))
+    assert(correctnessTest(CountNodes, "MotifCount/motiftest.csv", "Accumulator/results.csv", 23))
   }
   test("Test resetting of accumulators by running CountNodes twice (should not change result)") {
     assert(
             correctnessTest(
-                    CountNodes() -> CountNodes(),
+                    CountNodes -> CountNodes,
                     "MotifCount/motiftest.csv",
                     "Accumulator/results.csv",
                     23
@@ -75,11 +83,29 @@ class AccumulatorTest extends BaseCorrectnessTest {
   test("Test rotation of accumulators and state retention by running counting nodes twice") {
     assert(
             correctnessTest(
-                    CountNodesTwice(),
+                    CountNodesTwice,
                     "MotifCount/motiftest.csv",
                     "Accumulator/results2.csv",
                     23
             )
     )
+  }
+
+  test("Test nodeCount on graph state is consistent for multiple perspectives") {
+    graph = Raphtory.load(ResourceSpout("MotifCount/motiftest.csv"), BasicGraphBuilder())
+    val job = graph
+      .range(10, 23, 1)
+      .window(10, Alignment.END)
+      .execute(CheckNodeCount)
+      .writeTo(defaultSink)
+
+    job
+      .waitForJob()
+
+    getResults(job.getJobId).foreach { res =>
+      val t = res.split(",")
+      t(t.size - 1).shouldEqual("true")
+    }
+    graph.deployment.stop()
   }
 }

--- a/core/src/test/scala/com/raphtory/api/analysis/graphstate/AccumulatorTest.scala
+++ b/core/src/test/scala/com/raphtory/api/analysis/graphstate/AccumulatorTest.scala
@@ -99,10 +99,10 @@ class AccumulatorTest extends BaseCorrectnessTest {
       .execute(CheckNodeCount)
       .writeTo(defaultSink)
 
-    job
-      .waitForJob()
+    jobId = job.getJobId
+    job.waitForJob()
 
-    getResults(job.getJobId).foreach { res =>
+    getResults().foreach { res =>
       val t = res.split(",")
       t(t.size - 1).shouldEqual("true")
     }

--- a/core/src/test/scala/com/raphtory/api/analysis/graphview/RaphtoryGraphTest.scala
+++ b/core/src/test/scala/com/raphtory/api/analysis/graphview/RaphtoryGraphTest.scala
@@ -1,11 +1,7 @@
-package com.raphtory.api
+package com.raphtory.api.analysis.graphview
 
 import com.raphtory.Raphtory
 import com.raphtory.algorithms.generic.ConnectedComponents
-import com.raphtory.api.analysis.graphview.ClearChain
-import com.raphtory.api.analysis.graphview.Iterate
-import com.raphtory.api.analysis.graphview.Select
-import com.raphtory.api.analysis.graphview.Step
 import com.raphtory.api.analysis.table.Row
 import com.raphtory.api.analysis.table.TableFilter
 import com.raphtory.api.analysis.table.TableImplementation

--- a/core/src/test/scala/com/raphtory/api/analysis/graphview/TestIteration.scala
+++ b/core/src/test/scala/com/raphtory/api/analysis/graphview/TestIteration.scala
@@ -1,8 +1,7 @@
-package com.raphtory.api
+package com.raphtory.api.analysis.graphview
 
 import com.raphtory.BaseCorrectnessTest
 import com.raphtory.api.analysis.algorithm.Generic
-import com.raphtory.api.analysis.graphview.GraphPerspective
 import com.raphtory.api.analysis.table.Row
 import com.raphtory.api.analysis.table.Table
 import com.raphtory.api.analysis.visitor.Vertex

--- a/core/src/test/scala/com/raphtory/api/analysis/graphview/TimeSeriesTest.scala
+++ b/core/src/test/scala/com/raphtory/api/analysis/graphview/TimeSeriesTest.scala
@@ -1,4 +1,4 @@
-package com.raphtory.api
+package com.raphtory.api.analysis.graphview
 
 import com.raphtory.BaseCorrectnessTest
 import com.raphtory.TimeSeriesGraphState

--- a/core/src/test/scala/com/raphtory/lotrtest/LotrTest.scala
+++ b/core/src/test/scala/com/raphtory/lotrtest/LotrTest.scala
@@ -34,8 +34,6 @@ import sys.process._
 
 class LotrTest extends BaseRaphtoryAlgoTest[String] {
 
-  override def batchLoading(): Boolean = false
-
   test("Graph State Test") {
     val result = algorithmTest(
             algorithm = GraphState(),

--- a/core/src/test/scala/com/raphtory/stateTest/AllCommandsTest.scala
+++ b/core/src/test/scala/com/raphtory/stateTest/AllCommandsTest.scala
@@ -54,8 +54,6 @@ class AllCommandsTest extends BaseRaphtoryAlgoTest[String] {
     assert(results equals "ba662e8fe795c263566b1898c0f1fc6816c3f6ef5e6bbbce9db6cd06330f47a8")
   }
 
-  override def batchLoading(): Boolean = false
-
   override def setSpout(): Spout[String] = FileSpout()
 
   override def setGraphBuilder(): GraphBuilder[String] = new AllCommandsBuilder()


### PR DESCRIPTION
This adds a nodeCount method to the global GraphState object for use by algorithms

Also adds a test to make sure the nodeCount is correct when running a job with multiple perspectives.