### PR TITLE
Clean up scaladoc links and structure

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -152,7 +152,7 @@ lazy val examplesTwitter =
 
 lazy val deploy =
   (project in file("deploy"))
-  .settings(assemblySettings)
+    .settings(assemblySettings)
 
 // SETTINGS
 

--- a/core/src/main/scala/com/raphtory/Raphtory.scala
+++ b/core/src/main/scala/com/raphtory/Raphtory.scala
@@ -28,9 +28,9 @@ import scala.reflect.runtime.universe.TypeTag
   *
   * Usage:
   * {{{
-  * import com.raphtory.deployment.Raphtory
-  * import com.raphtory.components.spout.instance.ResourceSpout
-  * import com.raphtory.GraphState
+  * import com.raphtory.Raphtory
+  * import com.raphtory.spouts.ResourceSpout
+  * import com.raphtory.api.analysis.graphstate.GraphState
   * import com.raphtory.sinks.FileSink
   *
   * val builder = new YourGraphBuilder()
@@ -45,10 +45,10 @@ import scala.reflect.runtime.universe.TypeTag
   * graph.deployment.stop()
   * }}}
   *
-  * @see [[GraphBuilder]]
-  *      [[Spout]]
-  *      [[DeployedTemporalGraph]]
-  *      [[TemporalGraph]]
+  * @see [[api.input.GraphBuilder]]
+  *      [[api.input.Spout]]
+  *      [[api.analysis.graphview.DeployedTemporalGraph]]
+  *      [[api.analysis.graphview.TemporalGraph]]
   */
 object Raphtory {
   private val logger: Logger = Logger(LoggerFactory.getLogger(this.getClass))

--- a/core/src/main/scala/com/raphtory/RaphtoryService.scala
+++ b/core/src/main/scala/com/raphtory/RaphtoryService.scala
@@ -24,7 +24,7 @@ import scala.reflect.ClassTag
   * }
   * }}}
   *
-  *  @see [[GraphBuilder]] [[Spout]]
+  *  @see [[api.input.GraphBuilder]] [[api.input.Spout]]
   */
 abstract class RaphtoryService[T: ClassTag] {
   private val logger: Logger = Logger(LoggerFactory.getLogger(this.getClass))

--- a/core/src/main/scala/com/raphtory/api/analysis/algorithm/Identity.scala
+++ b/core/src/main/scala/com/raphtory/api/analysis/algorithm/Identity.scala
@@ -3,6 +3,9 @@ package com.raphtory.api.analysis.algorithm
 /**
   * Identity algorithm that does nothing and outputs an empty table (useful as a default argument for optional steps)
   *
-  * @see [[Generic]], [[com.raphtory.algorithms.generic.CBOD]]
+  * @see [[Generic]], <a href="../../../../../../_autodoc/com/raphtory/algorithms/generic/CBOD.html"
+  *  class="extype"
+  *  title="com.raphtory.algorithms.generic.CBOD"
+  * >CBOD</a>
   */
 object Identity extends Generic {}

--- a/core/src/main/scala/com/raphtory/api/analysis/graphstate/GraphState.scala
+++ b/core/src/main/scala/com/raphtory/api/analysis/graphstate/GraphState.scala
@@ -12,7 +12,7 @@ import com.raphtory.utils.ExtendedNumeric._
   *  Graph-level state takes the form of accumulators which expose the value computed during the last step/iteration
   *  and allow accumulation of new state based on a reduction function.
   *
-  * @see [[GraphPerspective]], [[Accumulator]]
+  * @see [[analysis.graphview.GraphPerspective GraphPerspective]], [[Accumulator]]
   *
   * @define retainState @param retainState If `true`, accumulation for the next step/iteration of an algorithm continues with the
   *                                        previously computed value, otherwise, the value is reset to `initialValue`` before each step.

--- a/core/src/main/scala/com/raphtory/api/analysis/graphview/DeployedTemporalGraph.scala
+++ b/core/src/main/scala/com/raphtory/api/analysis/graphview/DeployedTemporalGraph.scala
@@ -9,11 +9,11 @@ import com.typesafe.config.Config
   * A DeployedTemporalGraph is a [[TemporalGraph]]
   * with a [[Deployment]] object attached to it that allows to stop it.
   * To create a `DeployedTemporalGraph` use the `stream` or `load` method
-  * of the [[com.raphtory.Raphtory]] object.
+  * of the [[com.raphtory.Raphtory Raphtory]] object.
   *
   * @param deployment The deployment object used to control Raphtory
   *
-  * @see [[TemporalGraph]], [[Deployment]], [[com.raphtory.Raphtory]]
+  * @see [[TemporalGraph]], [[Deployment]], [[com.raphtory.Raphtory Raphtory]]
   */
 class DeployedTemporalGraph private[raphtory] (
     override private[api] val query: Query,

--- a/core/src/main/scala/com/raphtory/api/analysis/graphview/DottedGraph.scala
+++ b/core/src/main/scala/com/raphtory/api/analysis/graphview/DottedGraph.scala
@@ -1,7 +1,7 @@
 package com.raphtory.api.analysis.graphview
 
-import com.raphtory.internals.time.DiscreteInterval
-import com.raphtory.internals.time.Interval
+import com.raphtory.api.time.DiscreteInterval
+import com.raphtory.api.time.Interval
 import com.raphtory.internals.time.IntervalParser.{parse => parseInterval}
 
 import scala.reflect.ClassTag

--- a/core/src/main/scala/com/raphtory/api/analysis/graphview/GraphPerspective.scala
+++ b/core/src/main/scala/com/raphtory/api/analysis/graphview/GraphPerspective.scala
@@ -89,9 +89,9 @@ trait GraphPerspective {
   /** Switch to multilayer view
     *
     * After calling `multilayerView`, subsequent methods that manipulate vertices act on
-    * [[ExplodedVertex]] instead. If [[ExplodedVertex]]
+    * [[visitor.ExplodedVertex ExplodedVertex]] instead. If [[visitor.ExplodedVertex ExplodedVertex]]
     * instances were already created by a previous call to `multilayerView`, they are preserved. Otherwise, this
-    * method creates an [[ExplodedVertex]] instance for each
+    * method creates an [[visitor.ExplodedVertex ExplodedVertex]] instance for each
     * timepoint that a vertex is active.
     */
   def multilayerView: MultilayerGraph
@@ -99,21 +99,21 @@ trait GraphPerspective {
   /** Switch to multilayer view and add interlayer edges.
     *
     * @param interlayerEdgeBuilder Interlayer edge builder to create interlayer edges for each vertex. See
-    *                              [[visitor.InterlayerEdgeBuilders]] for predefined options.
+    *                              [[visitor.InterlayerEdgeBuilders InterlayerEdgeBuilders]] for predefined options.
     *
-    * Existing `ExplodedVertex` instances are preserved but all interlayer edges are recreated using the supplied
+    * Existing [[visitor.ExplodedVertex ExplodedVertex]] instances are preserved but all interlayer edges are recreated using the supplied
     * `interlayerEdgeBuilder`.
     */
   def multilayerView(
       interlayerEdgeBuilder: visitor.Vertex => Seq[InterlayerEdge] = _ => Seq()
   ): MultilayerGraph
 
-  /** Switch computation to act on [[visitor.Vertex]], inverse of `multilayerView`
+  /** Switch computation to act on [[visitor.Vertex Vertex]], inverse of `multilayerView`
     *
     * This operation does nothing if the view is already reduced. Otherwise it switches back to running computations
-    * on vertices but preserves any existing [[ExplodedVertex]] instances
+    * on vertices but preserves any existing [[visitor.ExplodedVertex ExplodedVertex]] instances
     * created by previous calls to `multilayerView` to allow switching back-and-forth between views while
-    * preserving computational state. Computational state on [[ExplodedVertex]]
+    * preserving computational state. Computational state on [[visitor.ExplodedVertex ExplodedVertex]]
     * instances is not accessible from the `Vertex` unless a merge strategy is supplied (see below).
     */
   def reducedView: ReducedGraph
@@ -201,7 +201,7 @@ trait GraphPerspective {
 
   /** Write output to table with one row per vertex
     *
-    * @parm f function to extract data from vertex (run once for each vertex)
+    * @param f function to extract data from vertex (run once for each vertex)
     */
   def select(f: Vertex => Row): Table
 
@@ -261,182 +261,45 @@ private[api] trait ConcreteGraphPerspective[V <: visitor.Vertex, G <: ConcreteGr
   //
   // Once this bug is fixed, these definitions should be removed again.
 
-  /** Add a function to manipulate global graph state, mainly used to initialise accumulators before the next algorithm step
-    *
-    * @param f function to set graph state (runs exactly once)
-    */
   def setGlobalState(f: (GraphState) => Unit): Graph
-
-  /** Filter vertices of the graph
-    *
-    * @param f filter function (only vertices for which `f` returns `true` are kept)
-    */
   def vertexFilter(f: (Vertex) => Boolean): Graph
-
-  /** Filter vertices of the graph with global graph state
-    *
-    * @param f filter function with access to graph state (only vertices for which `f` returns `true` are kept)
-    */
   def vertexFilter(f: (Vertex, GraphState) => Boolean): Graph
-
-  /** Filter edges of the graph
-    *
-    * @param f filter function (only edges for which `f` returns `true` are kept)
-    *
-    * @param pruneNodes if this is `true` then vertices which become isolated (have no incoming or outgoing edges)
-    *                   after this filtering are also removed.
-    */
   def edgeFilter(f: (Edge) => Boolean, pruneNodes: Boolean): Graph
-
-  /** Filter edges of the graph with global graph state
-    *
-    * @param f filter function with access to graph state (only edges for which `f` returns `true` are kept)
-    *
-    * @param pruneNodes if this is `true` then vertices which become isolated (have no incoming or outgoing edges)
-    *                   after this filtering are also removed.
-    */
   def edgeFilter(f: (Edge, GraphState) => Boolean, pruneNodes: Boolean): Graph
-
-  /** Switch to multilayer view
-    *
-    * After calling `multilayerView`, subsequent methods that manipulate vertices act on
-    * [[ExplodedVertex]] instead. If [[ExplodedVertex]]
-    * instances were already created by a previous call to `multilayerView`, they are preserved. Otherwise, this
-    * method creates an [[ExplodedVertex]] instance for each
-    * timepoint that a vertex is active.
-    */
   def multilayerView: MultilayerGraph
 
-  /** Switch to multilayer view and add interlayer edges.
-    *
-    * @param interlayerEdgeBuilder Interlayer edge builder to create interlayer edges for each vertex. See
-    *                              [[visitor.InterlayerEdgeBuilders]] for predefined options.
-    *
-    * Existing `ExplodedVertex` instances are preserved but all interlayer edges are recreated using the supplied
-    * `interlayerEdgeBuilder`.
-    */
   def multilayerView(
       interlayerEdgeBuilder: visitor.Vertex => Seq[InterlayerEdge] = _ => Seq()
   ): MultilayerGraph
-
-  /** Switch computation to act on [[visitor.Vertex]], inverse of `multilayerView`
-    *
-    * This operation does nothing if the view is already reduced. Otherwise it switches back to running computations
-    * on vertices but preserves any existing [[ExplodedVertex]] instances
-    * created by previous calls to `multilayerView` to allow switching back-and-forth between views while
-    * preserving computational state. Computational state on [[ExplodedVertex]]
-    * instances is not accessible from the `Vertex` unless a merge strategy is supplied (see below).
-    */
   def reducedView: ReducedGraph
-
-  /** Reduce view and apply the same merge strategy to convert each exploded state to vertex state
-    *
-    * @param mergeStragegy Function to convert a history of values of type to a single value of type (see
-    *          [[PropertyMergeStrategy]] for predefined options)
-    */
   def reducedView(mergeStrategy: PropertyMerge[_, _]): ReducedGraph
 
-  /** Reduce view and merge selected exploded state to vertex state
-    *
-    * @param mergeStrategyMap Map from state key to merge strategy. Only state included in
-    *                         `mergeStrategyMap` will be reduced and
-    *                         made available on the Vertex.
-    */
   def reducedView(
       mergeStrategyMap: Map[String, PropertyMerge[_, _]]
   ): ReducedGraph
 
-  /** Reduce view and merge all exploded vertex state
-    *
-    * @param defaultMergeStrategy Merge strategy for state not included in `mergeStrategyMap`
-    *
-    * @param mergeStrategyMap Map from state key to merge strategy (used to override `defaultMergeStrategy`).
-    */
   def reducedView(
       defaultMergeStrategy: PropertyMerge[_, _],
       mergeStrategyMap: Map[String, PropertyMerge[_, _]]
   ): ReducedGraph
 
-  /** Reduce view and delete exploded vertices permanently
-    *
-    * This function has the same effect as `reducedView`, except that the exploded vertices are deleted and no longer
-    * available for subsequent calls of `multilayerView`.
-    *
-    * @param defaultMergeStrategy Merge strategy for state not included in `mergeStrategyMap`
-    *
-    * @param mergeStrategyMap Map from state key to merge strategy (used to override `defaultMergeStrategy`).
-    */
   def aggregate(
       defaultMergeStrategy: PropertyMerge[_, _] = PropertyMergeStrategy.sequence[Any],
       mergeStrategyMap: Map[String, PropertyMerge[_, _]] = Map.empty[String, PropertyMerge[_, _]]
   ): ReducedGraph
-
-  /** Execute algorithm step
-    *
-    * @param f algorithm step (run once for each vertex)
-    */
   def step(f: (Vertex) => Unit): Graph
-
-  /** Execute algorithm step with global graph state (has access to accumulated state from
-    * previous steps and allows for accumulation of new values)
-    *
-    * @param f algorithm step (run once for each vertex)
-    */
   def step(f: (Vertex, GraphState) => Unit): Graph
-
-  /** Execute algorithm step with global graph state repeatedly for given number of iterations or
-    * until all vertices have voted to halt.
-    *
-    * @param f algorithm step (run once for each vertex per iteration)
-    *
-    * @param iterations maximum number of iterations
-    *
-    * @param executeMessagedOnly If `true`, only run step for vertices which received new messages
-    */
   def iterate(f: (Vertex) => Unit, iterations: Int, executeMessagedOnly: Boolean): Graph
 
-  /** Execute algorithm step with global graph state repeatedly for given number of iterations or
-    * until all vertices have voted to halt.
-    *
-    * @param f algorithm step (run once for each vertex per iteration)
-    *
-    * @param iterations maximum number of iterations
-    *
-    * @param executeMessagedOnly If `true`, only run step for vertices which received new messages
-    */
   def iterate(
       f: (Vertex, GraphState) => Unit,
       iterations: Int,
       executeMessagedOnly: Boolean
   ): Graph
-
-  /** Write output to table with one row per vertex
-    *
-    * @parm f function to extract data from vertex (run once for each vertex)
-    */
   def select(f: Vertex => Row): Table
-
-  /** Write output to table with access to global graph state
-    *
-    * @param f function to extract data from vertex and graph state (run once for each vertex)
-    */
   def select(f: (Vertex, GraphState) => Row): Table
-
-  /** Write global graph state to table (this creates a table with a single row)
-    *
-    * @param f function to extract data from graph state (runs only once)
-    */
   def globalSelect(f: GraphState => Row): Table
-
-  /** Write output to table with multiple rows per vertex
-    *
-    * @param f function to extract data from vertex
-    */
   def explodeSelect(f: Vertex => List[Row]): Table
-
-  //  TODO: Implement GraphState version of explodeSelect
-
-  /** Clear messages from previous operations */
   def clearMessages(): Graph
 }
 

--- a/core/src/main/scala/com/raphtory/api/analysis/graphview/GraphView.scala
+++ b/core/src/main/scala/com/raphtory/api/analysis/graphview/GraphView.scala
@@ -30,25 +30,25 @@ import com.raphtory.api.analysis.table.Table
   */
 trait GraphView extends GraphPerspective {
 
-  /** Apply a [[Generic]] algorithm to the graph
+  /** Apply a [[com.raphtory.api.analysis.algorithm.Generic Generic]] algorithm to the graph
     *
     * $transformBody
     */
   def transform(algorithm: Generic): Graph
 
-  /** Apply a [[MultilayerProjection]] algorithm to the graph
+  /** Apply a [[com.raphtory.api.analysis.algorithm.MultilayerProjection MultilayerProjection]] algorithm to the graph
     *
     * $transformBody
     */
   def transform(algorithm: MultilayerProjection): MultilayerGraph
 
-  /** Apply a [[GenericReduction]] algorithm to the graph
+  /** Apply a [[com.raphtory.api.analysis.algorithm.GenericReduction GenericReduction]] algorithm to the graph
     *
     * $transformBody
     */
   def transform(algorithm: GenericReduction): ReducedGraph
 
-  /** Run a [[GenericallyApplicable]] algorithm on the graph and return results
+  /** Run a [[com.raphtory.api.analysis.algorithm.GenericallyApplicable GenericallyApplicable]] algorithm on the graph and return results
     *
     * $executeBody
     */

--- a/core/src/main/scala/com/raphtory/api/analysis/graphview/TemporalGraph.scala
+++ b/core/src/main/scala/com/raphtory/api/analysis/graphview/TemporalGraph.scala
@@ -1,14 +1,14 @@
 package com.raphtory.api.analysis.graphview
 
 import com.raphtory.api.analysis.visitor.ExplodedVertex
+import com.raphtory.api.time.DiscreteInterval
+import com.raphtory.api.time.Interval
+import com.raphtory.api.time.NullInterval
 import com.raphtory.internals.components.querymanager.PointPath
 import com.raphtory.internals.components.querymanager.Query
 import com.raphtory.internals.components.querymanager.SinglePoint
 import com.raphtory.internals.management.QuerySender
 import com.raphtory.internals.time.DateTimeParser
-import com.raphtory.internals.time.DiscreteInterval
-import com.raphtory.internals.time.Interval
-import com.raphtory.internals.time.NullInterval
 import com.typesafe.config.Config
 import com.raphtory.internals.time.IntervalParser.{parse => parseInterval}
 
@@ -212,7 +212,7 @@ class TemporalGraph private[api] (
 /** The multilayer view corresponding to [[TemporalGraph]]
   *
   * This exposes the same timeline operations as [[TemporalGraph]] but extends
-  * [[MultilayerGraphView]] which means that all algorithm operations act on [[ExplodedVertex]]s.
+  * [[MultilayerGraphView]] which means that all algorithm operations act on [[visitor.ExplodedVertex]]s.
   *
   * @see [[TemporalGraph]], [[MultilayerGraphView]], [[DottedGraph]]
   */

--- a/core/src/main/scala/com/raphtory/api/analysis/table/Table.scala
+++ b/core/src/main/scala/com/raphtory/api/analysis/table/Table.scala
@@ -1,8 +1,8 @@
 package com.raphtory.api.analysis.table
 
 import com.raphtory.api.output.sink.Sink
+import com.raphtory.api.querytracker.QueryProgressTracker
 import com.raphtory.internals.components.querymanager.QueryManagement
-import com.raphtory.internals.components.querytracker.QueryProgressTracker
 sealed private[raphtory] trait TableFunction extends QueryManagement
 
 final private[raphtory] case class TableFilter(f: (Row) => Boolean)     extends TableFunction
@@ -11,7 +11,7 @@ private[raphtory] case object WriteToOutput                             extends 
 
 /**  Interface for table operations
   *
-  * @see [[Row]], [[Sink]], [[QueryProgressTracker]]
+  * @see [[Row]], [[com.raphtory.api.output.sink.Sink Sink]], [[com.raphtory.api.querytracker.QueryProgressTracker QueryProgressTracker]]
   */
 trait Table {
 
@@ -20,19 +20,29 @@ trait Table {
     */
   def filter(f: Row => Boolean): Table
 
-  /** Add an explode operation to table. This creates a new table where each row in the old table
-    *      is mapped to multiple rows in the new table.
-    * @param f function that runs once for each row and returns a list of new rows
+  /** Explode table rows
+    *
+    * This creates a new table where each row in the old table
+    * is mapped to multiple rows in the new table.
+    *
+    * @param f function that runs once for each row of the table and maps it to new rows
     */
   def explode(f: Row => IterableOnce[Row]): Table
 
-  /** Write out data based on [[Sink]] and
-    *    returns [[QueryProgressTracker]]
+  /** Write out data and
+    * return [[com.raphtory.api.querytracker.QueryProgressTracker QueryProgressTracker]]
+    * with custom job name
+    *
+    * @param sink [[com.raphtory.api.output.sink.Sink Sink]] for writing results
+    * @param jobName Name for job
     */
   def writeTo(sink: Sink, jobName: String): QueryProgressTracker
 
-  /** Blank write to allow usage from python api
-    * @see [[Table.writeTo(sink,jobName]]
+  /** Write out data and
+    * return [[com.raphtory.api.querytracker.QueryProgressTracker QueryProgressTracker]]
+    * with default job name
+    *
+    * @param sink [[com.raphtory.api.output.sink.Sink Sink]] for writing results
     */
   def writeTo(sink: Sink): QueryProgressTracker
 }

--- a/core/src/main/scala/com/raphtory/api/analysis/table/TableImplementation.scala
+++ b/core/src/main/scala/com/raphtory/api/analysis/table/TableImplementation.scala
@@ -1,8 +1,8 @@
 package com.raphtory.api.analysis.table
 
 import com.raphtory.api.output.sink.Sink
+import com.raphtory.api.querytracker.QueryProgressTracker
 import com.raphtory.internals.components.querymanager.Query
-import com.raphtory.internals.components.querytracker.QueryProgressTracker
 import com.raphtory.internals.management.QuerySender
 
 private[api] class TableImplementation(val query: Query, private val querySender: QuerySender)

--- a/core/src/main/scala/com/raphtory/api/analysis/visitor/EntityVisitor.scala
+++ b/core/src/main/scala/com/raphtory/api/analysis/visitor/EntityVisitor.scala
@@ -18,26 +18,26 @@ abstract class EntityVisitor {
   def Type(): String
 
   /** Return next event (addition or deletion) after timestamp `time` as an
-    * [[HistoricEvent]]. This is wrapped in an option as
+    * [[com.raphtory.api.analysis.visitor.HistoricEvent HistoricEvent]]. This is wrapped in an option as
     * it is possible that no activity occurred after the given time. An optional `strict` Boolean argument is also
     * available which allows events exactly at the given time to be returned if set to `false`.
     */
   def firstActivityAfter(time: Long, strict: Boolean = true): Option[HistoricEvent]
 
   /** Return the last event (addition or deletion) before timestamp `time` as an
-    * [[HistoricEvent]].  The result is wrapped in an option as it is
+    * [[com.raphtory.api.analysis.visitor.HistoricEvent HistoricEvent]].  The result is wrapped in an option as it is
     * possible that no activity occurred before the given time. An optional `strict` Boolean argument is also
     * available which allows events exactly at the given time to be returned if set to `false`.
     */
   def lastActivityBefore(time: Long, strict: Boolean = true): Option[HistoricEvent]
 
   /** Return the most recent event (addition or deletion) in the current view as an
-    * [[HistoricEvent]]
+    * [[com.raphtory.api.analysis.visitor.HistoricEvent HistoricEvent]]
     */
   def latestActivity(): HistoricEvent
 
   /** Return the first event (addition or deltion) in the current view as an
-    * [[HistoricEvent]]
+    * [[com.raphtory.api.analysis.visitor.HistoricEvent HistoricEvent]]
     */
   def earliestActivity(): HistoricEvent
 
@@ -57,7 +57,7 @@ abstract class EntityVisitor {
     * @param mergeStrategy function to apply to the property history to compute the property value
     *                      The `mergeStrategy` can be an arbitrary function to apply to the property history. However, predefined
     *                      merge strategies for common use cases are provided in
-    *                      [[PropertyMergeStrategy]]. To e.g., compute the
+    *                      [[com.raphtory.api.analysis.visitor.PropertyMergeStrategy PropertyMergeStrategy]]. To e.g., compute the
     *                      average value of a property use
     *                      {{{
     *                      import com.raphtory.graph.visitor.PropertyMergeStrategy
@@ -215,7 +215,7 @@ abstract class EntityVisitor {
 
   //functionality to access the history of the edge or vertex + helpers
   /** Return list of all events (additions or deletions) in the current view. Each event is
-    * returned as an [[HistoricEvent]] which
+    * returned as an [[com.raphtory.api.analysis.visitor.HistoricEvent HistoricEvent]] which
     * encodes whether the event is an addition or deletion and the time of the event.
     */
   def history(): List[HistoricEvent]

--- a/core/src/main/scala/com/raphtory/api/analysis/visitor/Vertex.scala
+++ b/core/src/main/scala/com/raphtory/api/analysis/visitor/Vertex.scala
@@ -18,10 +18,12 @@ trait Vertex extends EntityVisitor {
   /** ID type of this vertex */
   type IDType
 
-  /** Concrete edge type for this vertex which implements [[visitor.Edge]] */
+  /** Concrete edge type for this vertex which implements [[com.raphtory.api.analysis.visitor.Edge Edge]] */
   type Edge <: visitor.ConcreteEdge[IDType]
 
-  /** Concrete type for this vertex's exploded edges which implements [[visitor.ExplodedEdge]] */
+  /** Concrete type for this vertex's exploded edges which implements
+    * [[com.raphtory.api.analysis.visitor.ExplodedEdge ExplodedEdge]]
+    */
   type ExplodedEdge = visitor.ConcreteExplodedEdge[IDType]
 
   /** implicit ordering object for use when comparing vertex IDs */
@@ -177,7 +179,7 @@ trait Vertex extends EntityVisitor {
       before: Long = Long.MaxValue
   ): Option[Edge]
 
-  /** Return all exploded [[visitor.ExplodedEdge]] views for each time point
+  /** Return all exploded [[com.raphtory.api.analysis.visitor.ExplodedEdge ExplodedEdge]] views for each time point
     * that an in- or out-edge of this vertex is active
     *
     * @param after  only return views for activity after time `after`
@@ -189,7 +191,7 @@ trait Vertex extends EntityVisitor {
   ): List[ExplodedEdge] =
     getEdges(after, before).flatMap(_.explode())
 
-  /** Return all exploded [[visitor.ExplodedEdge]] views for each time point
+  /** Return all exploded [[com.raphtory.api.analysis.visitor.ExplodedEdge ExplodedEdge]] views for each time point
     * that an out-edge of this vertex is active
     *
     * @param after  only return views for activity after time `after`
@@ -201,7 +203,7 @@ trait Vertex extends EntityVisitor {
   ): List[ExplodedEdge] =
     getOutEdges(after, before).flatMap(_.explode())
 
-  /** Return all exploded [[visitor.ExplodedEdge]] views for each time point
+  /** Return all exploded [[com.raphtory.api.analysis.visitor.ExplodedEdge ExplodedEdge]] views for each time point
     * that an in-edge of this vertex is active
     *
     * @param after  only return views for activity after time `after`
@@ -213,7 +215,7 @@ trait Vertex extends EntityVisitor {
   ): List[ExplodedEdge] =
     getInEdges(after, before).flatMap(_.explode())
 
-  /** Return an individual exploded [[visitor.ExplodedEdge]] views for an individual edge
+  /** Return an individual exploded [[com.raphtory.api.analysis.visitor.ExplodedEdge ExplodedEdge]] views for an individual edge
     * if it is an out-edge of this vertex
     *
     * @param id ID of edge to explode
@@ -227,7 +229,7 @@ trait Vertex extends EntityVisitor {
   ): Option[List[ExplodedEdge]] =
     getOutEdge(id, after, before).map(_.explode())
 
-  /** Return exploded [[visitor.ExplodedEdge]] views for an individual edge
+  /** Return exploded [[com.raphtory.api.analysis.visitor.ExplodedEdge ExplodedEdge]] views for an individual edge
     * if it is an in-edge of this vertex
     *
     * @param id ID of edge to explode
@@ -241,7 +243,7 @@ trait Vertex extends EntityVisitor {
   ): Option[List[ExplodedEdge]] =
     getInEdge(id, after, before).map(_.explode())
 
-  /** Return an individual exploded [[visitor.ExplodedEdge]] views for an individual edge
+  /** Return an individual exploded [[com.raphtory.api.analysis.visitor.ExplodedEdge ExplodedEdge]] views for an individual edge
     * if it is an in- or out-edge of this vertex
     *
     * @param id ID of edge to explode
@@ -316,7 +318,7 @@ trait Vertex extends EntityVisitor {
       .sum
 
   /** Sum of incoming edge weights.
-    * For the meaning of the input arguments see [[visitor.Edge]]
+    * For the meaning of the input arguments see [[com.raphtory.api.analysis.visitor.Edge Edge]]
     */
   def weightedInDegree[A, B: Numeric](
       weightProperty: String = "weight",
@@ -331,7 +333,7 @@ trait Vertex extends EntityVisitor {
     )
 
   /** Sum of incoming edge weights.
-    * For the meaning of the input arguments see [[visitor.Edge]]
+    * For the meaning of the input arguments see [[com.raphtory.api.analysis.visitor.Edge Edge]]
     */
   def weightedInDegree[A: Numeric, B: Numeric](
       weightProperty: String,
@@ -340,7 +342,7 @@ trait Vertex extends EntityVisitor {
     weightedInDegree(weightProperty, edgeMergeStrategy, DefaultValues.defaultVal[A])
 
   /** Sum of incoming edge weights.
-    * For the meaning of the input arguments see [[visitor.Edge]]
+    * For the meaning of the input arguments see [[com.raphtory.api.analysis.visitor.Edge Edge]]
     */
   def weightedInDegree[A: Numeric, B: Numeric](
       edgeMergeStrategy: PropertyMerge[A, B]
@@ -348,7 +350,7 @@ trait Vertex extends EntityVisitor {
     weightedInDegree(DefaultValues.weightProperty, edgeMergeStrategy, DefaultValues.defaultVal[A])
 
   /** Sum of incoming edge weights.
-    * For the meaning of the input arguments see [[visitor.Edge]]
+    * For the meaning of the input arguments see [[com.raphtory.api.analysis.visitor.Edge Edge]]
     */
   def weightedInDegree[A: Numeric](
       weightProperty: String,
@@ -357,7 +359,7 @@ trait Vertex extends EntityVisitor {
     weightedInDegree(weightProperty, DefaultValues.mergeStrategy[A], defaultWeight)
 
   /** Sum of incoming edge weights.
-    * For the meaning of the input arguments see [[visitor.Edge]]
+    * For the meaning of the input arguments see [[com.raphtory.api.analysis.visitor.Edge Edge]]
     */
   def weightedInDegree[A: Numeric](
       defaultWeight: A
@@ -365,7 +367,7 @@ trait Vertex extends EntityVisitor {
     weightedInDegree(DefaultValues.weightProperty, DefaultValues.mergeStrategy[A], defaultWeight)
 
   /** Sum of incoming edge weights.
-    * For the meaning of the input arguments see [[visitor.Edge]]
+    * For the meaning of the input arguments see [[com.raphtory.api.analysis.visitor.Edge Edge]]
     */
   def weightedInDegree[A: Numeric](
       weightProperty: String
@@ -373,7 +375,7 @@ trait Vertex extends EntityVisitor {
     weightedInDegree(weightProperty, DefaultValues.mergeStrategy[A], DefaultValues.defaultVal[A])
 
   /** Sum of incoming edge weights.
-    * For the meaning of the input arguments see [[visitor.Edge]]
+    * For the meaning of the input arguments see [[com.raphtory.api.analysis.visitor.Edge Edge]]
     */
   def weightedInDegree[A: Numeric](
   ): A =
@@ -384,7 +386,7 @@ trait Vertex extends EntityVisitor {
     )
 
   /** Sum of outgoing edge weights
-    * For the meaning of the input arguments see [[visitor.Edge]]
+    * For the meaning of the input arguments see [[com.raphtory.api.analysis.visitor.Edge Edge]]
     */
   def weightedOutDegree[A, B: Numeric](
       weightProperty: String = "weight",
@@ -399,7 +401,7 @@ trait Vertex extends EntityVisitor {
     )
 
   /** Sum of outgoing edge weights
-    * For the meaning of the input arguments see [[visitor.Edge]]
+    * For the meaning of the input arguments see [[com.raphtory.api.analysis.visitor.Edge Edge]]
     */
   def weightedOutDegree[A: Numeric, B: Numeric](
       weightProperty: String,
@@ -408,7 +410,7 @@ trait Vertex extends EntityVisitor {
     weightedOutDegree(weightProperty, edgeMergeStrategy, DefaultValues.defaultVal[A])
 
   /** Sum of outgoing edge weights
-    * For the meaning of the input arguments see [[visitor.Edge]]
+    * For the meaning of the input arguments see [[com.raphtory.api.analysis.visitor.Edge Edge]]
     */
   def weightedOutDegree[A: Numeric, B: Numeric](
       edgeMergeStrategy: PropertyMerge[A, B]
@@ -416,7 +418,7 @@ trait Vertex extends EntityVisitor {
     weightedOutDegree(DefaultValues.weightProperty, edgeMergeStrategy, DefaultValues.defaultVal[A])
 
   /** Sum of outgoing edge weights
-    * For the meaning of the input arguments see [[visitor.Edge]]
+    * For the meaning of the input arguments see [[com.raphtory.api.analysis.visitor.Edge Edge]]
     */
   def weightedOutDegree[A: Numeric](
       weightProperty: String,
@@ -425,7 +427,7 @@ trait Vertex extends EntityVisitor {
     weightedOutDegree(weightProperty, DefaultValues.mergeStrategy[A], defaultWeight)
 
   /** Sum of outgoing edge weights
-    * For the meaning of the input arguments see [[visitor.Edge]]
+    * For the meaning of the input arguments see [[com.raphtory.api.analysis.visitor.Edge Edge]]
     */
   def weightedOutDegree[A: Numeric](
       defaultWeight: A
@@ -437,7 +439,7 @@ trait Vertex extends EntityVisitor {
     )
 
   /** Sum of outgoing edge weights
-    * For the meaning of the input arguments see [[visitor.Edge]]
+    * For the meaning of the input arguments see [[com.raphtory.api.analysis.visitor.Edge Edge]]
     */
   def weightedOutDegree[A: Numeric](
       weightProperty: String
@@ -445,7 +447,7 @@ trait Vertex extends EntityVisitor {
     weightedOutDegree(weightProperty, DefaultValues.mergeStrategy[A], DefaultValues.defaultVal[A])
 
   /** Sum of outgoing edge weights
-    * For the meaning of the input arguments see [[visitor.Edge]]
+    * For the meaning of the input arguments see [[com.raphtory.api.analysis.visitor.Edge Edge]]
     */
   def weightedOutDegree[A: Numeric](
   ): A =
@@ -456,7 +458,7 @@ trait Vertex extends EntityVisitor {
     )
 
   /** Sum of incoming and outgoing edge weights
-    *  For the meaning of the input arguments see [[visitor.Edge]]
+    *  For the meaning of the input arguments see [[com.raphtory.api.analysis.visitor.Edge Edge]]
     */
   def weightedTotalDegree[A, B: Numeric](
       weightProperty: String = "weight",
@@ -471,7 +473,7 @@ trait Vertex extends EntityVisitor {
     )
 
   /** Sum of incoming and outgoing edge weights
-    *  For the meaning of the input arguments see [[visitor.Edge]]
+    *  For the meaning of the input arguments see [[com.raphtory.api.analysis.visitor.Edge Edge]]
     */
   def weightedTotalDegree[A: Numeric, B: Numeric](
       weightProperty: String,
@@ -480,7 +482,7 @@ trait Vertex extends EntityVisitor {
     weightedTotalDegree(weightProperty, edgeMergeStrategy, DefaultValues.defaultVal[A])
 
   /** Sum of incoming and outgoing edge weights
-    *  For the meaning of the input arguments see [[visitor.Edge]]
+    *  For the meaning of the input arguments see [[com.raphtory.api.analysis.visitor.Edge Edge]]
     */
   def weightedTotalDegree[A: Numeric, B: Numeric](
       edgeMergeStrategy: PropertyMerge[A, B]
@@ -492,7 +494,7 @@ trait Vertex extends EntityVisitor {
     )
 
   /** Sum of incoming and outgoing edge weights
-    *  For the meaning of the input arguments see [[visitor.Edge]]
+    *  For the meaning of the input arguments see [[com.raphtory.api.analysis.visitor.Edge Edge]]
     */
   def weightedTotalDegree[A: Numeric](
       weightProperty: String,
@@ -501,7 +503,7 @@ trait Vertex extends EntityVisitor {
     weightedTotalDegree(weightProperty, DefaultValues.mergeStrategy[A], defaultWeight)
 
   /** Sum of incoming and outgoing edge weights
-    *  For the meaning of the input arguments see [[visitor.Edge]]
+    *  For the meaning of the input arguments see [[com.raphtory.api.analysis.visitor.Edge Edge]]
     */
   def weightedTotalDegree[A: Numeric](
       defaultWeight: A
@@ -509,7 +511,7 @@ trait Vertex extends EntityVisitor {
     weightedTotalDegree(DefaultValues.weightProperty, DefaultValues.mergeStrategy[A], defaultWeight)
 
   /** Sum of incoming and outgoing edge weights
-    *  For the meaning of the input arguments see [[visitor.Edge]]
+    *  For the meaning of the input arguments see [[com.raphtory.api.analysis.visitor.Edge Edge]]
     */
   def weightedTotalDegree[A: Numeric](
       weightProperty: String
@@ -517,7 +519,7 @@ trait Vertex extends EntityVisitor {
     weightedTotalDegree(weightProperty, DefaultValues.mergeStrategy[A], DefaultValues.defaultVal[A])
 
   /** Sum of incoming and outgoing edge weights
-    *  For the meaning of the input arguments see [[visitor.Edge]]
+    *  For the meaning of the input arguments see [[com.raphtory.api.analysis.visitor.Edge Edge]]
     */
   def weightedTotalDegree[A: Numeric](
   ): A =

--- a/core/src/main/scala/com/raphtory/api/output/format/Format.scala
+++ b/core/src/main/scala/com/raphtory/api/output/format/Format.scala
@@ -1,6 +1,5 @@
 package com.raphtory.api.output.format
 
-import com.raphtory.api.analysis.table.Table
 import com.raphtory.api.output.sink.SinkConnector
 import com.raphtory.api.output.sink.SinkExecutor
 import com.typesafe.config.Config
@@ -18,12 +17,12 @@ import com.typesafe.config.Config
   * They shouldn't write out any data by themselves.
   * Instead, they should rely on the provided `SinkConnector` to output the items.
   *
-  * @see [[Table]]
-  *      [[com.raphtory.api.output.sink.Sink]]
-  *      [[SinkExecutor]]
-  *      [[SinkConnector]]
-  *      [[com.raphtory.formats.CsvFormat]]
-  *      [[com.raphtory.formats.JsonFormat]]
+  * @see [[com.raphtory.api.analysis.table.Table Table]]
+  *      [[com.raphtory.api.output.sink.Sink Sink]]
+  *      [[com.raphtory.api.output.sink.SinkExecutor SinkExecutor]]
+  *      [[com.raphtory.api.output.sink.SinkConnector SinkConnector]]
+  *      [[com.raphtory.formats.CsvFormat CsvFormat]]
+  *      [[com.raphtory.formats.JsonFormat JsonFormat]]
   */
 trait Format {
 

--- a/core/src/main/scala/com/raphtory/api/output/sink/FormatAgnosticSink.scala
+++ b/core/src/main/scala/com/raphtory/api/output/sink/FormatAgnosticSink.scala
@@ -3,31 +3,36 @@ package com.raphtory.api.output.sink
 import com.raphtory.api.output.format.Format
 import com.typesafe.config.Config
 
-/** Base trait for sinks that use a generic `Format` to write the data.
+/** Base trait for sinks that use a generic [[com.raphtory.api.output.format.Format Format]] to write the data.
   *
-  * This trait allows defining a `Sink` just by overriding the `buildConnector` method
-  * @param format the `Format`
-  * @see [[Format]]
+  * This trait allows defining a [[Sink]] just by overriding the `buildConnector` method
+  * @param format the [[com.raphtory.api.output.format.Format Format]]
+  * @see [[com.raphtory.api.output.format.Format Format]]
   */
 abstract class FormatAgnosticSink(format: Format) extends Sink {
 
-  /** Builds a `SinkConnector` to be used by Raphtory for writing a table using the provided `Format`.
-    * @param jobID the ID of the job that generated the table
-    * @param partitionID the ID of the partition of the table
-    * @param config the configuration provided by the user
-    * @param itemDelimiter the `String` to be used as delimiter between items when necessary
-    * @return the `SinkConnector` implementing the execution of this `FormatAgnosticSink`
+  /** Builds a [[com.raphtory.api.output.sink.SinkConnector SinkConnector]] to be used by Raphtory for
+    * writing a table using the provided [[com.raphtory.api.output.format.Format Format]].
+    * @param jobID The ID of the job that generated the table
+    * @param partitionID The ID of the partition of the table
+    * @param config The configuration provided by the user
+    * @param itemDelimiter The `String` to be used as delimiter between items when necessary
+    * @return The [[com.raphtory.api.output.sink.SinkConnector SinkConnector]] implementing the execution of this `FormatAgnosticSink`
     *
-    * @see [[SinkConnector]]
+    * @see [[com.raphtory.api.output.sink.SinkConnector SinkConnector]]
     */
-  protected def buildConnector(
+  def buildConnector(
       jobID: String,
       partitionID: Int,
       config: Config,
       itemDelimiter: String
   ): SinkConnector
 
-  final override def executor(jobID: String, partitionID: Int, config: Config): SinkExecutor = {
+  final override def executor(
+      jobID: String,
+      partitionID: Int,
+      config: Config
+  ): SinkExecutor = {
     val connector =
       buildConnector(jobID, partitionID, config, format.defaultDelimiter)
     format.executor(connector, jobID, partitionID, config)

--- a/core/src/main/scala/com/raphtory/api/output/sink/Sink.scala
+++ b/core/src/main/scala/com/raphtory/api/output/sink/Sink.scala
@@ -1,7 +1,7 @@
 package com.raphtory.api.output.sink
 
 import com.raphtory.api.analysis.table.Row
-import com.raphtory.internals.graph.Perspective
+import com.raphtory.api.time.Perspective
 import com.raphtory.sinks.FileSink
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.Logger
@@ -13,8 +13,8 @@ import org.slf4j.LoggerFactory
   * In order to do this, concrete implementations need to override `executor` method creating their own `SinkExecutor`,
   * which is the class holding the actual implementation of the execution of the sink.
   *
-  * @see [[FileSink]], [[com.raphtory.sinks.PulsarSink]],
-  *      [[com.raphtory.api.analysis.table.Table]]
+  * @see [[com.raphtory.sinks.FileSink FileSink]], [[com.raphtory.sinks.PulsarSink PulsarSink]],
+  *      [[com.raphtory.api.analysis.table.Table Table]]
   */
 trait Sink {
 
@@ -32,7 +32,7 @@ trait Sink {
   * Concrete implementations need to override the `setupPerspective`, `writeRow`, `closePerspective`, and `close`
   * methods.
   *
-  *  @see [[Row]], [[Perspective]]
+  *  @see [[com.raphtory.api.analysis.table.Row Row]], [[com.raphtory.api.time.Perspective Perspective]]
   */
 trait SinkExecutor {
 

--- a/core/src/main/scala/com/raphtory/api/time/Intervals.scala
+++ b/core/src/main/scala/com/raphtory/api/time/Intervals.scala
@@ -1,12 +1,11 @@
-package com.raphtory.internals.time
+package com.raphtory.api.time
 
+import java.time.temporal.TemporalAmount
 import java.time.Duration
 import java.time.Instant
 import java.time.Period
-import java.time.temporal.TemporalAmount
 import scala.language.postfixOps
 
-/** @note DoNotDocument */
 sealed trait Interval extends Ordered[Interval] {
   def toString: String
   def *(number: Long): Interval

--- a/core/src/main/scala/com/raphtory/api/time/Perspective.scala
+++ b/core/src/main/scala/com/raphtory/api/time/Perspective.scala
@@ -1,0 +1,18 @@
+package com.raphtory.api.time
+
+/** Information about the graph view
+  */
+trait Perspective {
+
+  /** Timestamp anchor at which the view was created */
+  val timestamp: Long
+
+  /** Time window of the view if it is set */
+  val window: Option[Interval]
+
+  /** Earliest time point included in the view */
+  val actualStart: Long
+
+  /** Latest time point included in the view */
+  val actualEnd: Long
+}

--- a/core/src/main/scala/com/raphtory/formats/CsvFormat.scala
+++ b/core/src/main/scala/com/raphtory/formats/CsvFormat.scala
@@ -4,7 +4,7 @@ import com.raphtory.api.analysis.table.Row
 import com.raphtory.api.output.format.Format
 import com.raphtory.api.output.sink.SinkConnector
 import com.raphtory.api.output.sink.SinkExecutor
-import com.raphtory.internals.graph.Perspective
+import com.raphtory.api.time.Perspective
 import com.typesafe.config.Config
 
 /** A `Format` that writes a `Table` in comma-separated values (CSV) format

--- a/core/src/main/scala/com/raphtory/formats/JsonFormat.scala
+++ b/core/src/main/scala/com/raphtory/formats/JsonFormat.scala
@@ -7,9 +7,9 @@ import com.raphtory.api.analysis.table.Row
 import com.raphtory.api.output.format.Format
 import com.raphtory.api.output.sink.SinkConnector
 import com.raphtory.api.output.sink.SinkExecutor
-import com.raphtory.internals.graph.Perspective
-import com.raphtory.internals.time.DiscreteInterval
-import com.raphtory.internals.time.TimeInterval
+import com.raphtory.api.time.DiscreteInterval
+import com.raphtory.api.time.Perspective
+import com.raphtory.api.time.TimeInterval
 import com.typesafe.config.Config
 
 import java.io.StringWriter

--- a/core/src/main/scala/com/raphtory/internals/communication/CancelableListener.scala
+++ b/core/src/main/scala/com/raphtory/internals/communication/CancelableListener.scala
@@ -1,12 +1,11 @@
 package com.raphtory.internals.communication
 
-/** @DoNotDocument */
-trait CancelableListener {
+private[raphtory] trait CancelableListener {
   def start(): Unit
   def close(): Unit
 }
 
-object CancelableListener {
+private[raphtory] object CancelableListener {
 
   def apply(listeners: Seq[CancelableListener]): CancelableListener =
     new CancelableListener {

--- a/core/src/main/scala/com/raphtory/internals/communication/Connector.scala
+++ b/core/src/main/scala/com/raphtory/internals/communication/Connector.scala
@@ -1,7 +1,6 @@
 package com.raphtory.internals.communication
 
-/** @DoNotDocument */
-trait Connector {
+private[raphtory] trait Connector {
 
   def register[T](
       id: String,

--- a/core/src/main/scala/com/raphtory/internals/communication/EndPoint.scala
+++ b/core/src/main/scala/com/raphtory/internals/communication/EndPoint.scala
@@ -2,8 +2,7 @@ package com.raphtory.internals.communication
 
 import java.util.concurrent.CompletableFuture
 
-/** @DoNotDocument */
-trait EndPoint[T] {
+private[raphtory] trait EndPoint[T] {
   def sendAsync(message: T): Unit
   def flushAsync(): CompletableFuture[Void]
   def close(): Unit

--- a/core/src/main/scala/com/raphtory/internals/communication/Topic.scala
+++ b/core/src/main/scala/com/raphtory/internals/communication/Topic.scala
@@ -1,32 +1,31 @@
 package com.raphtory.internals.communication
 
-/** @DoNotDocument */
-sealed trait Topic[+T] {
+sealed private[raphtory] trait Topic[+T] {
   def id: String
   def subTopic: String
   def customAddress: String
   def connector: Connector
 }
 
-sealed trait CanonicalTopic[+T] extends Topic[T] {
+sealed private[raphtory] trait CanonicalTopic[+T] extends Topic[T] {
   def endPoint[E >: T]: EndPoint[E] = connector.endPoint(this)
 }
 
-case class ExclusiveTopic[T](
+private[raphtory] case class ExclusiveTopic[T](
     connector: Connector,
     id: String,
     subTopic: String = "",
     customAddress: String = ""
 ) extends CanonicalTopic[T]
 
-case class WorkPullTopic[T](
+private[raphtory] case class WorkPullTopic[T](
     connector: Connector,
     id: String,
     subTopic: String = "",
     customAddress: String = ""
 ) extends CanonicalTopic[T]
 
-case class BroadcastTopic[T](
+private[raphtory] case class BroadcastTopic[T](
     numListeners: Int,
     connector: Connector,
     id: String,
@@ -34,7 +33,7 @@ case class BroadcastTopic[T](
     customAddress: String = ""
 ) extends CanonicalTopic[T]
 
-case class ShardingTopic[T](
+private[raphtory] case class ShardingTopic[T](
     numPartitions: Int,
     connector: Connector,
     id: String,

--- a/core/src/main/scala/com/raphtory/internals/communication/TopicRepository.scala
+++ b/core/src/main/scala/com/raphtory/internals/communication/TopicRepository.scala
@@ -8,8 +8,11 @@ import com.raphtory.internals.components.querymanager.QueryManagement
 import com.raphtory.internals.components.querymanager.WatermarkTime
 import com.typesafe.config.Config
 
-/** @DoNotDocument */
-class TopicRepository(defaultConnector: Connector, conf: Config, allConnectors: Array[Connector]) {
+private[raphtory] class TopicRepository(
+    defaultConnector: Connector,
+    conf: Config,
+    allConnectors: Array[Connector]
+) {
 
   // Methods to override:
   protected def spoutConnector: Connector            = defaultConnector

--- a/core/src/main/scala/com/raphtory/internals/communication/connectors/AkkaConnector.scala
+++ b/core/src/main/scala/com/raphtory/internals/communication/connectors/AkkaConnector.scala
@@ -25,10 +25,10 @@ import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 import scala.concurrent.duration.DurationInt
 
-/** @DoNotDocument */
-case object StopActor
+private case object StopActor
 
-class AkkaConnector(actorSystem: ActorSystem[SpawnProtocol.Command]) extends Connector {
+private[raphtory] class AkkaConnector(actorSystem: ActorSystem[SpawnProtocol.Command])
+        extends Connector {
   private val logger: Logger                              = Logger(LoggerFactory.getLogger(this.getClass))
   private val akkaReceptionistRegisteringTimeout: Timeout = 1.seconds
   private val akkaSpawnerTimeout: Timeout                 = 1.seconds

--- a/core/src/main/scala/com/raphtory/internals/communication/connectors/PulsarConnector.scala
+++ b/core/src/main/scala/com/raphtory/internals/communication/connectors/PulsarConnector.scala
@@ -22,8 +22,7 @@ import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 import scala.math.Ordering.Implicits.infixOrderingOps
 
-/** @DoNotDocument */
-class PulsarConnector(config: Config) extends Connector {
+private[raphtory] class PulsarConnector(config: Config) extends Connector {
   private val logger: Logger = Logger(LoggerFactory.getLogger(this.getClass))
 
   case class PulsarEndPoint[T](producer: Producer[Array[Byte]]) extends EndPoint[T] {

--- a/core/src/main/scala/com/raphtory/internals/communication/repositories/AkkaTopicRepository.scala
+++ b/core/src/main/scala/com/raphtory/internals/communication/repositories/AkkaTopicRepository.scala
@@ -6,8 +6,8 @@ import com.raphtory.internals.communication.TopicRepository
 import com.raphtory.internals.communication.connectors.AkkaConnector
 import com.typesafe.config.Config
 
-/** @DoNotDocument This object only exists for testing purposes -- no more deployments are fully akka */
-object AkkaTopicRepository {
+/** This object only exists for testing purposes -- no more deployments are fully akka */
+private[raphtory] object AkkaTopicRepository {
 
   def apply(config: Config): TopicRepository = {
     val actorSystem   = ActorSystem(SpawnProtocol(), "spawner")

--- a/core/src/main/scala/com/raphtory/internals/communication/repositories/PulsarAkkaTopicRepository.scala
+++ b/core/src/main/scala/com/raphtory/internals/communication/repositories/PulsarAkkaTopicRepository.scala
@@ -8,8 +8,7 @@ import com.raphtory.internals.communication.Connector
 import com.raphtory.internals.communication.TopicRepository
 import com.typesafe.config.Config
 
-/** @DoNotDocument */
-object PulsarAkkaTopicRepository {
+private[raphtory] object PulsarAkkaTopicRepository {
 
   def apply(config: Config): TopicRepository = {
     val actorSystem     = ActorSystem(SpawnProtocol(), "spawner")

--- a/core/src/main/scala/com/raphtory/internals/communication/repositories/PulsarTopicRepository.scala
+++ b/core/src/main/scala/com/raphtory/internals/communication/repositories/PulsarTopicRepository.scala
@@ -4,8 +4,7 @@ import com.raphtory.internals.communication.TopicRepository
 import com.raphtory.internals.communication.connectors.PulsarConnector
 import com.typesafe.config.Config
 
-/** @DoNotDocument */
-object PulsarTopicRepository {
+private[raphtory] object PulsarTopicRepository {
 
   def apply(config: Config): TopicRepository = {
     val pulsarConnector = new PulsarConnector(config)

--- a/core/src/main/scala/com/raphtory/internals/components/Component.scala
+++ b/core/src/main/scala/com/raphtory/internals/components/Component.scala
@@ -4,7 +4,7 @@ import com.raphtory.internals.management.telemetry.ComponentTelemetryHandler
 import com.typesafe.config.Config
 
 /** @note DoNotDocument */
-abstract class Component[T](conf: Config) {
+abstract private[raphtory] class Component[T](conf: Config) {
 
   protected val telemetry: ComponentTelemetryHandler.type = ComponentTelemetryHandler
   private val partitionServers: Int                       = conf.getInt("raphtory.partitions.serverCount")
@@ -14,6 +14,6 @@ abstract class Component[T](conf: Config) {
 
   def getWriter(srcId: Long): Int = (srcId.abs % totalPartitions).toInt
   def handleMessage(msg: T): Unit
-  def run(): Unit
-  def stop(): Unit = {}
+  private[raphtory] def run(): Unit
+  private[raphtory] def stop(): Unit = {}
 }

--- a/core/src/main/scala/com/raphtory/internals/components/graphbuilder/BuilderExecutor.scala
+++ b/core/src/main/scala/com/raphtory/internals/components/graphbuilder/BuilderExecutor.scala
@@ -11,8 +11,7 @@ import org.slf4j.LoggerFactory
 
 import scala.reflect.ClassTag
 
-/** @note DoNotDocument */
-class BuilderExecutor[T: ClassTag](
+private[raphtory] class BuilderExecutor[T: ClassTag](
     name: Int,
     deploymentID: String,
     graphBuilder: GraphBuilder[T],

--- a/core/src/main/scala/com/raphtory/internals/components/partition/BatchWriter.scala
+++ b/core/src/main/scala/com/raphtory/internals/components/partition/BatchWriter.scala
@@ -14,8 +14,7 @@ import org.slf4j.LoggerFactory
 import scala.language.postfixOps
 import scala.reflect.ClassTag
 
-/** @note DoNotDocument */
-class BatchWriter[T: ClassTag](
+private[raphtory] class BatchWriter[T: ClassTag](
     partitionID: Int,
     storage: GraphPartition
 ) {

--- a/core/src/main/scala/com/raphtory/internals/components/partition/LocalBatchHandler.scala
+++ b/core/src/main/scala/com/raphtory/internals/components/partition/LocalBatchHandler.scala
@@ -13,8 +13,7 @@ import scala.collection.mutable
 import scala.concurrent.duration.DurationInt
 import scala.reflect.ClassTag
 
-/** @note DoNotDocument */
-class LocalBatchHandler[T: ClassTag](
+private[raphtory] class LocalBatchHandler[T: ClassTag](
     partitionIDs: mutable.Set[Int],
     batchWriters: mutable.Map[Int, BatchWriter[T]],
     spout: Spout[T],

--- a/core/src/main/scala/com/raphtory/internals/components/partition/QueryExecutor.scala
+++ b/core/src/main/scala/com/raphtory/internals/components/partition/QueryExecutor.scala
@@ -46,8 +46,7 @@ import org.slf4j.LoggerFactory
 
 import java.util.concurrent.atomic.AtomicInteger
 
-/** @note DoNotDocument */
-class QueryExecutor(
+private[raphtory] class QueryExecutor(
     partitionID: Int,
     sink: Sink,
     storage: GraphPartition,

--- a/core/src/main/scala/com/raphtory/internals/components/partition/Reader.scala
+++ b/core/src/main/scala/com/raphtory/internals/components/partition/Reader.scala
@@ -15,8 +15,7 @@ import org.slf4j.LoggerFactory
 import scala.collection.mutable
 import scala.concurrent.duration.DurationInt
 
-/** @note DoNotDocument */
-class Reader(
+private[raphtory] class Reader(
     partitionID: Int,
     storage: GraphPartition,
     scheduler: MonixScheduler,

--- a/core/src/main/scala/com/raphtory/internals/components/partition/StreamWriter.scala
+++ b/core/src/main/scala/com/raphtory/internals/components/partition/StreamWriter.scala
@@ -23,8 +23,7 @@ import org.slf4j.LoggerFactory
 
 import scala.language.postfixOps
 
-/** @note DoNotDocument */
-class StreamWriter(
+private[raphtory] class StreamWriter(
     partitionID: Int,
     storage: GraphPartition,
     conf: Config,

--- a/core/src/main/scala/com/raphtory/internals/components/querymanager/QueryHandler.scala
+++ b/core/src/main/scala/com/raphtory/internals/components/querymanager/QueryHandler.scala
@@ -38,8 +38,7 @@ import scala.collection.mutable
 import scala.concurrent.duration.DurationInt
 import scala.util.Try
 
-/** @note DoNotDocument */
-class QueryHandler(
+private[raphtory] class QueryHandler(
     queryManager: QueryManager,
     scheduler: MonixScheduler,
     jobID: String,
@@ -571,7 +570,7 @@ class QueryHandler(
   private def getOptionalEarliestTime: Option[Long] = queryManager.earliestTime()
 }
 
-object Stages extends Enumeration {
+private[raphtory] object Stages extends Enumeration {
   type Stage = Value
   val SpawnExecutors, EstablishPerspective, ExecuteGraph, ExecuteTable, EndTask = Value
 }

--- a/core/src/main/scala/com/raphtory/internals/components/querymanager/QueryManager.scala
+++ b/core/src/main/scala/com/raphtory/internals/components/querymanager/QueryManager.scala
@@ -10,9 +10,11 @@ import org.slf4j.LoggerFactory
 import scala.collection.concurrent._
 import scala.collection.mutable
 
-/** @note DoNotDocument */
-class QueryManager(scheduler: MonixScheduler, conf: Config, topics: TopicRepository)
-        extends Component[QueryManagement](conf) {
+private[raphtory] class QueryManager(
+    scheduler: MonixScheduler,
+    conf: Config,
+    topics: TopicRepository
+) extends Component[QueryManagement](conf) {
   private val logger: Logger = Logger(LoggerFactory.getLogger(this.getClass))
 
   private val currentQueries = mutable.Map[String, QueryHandler]()

--- a/core/src/main/scala/com/raphtory/internals/components/spout/SpoutExecutor.scala
+++ b/core/src/main/scala/com/raphtory/internals/components/spout/SpoutExecutor.scala
@@ -11,8 +11,7 @@ import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration.DurationInt
 
-/** @note DoNotDocument */
-class SpoutExecutor[T](
+private[raphtory] class SpoutExecutor[T](
     spout: Spout[T],
     conf: Config,
     topics: TopicRepository,

--- a/core/src/main/scala/com/raphtory/internals/graph/GraphLens.scala
+++ b/core/src/main/scala/com/raphtory/internals/graph/GraphLens.scala
@@ -1,4 +1,3 @@
 package com.raphtory.internals.graph
 
-/** @note DoNotDocument */
-abstract class GraphLens(jobId: String, start: Long, end: Long)
+abstract private[raphtory] class GraphLens(jobId: String, start: Long, end: Long)

--- a/core/src/main/scala/com/raphtory/internals/graph/GraphPartition.scala
+++ b/core/src/main/scala/com/raphtory/internals/graph/GraphPartition.scala
@@ -9,9 +9,8 @@ import com.typesafe.config.Config
 import scala.collection.mutable
 
 /** Singleton representing the Storage for the entities
-  * @note DoNotDocument
   */
-abstract class GraphPartition(partitionID: Int, conf: Config) {
+abstract private[raphtory] class GraphPartition(partitionID: Int, conf: Config) {
 
   protected val failOnError: Boolean = conf.getBoolean("raphtory.partitions.failOnError")
   private var batchIngesting         = false

--- a/core/src/main/scala/com/raphtory/internals/graph/LensInterface.scala
+++ b/core/src/main/scala/com/raphtory/internals/graph/LensInterface.scala
@@ -9,9 +9,8 @@ import com.raphtory.internals.components.querymanager.GenericVertexMessage
 import com.raphtory.internals.storage.pojograph.messaging.VertexMessageHandler
 
 /** Abstract interface for the GraphLens, responsible for executing algorithms
-  * @note DoNotDocument
   */
-trait LensInterface {
+private[raphtory] trait LensInterface {
 
   def partitionID(): Int
 

--- a/core/src/main/scala/com/raphtory/internals/graph/PerspectiveController.scala
+++ b/core/src/main/scala/com/raphtory/internals/graph/PerspectiveController.scala
@@ -1,31 +1,33 @@
 package com.raphtory.internals.graph
 
 import com.raphtory.api.analysis.graphview.Alignment
+import com.raphtory.api.time
+import com.raphtory.api.time.DiscreteInterval
+import com.raphtory.api.time.Interval
+import com.raphtory.api.time.NullInterval
 import com.raphtory.internals.components.querymanager.NullPointSet
 import com.raphtory.internals.components.querymanager.PointPath
 import com.raphtory.internals.components.querymanager.Query
 import com.raphtory.internals.components.querymanager.QueryManagement
 import com.raphtory.internals.components.querymanager.SinglePoint
-import com.raphtory.internals.time.DiscreteInterval
-import com.raphtory.internals.time.Interval
-import com.raphtory.internals.time.NullInterval
 import com.typesafe.scalalogging.Logger
 import org.slf4j.LoggerFactory
 import com.raphtory.internals.time.TimeConverters._
+
 import scala.annotation.tailrec
 import scala.util.Try
 
 /** The PerspectiveController is responsible for constructing graph views
-  * @note DoNotDocument
   */
-case class Perspective(
+private[raphtory] case class Perspective(
     timestamp: Long,
     window: Option[Interval],
     actualStart: Long,
     actualEnd: Long
 ) extends QueryManagement
+        with time.Perspective
 
-class PerspectiveController(
+private[raphtory] class PerspectiveController(
     private var perspectiveStreams: Array[LazyList[Perspective]]
 ) {
 
@@ -44,7 +46,7 @@ class PerspectiveController(
   }
 }
 
-object PerspectiveController {
+private[raphtory] object PerspectiveController {
 
   final val DEFAULT_PERSPECTIVE_TIME: Long             = -1L
   final val DEFAULT_PERSPECTIVE_WINDOW: Some[Interval] = Some(DiscreteInterval(-1L))

--- a/core/src/main/scala/com/raphtory/internals/graph/Watermarker.scala
+++ b/core/src/main/scala/com/raphtory/internals/graph/Watermarker.scala
@@ -12,7 +12,7 @@ import scala.collection.concurrent.Map
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable
 
-class Watermarker(storage: GraphPartition) {
+private[raphtory] class Watermarker(storage: GraphPartition) {
 
   private val logger: Logger = Logger(LoggerFactory.getLogger(this.getClass))
   private val lock: Lock     = new ReentrantLock()

--- a/core/src/main/scala/com/raphtory/internals/management/ComponentFactory.scala
+++ b/core/src/main/scala/com/raphtory/internals/management/ComponentFactory.scala
@@ -3,6 +3,7 @@ package com.raphtory.internals.management
 import com.raphtory.api.input.GraphAlteration
 import com.raphtory.api.input.GraphBuilder
 import com.raphtory.api.input.Spout
+import com.raphtory.api.querytracker.QueryProgressTracker
 import com.raphtory.internals.communication.TopicRepository
 import com.raphtory.internals.components.Component
 import com.raphtory.internals.components.graphbuilder.BuilderExecutor
@@ -12,7 +13,6 @@ import com.raphtory.internals.components.partition.Reader
 import com.raphtory.internals.components.partition.StreamWriter
 import com.raphtory.internals.components.querymanager.QueryManagement
 import com.raphtory.internals.components.querymanager.QueryManager
-import com.raphtory.internals.components.querytracker.QueryProgressTracker
 import com.raphtory.internals.components.spout.SpoutExecutor
 import com.raphtory.internals.graph.GraphPartition
 import com.raphtory.internals.management.id.LocalIDManager
@@ -25,7 +25,6 @@ import org.slf4j.LoggerFactory
 import scala.collection.mutable
 import scala.reflect.ClassTag
 
-/** @note DoNotDocument */
 private[raphtory] class ComponentFactory(
     conf: Config,
     topicRepo: TopicRepository,
@@ -217,9 +216,9 @@ private[raphtory] class ComponentFactory(
   }
 }
 
-case class ThreadedWorker[T](worker: Component[T])
+private[raphtory] case class ThreadedWorker[T](worker: Component[T])
 
-case class Partitions(
+private[raphtory] case class Partitions(
     storages: List[GraphPartition],
     readers: List[Reader],
     writers: List[Component[GraphAlteration]]

--- a/core/src/main/scala/com/raphtory/internals/management/ConfigHandler.scala
+++ b/core/src/main/scala/com/raphtory/internals/management/ConfigHandler.scala
@@ -10,7 +10,6 @@ import org.slf4j.LoggerFactory
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Random
 
-/** @note DoNotDocument */
 private[raphtory] class ConfigHandler {
   private lazy val defaults       = createConf()
   private lazy val logger: Logger = Logger(LoggerFactory.getLogger(this.getClass))

--- a/core/src/main/scala/com/raphtory/internals/management/MonixScheduler.scala
+++ b/core/src/main/scala/com/raphtory/internals/management/MonixScheduler.scala
@@ -15,7 +15,6 @@ import java.util.concurrent.locks.Lock
 import java.util.concurrent.locks.ReentrantLock
 import scala.concurrent.duration.FiniteDuration
 
-/** @note DoNotDocument */
 private[raphtory] class MonixScheduler {
   private val threads: Int     = 8
   private var schedulerRunning = true

--- a/core/src/main/scala/com/raphtory/internals/management/Py4JServer.scala
+++ b/core/src/main/scala/com/raphtory/internals/management/Py4JServer.scala
@@ -17,7 +17,7 @@ import java.security.SecureRandom
 
 /** Setups the Py4J Java server which allows Python to interact with Raphtory
   */
-class Py4JServer(entryPoint: Object) {
+private[raphtory] class Py4JServer(entryPoint: Object) {
 
   private val logger: Logger = Logger(LoggerFactory.getLogger(this.getClass))
 
@@ -108,7 +108,7 @@ class Py4JServer(entryPoint: Object) {
     }
 }
 
-object Py4JServer {
+private[raphtory] object Py4JServer {
 
   def apply(entryPoint: Object) =
     new Py4JServer(entryPoint: Object)

--- a/core/src/main/scala/com/raphtory/internals/management/QuerySender.scala
+++ b/core/src/main/scala/com/raphtory/internals/management/QuerySender.scala
@@ -1,13 +1,12 @@
 package com.raphtory.internals.management
 
+import com.raphtory.api.querytracker.QueryProgressTracker
 import com.raphtory.internals.communication.TopicRepository
 import com.raphtory.internals.components.querymanager.Query
-import com.raphtory.internals.components.querytracker.QueryProgressTracker
 
 import scala.util.Random
 
-/** @note DoNotDocument */
-class QuerySender(
+private[raphtory] class QuerySender(
     private val componentFactory: ComponentFactory,
     private val scheduler: MonixScheduler,
     private val topics: TopicRepository

--- a/core/src/main/scala/com/raphtory/internals/management/id/IDManager.scala
+++ b/core/src/main/scala/com/raphtory/internals/management/id/IDManager.scala
@@ -1,7 +1,6 @@
 package com.raphtory.internals.management.id
 
-/** @DoNotDocument */
-trait IDManager {
+private[raphtory] trait IDManager {
   def getNextAvailableID(): Option[Int]
   def resetID(): Unit
   def stop(): Unit

--- a/core/src/main/scala/com/raphtory/internals/management/id/LocalIDManager.scala
+++ b/core/src/main/scala/com/raphtory/internals/management/id/LocalIDManager.scala
@@ -2,8 +2,7 @@ package com.raphtory.internals.management.id
 
 import java.util.concurrent.atomic.AtomicInteger
 
-/** @DoNotDocument */
-class LocalIDManager extends IDManager {
+private[raphtory] class LocalIDManager extends IDManager {
   private val nextId = new AtomicInteger(0)
 
   override def getNextAvailableID(): Option[Int] = Some(nextId.getAndIncrement())

--- a/core/src/main/scala/com/raphtory/internals/management/id/ZookeeperIDManager.scala
+++ b/core/src/main/scala/com/raphtory/internals/management/id/ZookeeperIDManager.scala
@@ -8,7 +8,6 @@ import org.apache.curator.retry.ExponentialBackoffRetry
 import org.apache.curator.retry.RetryNTimes
 import org.slf4j.LoggerFactory;
 
-/** @note DoNotDocument */
 private[raphtory] class ZookeeperIDManager(zookeeperAddress: String, atomicPath: String)
         extends IDManager {
   private val logger: Logger = Logger(LoggerFactory.getLogger(this.getClass))

--- a/core/src/main/scala/com/raphtory/internals/management/telemetry/BuilderTelemetry.scala
+++ b/core/src/main/scala/com/raphtory/internals/management/telemetry/BuilderTelemetry.scala
@@ -7,7 +7,7 @@ import io.prometheus.client.Counter
   * by the graph builder
   * Statistics are made available on http://localhost:9999 on running tests and can be visualised using Grafana dashboards
   */
-object BuilderTelemetry {
+private[raphtory] object BuilderTelemetry {
 
   def totalVertexAdds =
     Counter.build

--- a/core/src/main/scala/com/raphtory/internals/management/telemetry/PartitionTelemetry.scala
+++ b/core/src/main/scala/com/raphtory/internals/management/telemetry/PartitionTelemetry.scala
@@ -7,7 +7,7 @@ import io.prometheus.client.Gauge
   * Exposes Counter and Summary stats for tracking number of graph updates, watermarks created by reader, vertices and edges added and deleted by writers in Raphtory
   * Statistics are made available on http://localhost:9999 on running tests and can be visualised using Grafana dashboards
   */
-object PartitionTelemetry {
+private[raphtory] object PartitionTelemetry {
 
   def lastWatermarkProcessed =
     Gauge.build

--- a/core/src/main/scala/com/raphtory/internals/management/telemetry/QueryTelemetry.scala
+++ b/core/src/main/scala/com/raphtory/internals/management/telemetry/QueryTelemetry.scala
@@ -7,7 +7,7 @@ import io.prometheus.client.Gauge
   * Exposes Counter stats for tracking number of vertices, messages received and sent by `Query` handler, manager and executor
   * Statistics are made available on http://localhost:9999 on running tests and can be visualised using Grafana dashboards
   */
-object QueryTelemetry {
+private[raphtory] object QueryTelemetry {
 
   def receivedMessageCount: Counter =
     Counter.build

--- a/core/src/main/scala/com/raphtory/internals/management/telemetry/SpoutTelemetry.scala
+++ b/core/src/main/scala/com/raphtory/internals/management/telemetry/SpoutTelemetry.scala
@@ -6,7 +6,7 @@ import io.prometheus.client.Counter
   * Exposes Counter stats for tracking number of files processed, lines parsed, spout reschedules and processing errors
   * Statistics are made available on http://localhost:9999 on running tests and can be visualised using Grafana dashboards
   */
-object SpoutTelemetry {
+private[raphtory] object SpoutTelemetry {
 
   def totalFilesProcessed: Counter =
     Counter.build

--- a/core/src/main/scala/com/raphtory/internals/management/telemetry/StorageTelemetry.scala
+++ b/core/src/main/scala/com/raphtory/internals/management/telemetry/StorageTelemetry.scala
@@ -6,7 +6,7 @@ import io.prometheus.client.Counter
   * Exposes Counter stats for tracking number of files processed, lines parsed, spout reschedules and processing errors
   * Statistics are made available on http://localhost:9999 on running tests and can be visualised using Grafana dashboards
   */
-object StorageTelemetry {
+private[raphtory] object StorageTelemetry {
 
   def pojoLensGraphSize: Counter =
     Counter.build

--- a/core/src/main/scala/com/raphtory/internals/serialisers/KryoSerialiser.scala
+++ b/core/src/main/scala/com/raphtory/internals/serialisers/KryoSerialiser.scala
@@ -21,7 +21,7 @@ import com.twitter.chill.ScalaKryoInstantiator
   * producer.sendAsync(kryo.serialise("Gandalf,Benjamin,400"))
   * }}}
   */
-class KryoSerialiser {
+private[raphtory] class KryoSerialiser {
   private val kryo = ScalaKryoInstantiator.defaultPool
 
   /** serialise value to byte array
@@ -36,7 +36,7 @@ class KryoSerialiser {
     kryo.fromBytes(bytes).asInstanceOf[T]
 }
 
-object KryoSerialiser {
+private[raphtory] object KryoSerialiser {
 
   def apply(): KryoSerialiser =
     new KryoSerialiser()

--- a/core/src/main/scala/com/raphtory/internals/serialisers/Marshal.scala
+++ b/core/src/main/scala/com/raphtory/internals/serialisers/Marshal.scala
@@ -17,7 +17,7 @@ import scala.reflect.ClassTag
   *
   * @see [[KryoSerialiser]]
   */
-object Marshal {
+private[raphtory] object Marshal {
 
   /** Serialise to byte array
     * @param o object to serialise

--- a/core/src/main/scala/com/raphtory/internals/storage/pojograph/PojoBasedPartition.scala
+++ b/core/src/main/scala/com/raphtory/internals/storage/pojograph/PojoBasedPartition.scala
@@ -31,8 +31,7 @@ import org.slf4j.LoggerFactory
 
 import scala.collection.mutable
 
-/** @note DoNotDocument */
-class PojoBasedPartition(partition: Int, conf: Config)
+private[raphtory] class PojoBasedPartition(partition: Int, conf: Config)
         extends GraphPartition(partition: Int, conf: Config) {
   private val logger: Logger        = Logger(LoggerFactory.getLogger(this.getClass))
   private val hasDeletionsPath      = "raphtory.data.containsDeletions"

--- a/core/src/main/scala/com/raphtory/internals/storage/pojograph/PojoGraphLens.scala
+++ b/core/src/main/scala/com/raphtory/internals/storage/pojograph/PojoGraphLens.scala
@@ -24,8 +24,7 @@ import org.slf4j.LoggerFactory
 import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.mutable
 
-/** @note DoNotDocument */
-final case class PojoGraphLens(
+final private[raphtory] case class PojoGraphLens(
     jobId: String,
     start: Long,
     end: Long,

--- a/core/src/main/scala/com/raphtory/internals/storage/pojograph/entities/external/PojoExEdge.scala
+++ b/core/src/main/scala/com/raphtory/internals/storage/pojograph/entities/external/PojoExEdge.scala
@@ -8,8 +8,7 @@ import com.raphtory.internals.storage.pojograph.PojoGraphLens
 import com.raphtory.internals.storage.pojograph.entities.internal.PojoEdge
 import com.raphtory.internals.storage.pojograph.entities.internal.SplitEdge
 
-/** @note DoNotDocument */
-class PojoExEdge(val edge: PojoEdge, id: Long, val view: PojoGraphLens)
+private[raphtory] class PojoExEdge(val edge: PojoEdge, id: Long, val view: PojoGraphLens)
         extends PojoExEntity(edge, view)
         with ConcreteEdge[Long] {
 

--- a/core/src/main/scala/com/raphtory/internals/storage/pojograph/entities/external/PojoExEntity.scala
+++ b/core/src/main/scala/com/raphtory/internals/storage/pojograph/entities/external/PojoExEntity.scala
@@ -9,8 +9,8 @@ import com.raphtory.utils.OrderedBuffer.TupleByFirstOrdering
 import scala.collection.Searching.Found
 import scala.collection.Searching.InsertionPoint
 
-/** @note DoNotDocument */
-abstract class PojoExEntity(entity: PojoEntity, view: PojoGraphLens) extends EntityVisitor {
+abstract private[raphtory] class PojoExEntity(entity: PojoEntity, view: PojoGraphLens)
+        extends EntityVisitor {
   def Type(): String = entity.getType
 
   def firstActivityAfter(time: Long, strict: Boolean = true): Option[HistoricEvent] =

--- a/core/src/main/scala/com/raphtory/internals/storage/pojograph/entities/external/PojoExMultilayerEdge.scala
+++ b/core/src/main/scala/com/raphtory/internals/storage/pojograph/entities/external/PojoExMultilayerEdge.scala
@@ -8,7 +8,7 @@ import com.raphtory.internals.components.querymanager.FilteredOutEdgeMessage
 import com.raphtory.internals.components.querymanager.VertexMessage
 import com.raphtory.internals.storage.pojograph.PojoGraphLens
 
-class PojoExMultilayerEdge(
+private[raphtory] class PojoExMultilayerEdge(
     override val timestamp: Long,
     override val ID: (Long, Long),
     override val src: (Long, Long),

--- a/core/src/main/scala/com/raphtory/internals/storage/pojograph/entities/external/PojoExVertex.scala
+++ b/core/src/main/scala/com/raphtory/internals/storage/pojograph/entities/external/PojoExVertex.scala
@@ -14,8 +14,7 @@ import scala.collection.mutable
 import scala.math.Ordering
 import scala.reflect.ClassTag
 
-/** @note DoNotDocument */
-class PojoExVertex(
+private[raphtory] class PojoExVertex(
     private val v: PojoVertex,
     override protected val internalIncomingEdges: mutable.Map[Long, PojoExEdge],
     override protected val internalOutgoingEdges: mutable.Map[Long, PojoExEdge],

--- a/core/src/main/scala/com/raphtory/internals/storage/pojograph/entities/external/PojoExplodedEdge.scala
+++ b/core/src/main/scala/com/raphtory/internals/storage/pojograph/entities/external/PojoExplodedEdge.scala
@@ -7,8 +7,7 @@ import com.raphtory.internals.components.querymanager.VertexMessage
 import com.raphtory.internals.storage.pojograph.PojoGraphLens
 import com.raphtory.internals.storage.pojograph.entities.internal.PojoEdge
 
-/** @note DoNotDocument */
-class PojoExplodedEdge(
+private[raphtory] class PojoExplodedEdge(
     objectEdge: PojoEdge,
     view: PojoGraphLens,
     id: Long,
@@ -37,7 +36,7 @@ class PojoExplodedEdge(
   }
 }
 
-object PojoExplodedEdge {
+private[raphtory] object PojoExplodedEdge {
 
   def fromEdge(pojoExEdge: PojoExEdge, timestamp: Long): PojoExplodedEdge =
     new PojoExplodedEdge(

--- a/core/src/main/scala/com/raphtory/internals/storage/pojograph/entities/external/PojoExplodedVertex.scala
+++ b/core/src/main/scala/com/raphtory/internals/storage/pojograph/entities/external/PojoExplodedVertex.scala
@@ -7,7 +7,7 @@ import com.raphtory.internals.storage.pojograph.PojoGraphLens
 import scala.collection.mutable
 import scala.reflect.ClassTag
 
-class PojoExplodedVertex(
+private[raphtory] class PojoExplodedVertex(
     val vertex: PojoExVertex,
     override val timestamp: Long,
     override val lens: PojoGraphLens

--- a/core/src/main/scala/com/raphtory/internals/storage/pojograph/entities/external/PojoVertexBase.scala
+++ b/core/src/main/scala/com/raphtory/internals/storage/pojograph/entities/external/PojoVertexBase.scala
@@ -11,7 +11,7 @@ import com.raphtory.internals.storage.pojograph.messaging.VertexMultiQueue
 
 import scala.collection.mutable
 
-trait PojoVertexBase extends Vertex {
+private[raphtory] trait PojoVertexBase extends Vertex {
   // abstract state
   protected def lens: PojoGraphLens
   protected val internalIncomingEdges: mutable.Map[IDType, Edge]

--- a/core/src/main/scala/com/raphtory/internals/storage/pojograph/entities/internal/ImmutableProperty.scala
+++ b/core/src/main/scala/com/raphtory/internals/storage/pojograph/entities/internal/ImmutableProperty.scala
@@ -1,6 +1,6 @@
 package com.raphtory.internals.storage.pojograph.entities.internal
 
-class ImmutableProperty(creationTime: Long, value: Any) extends Property {
+private[raphtory] class ImmutableProperty(creationTime: Long, value: Any) extends Property {
   private var earliestTime: Long                = creationTime
   override def valueAt(time: Long): Option[Any] = if (time >= earliestTime) Some(value) else None
 

--- a/core/src/main/scala/com/raphtory/internals/storage/pojograph/entities/internal/MutableProperty.scala
+++ b/core/src/main/scala/com/raphtory/internals/storage/pojograph/entities/internal/MutableProperty.scala
@@ -10,7 +10,7 @@ import scala.collection.mutable
   * @param creationTime
   * @param value         Property value
   */
-class MutableProperty(creationTime: Long, value: Any) extends Property {
+private[raphtory] class MutableProperty(creationTime: Long, value: Any) extends Property {
   private var previousState: mutable.ArrayBuffer[(Long, Any)] = mutable.ArrayBuffer()
   // add in the initial information
   update(creationTime, value)

--- a/core/src/main/scala/com/raphtory/internals/storage/pojograph/entities/internal/PojoEdge.scala
+++ b/core/src/main/scala/com/raphtory/internals/storage/pojograph/entities/internal/PojoEdge.scala
@@ -2,8 +2,7 @@ package com.raphtory.internals.storage.pojograph.entities.internal
 
 import com.raphtory.utils.OrderedBuffer._
 
-/** @note DoNotDocument */
-class PojoEdge(msgTime: Long, srcId: Long, dstId: Long, initialValue: Boolean)
+private[raphtory] class PojoEdge(msgTime: Long, srcId: Long, dstId: Long, initialValue: Boolean)
         extends PojoEntity(msgTime, initialValue) {
 
   def killList(vKills: List[Long]): Unit = history sortedExtend vKills.map(x => (x, false))

--- a/core/src/main/scala/com/raphtory/internals/storage/pojograph/entities/internal/PojoEntity.scala
+++ b/core/src/main/scala/com/raphtory/internals/storage/pojograph/entities/internal/PojoEntity.scala
@@ -6,15 +6,15 @@ import scala.collection.Searching.Found
 import scala.collection.Searching.InsertionPoint
 import scala.collection.mutable
 
-/** @note DoNotDocument
-  * Represents Graph Entities (Edges and Vertices)
+/** Represents Graph Entities (Edges and Vertices)
+  *
   * Contains a Map of properties (currently String to string)
   * longs representing unique vertex ID's stored in subclasses
   *
   * @param creationTime ID of the message that created the entity
   * @param isInitialValue  Is the first moment this entity is referenced
   */
-abstract class PojoEntity(val creationTime: Long, isInitialValue: Boolean) {
+abstract private[raphtory] class PojoEntity(val creationTime: Long, isInitialValue: Boolean) {
 
   // Properties from that entity
   private var entityType: String                = ""

--- a/core/src/main/scala/com/raphtory/internals/storage/pojograph/entities/internal/PojoVertex.scala
+++ b/core/src/main/scala/com/raphtory/internals/storage/pojograph/entities/internal/PojoVertex.scala
@@ -6,8 +6,7 @@ import com.raphtory.internals.storage.pojograph.entities.external.PojoExVertex
 
 import scala.collection.mutable
 
-/** @note DoNotDocument */
-class PojoVertex(msgTime: Long, val vertexId: Long, initialValue: Boolean)
+private[raphtory] class PojoVertex(msgTime: Long, val vertexId: Long, initialValue: Boolean)
         extends PojoEntity(msgTime, initialValue) {
 
   var incomingEdges: mutable.Map[Long, PojoEdge] =

--- a/core/src/main/scala/com/raphtory/internals/storage/pojograph/entities/internal/Property.scala
+++ b/core/src/main/scala/com/raphtory/internals/storage/pojograph/entities/internal/Property.scala
@@ -1,6 +1,6 @@
 package com.raphtory.internals.storage.pojograph.entities.internal
 
-abstract class Property {
+abstract private[raphtory] class Property {
   def update(msgTime: Long, newValue: Any): Unit
   def valueAt(time: Long): Option[Any]
   def values(): Array[(Long, Any)]

--- a/core/src/main/scala/com/raphtory/internals/storage/pojograph/entities/internal/SplitEdge.scala
+++ b/core/src/main/scala/com/raphtory/internals/storage/pojograph/entities/internal/SplitEdge.scala
@@ -1,10 +1,9 @@
 package com.raphtory.internals.storage.pojograph.entities.internal
 
-/** @note DoNotDocument
-  * Extension of the Edge entity, used when we want to store a remote edge
+/** Extension of the Edge entity, used when we want to store a remote edge
   * i.e. one spread across two partitions
   * currently only stores what end of the edge is remote
   * and which partition this other half is stored in
   */
-class SplitEdge(msgTime: Long, srcID: Long, dstID: Long, initialValue: Boolean)
+private[raphtory] class SplitEdge(msgTime: Long, srcID: Long, dstID: Long, initialValue: Boolean)
         extends PojoEdge(msgTime, srcID, dstID, initialValue) {}

--- a/core/src/main/scala/com/raphtory/internals/storage/pojograph/messaging/VertexMessageHandler.scala
+++ b/core/src/main/scala/com/raphtory/internals/storage/pojograph/messaging/VertexMessageHandler.scala
@@ -13,8 +13,7 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.mutable
 
-/** @note DoNotDocument */
-class VertexMessageHandler(
+private[raphtory] class VertexMessageHandler(
     config: Config,
     endPoints: Option[Map[Int, EndPoint[QueryManagement]]],
     pojoGraphLens: PojoGraphLens,
@@ -99,7 +98,7 @@ class VertexMessageHandler(
 
 }
 
-object VertexMessageHandler {
+private[raphtory] object VertexMessageHandler {
 
   def apply(
       config: Config,

--- a/core/src/main/scala/com/raphtory/internals/storage/pojograph/messaging/VertexMultiQueue.scala
+++ b/core/src/main/scala/com/raphtory/internals/storage/pojograph/messaging/VertexMultiQueue.scala
@@ -5,8 +5,7 @@ import org.slf4j.LoggerFactory
 
 import scala.collection.mutable.ArrayBuffer
 
-/** @note DoNotDocument */
-final class VertexMultiQueue {
+final private[raphtory] class VertexMultiQueue {
   private val logger: Logger = Logger(LoggerFactory.getLogger(this.getClass))
 
   private val evenMessageQueue: ArrayBuffer[Any] = ArrayBuffer.empty

--- a/core/src/main/scala/com/raphtory/internals/time/DateTimeParser.scala
+++ b/core/src/main/scala/com/raphtory/internals/time/DateTimeParser.scala
@@ -7,8 +7,7 @@ import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import scala.util.Try
 
-/** @note DoNotDocument */
-class DateTimeParser(format: String) {
+private[raphtory] class DateTimeParser(format: String) {
   private val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern(format)
 
   def parse(datetime: String): Long =
@@ -18,7 +17,7 @@ class DateTimeParser(format: String) {
       .get
 }
 
-object DateTimeParser {
+private[raphtory] object DateTimeParser {
   def apply(format: String) = new DateTimeParser(format)
 
   def defaultParse(datetime: String): Long =

--- a/core/src/main/scala/com/raphtory/internals/time/IntervalParser.scala
+++ b/core/src/main/scala/com/raphtory/internals/time/IntervalParser.scala
@@ -1,5 +1,7 @@
 package com.raphtory.internals.time
 
+import com.raphtory.api.time.TimeInterval
+
 import java.time.Duration
 import java.time.Period
 import scala.language.postfixOps
@@ -7,8 +9,7 @@ import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
 
-/** @note DoNotDocument */
-object IntervalParser {
+private[raphtory] object IntervalParser {
 
   sealed trait Unit
   sealed trait PeriodUnit   extends Unit // Can only be handled by java.time.Period

--- a/core/src/main/scala/com/raphtory/internals/time/InvalidIntervalException.scala
+++ b/core/src/main/scala/com/raphtory/internals/time/InvalidIntervalException.scala
@@ -1,4 +1,3 @@
 package com.raphtory.internals.time
 
-/** @note DoNotDocument */
-class InvalidIntervalException(message: String) extends Exception(message)
+private[raphtory] class InvalidIntervalException(message: String) extends Exception(message)

--- a/core/src/main/scala/com/raphtory/internals/time/TimeConverters.scala
+++ b/core/src/main/scala/com/raphtory/internals/time/TimeConverters.scala
@@ -1,10 +1,14 @@
 package com.raphtory.internals.time
 
+import com.raphtory.api.time.DiscreteInterval
+import com.raphtory.api.time.Interval
+import com.raphtory.api.time.NullInterval
+import com.raphtory.api.time.TimeInterval
+
 import java.time.Instant
 import java.time.ZoneOffset
 
-/** @note DoNotDocument */
-object TimeConverters {
+private[raphtory] object TimeConverters {
 
   implicit class TimeHolder(val time: Long) {
 

--- a/core/src/main/scala/com/raphtory/sinks/FileSink.scala
+++ b/core/src/main/scala/com/raphtory/sinks/FileSink.scala
@@ -3,17 +3,15 @@ package com.raphtory.sinks
 import com.raphtory.api.analysis.table.Table
 import com.raphtory.api.output.format.Format
 import com.raphtory.api.output.sink.FormatAgnosticSink
-import com.raphtory.api.output.sink.Sink
 import com.raphtory.api.output.sink.SinkConnector
 import com.raphtory.api.output.sink.StreamSinkConnector
 import com.raphtory.formats.CsvFormat
-import com.raphtory.internals.management.GraphDeployment
 import com.typesafe.config.Config
 
 import java.io.File
 import java.io.FileWriter
 
-/** A `Sink` that writes a `Table` into files using the given `format`.
+/** A [[com.raphtory.api.output.sink.Sink Sink]] that writes a `Table` into files using the given `format`.
   *
   * The sink creates one directory with the job id as name inside `filepath`
   * and one file for every partition on the server inside that directory.
@@ -34,16 +32,16 @@ import java.io.FileWriter
   *
   * graph.execute(EdgeList()).writeTo(sink)
   * }}}
-  * @see [[Sink]]
-  *      [[Format]]
-  *      [[CsvFormat]]
-  *      [[Table]]
-  *      [[com.raphtory.Raphtory]]
+  * @see [[com.raphtory.api.output.sink.Sink Sink]]
+  *      [[com.raphtory.api.output.format.Format Format]]
+  *      [[com.raphtory.formats.CsvFormat CsvFormat]]
+  *      [[com.raphtory.api.analysis.table.Table Table]]
+  *      [[com.raphtory.Raphtory Raphtory]]
   */
 case class FileSink(filePath: String, format: Format = CsvFormat())
         extends FormatAgnosticSink(format) {
 
-  override protected def buildConnector(
+  override def buildConnector(
       jobID: String,
       partitionID: Int,
       config: Config,

--- a/core/src/main/scala/com/raphtory/sinks/PrintSink.scala
+++ b/core/src/main/scala/com/raphtory/sinks/PrintSink.scala
@@ -9,7 +9,7 @@ import com.raphtory.api.output.sink.StreamSinkConnector
 import com.raphtory.formats.CsvFormat
 import com.typesafe.config.Config
 
-/** A `Sink` that prints a `Table` to the standard output.
+/** A [[com.raphtory.api.output.sink.Sink Sink]] that prints a `Table` to the standard output.
   *
   * @param format the format to be used by this sink (`CsvFormat` by default)
   *
@@ -27,15 +27,15 @@ import com.typesafe.config.Config
   *
   * graph.execute(EdgeList()).writeTo(sink)
   * }}}
-  * @see [[Sink]]
-  *      [[Format]]
-  *      [[CsvFormat]]
-  *      [[Table]]
-  *      [[com.raphtory.Raphtory]]
+  * @see [[com.raphtory.api.output.sink.Sink Sink]]
+  *      [[com.raphtory.api.output.format.Format Format]]
+  *      [[com.raphtory.formats.CsvFormat CsvFormat]]
+  *      [[com.raphtory.api.analysis.table.Table Table]]
+  *      [[com.raphtory.Raphtory Raphtory]]
   */
 case class PrintSink(format: Format = CsvFormat()) extends FormatAgnosticSink(format) {
 
-  override protected def buildConnector(
+  override def buildConnector(
       jobID: String,
       partitionID: Int,
       config: Config,

--- a/core/src/main/scala/com/raphtory/sinks/PulsarSink.scala
+++ b/core/src/main/scala/com/raphtory/sinks/PulsarSink.scala
@@ -12,7 +12,7 @@ import com.raphtory.internals.management.GraphDeployment
 import com.typesafe.config.Config
 import org.apache.pulsar.client.api.Schema
 
-/** A `Sink` that sends a `Table` to the specified Pulsar `topic` using the given `format`.
+/** A [[com.raphtory.api.output.sink.Sink Sink]] that sends a `Table` to the specified Pulsar `topic` using the given `format`.
   *
   * @param topic the name of the Pulsar topic to send the table to
   * @param format the format to be used by this sink (`CsvFormat` by default)
@@ -30,16 +30,16 @@ import org.apache.pulsar.client.api.Schema
   *
   * graph.execute(EdgeList()).writeTo(sink)
   * }}}
-  * @see [[Sink]]
-  *      [[Format]]
-  *      [[CsvFormat]]
-  *      [[Table]]
-  *      [[com.raphtory.Raphtory]]
+  * @see [[com.raphtory.api.output.sink.Sink Sink]]
+  *      [[com.raphtory.api.output.format.Format Format]]
+  *      [[com.raphtory.formats.CsvFormat CsvFormat]]
+  *      [[com.raphtory.api.analysis.table.Table Table]]
+  *      [[com.raphtory.Raphtory Raphtory]]
   */
 case class PulsarSink(topic: String, format: Format = CsvFormat())
         extends FormatAgnosticSink(format) {
 
-  override protected def buildConnector(
+  override def buildConnector(
       jobID: String,
       partitionID: Int,
       config: Config,

--- a/core/src/test/scala/com/raphtory/api/analysis/graphview/RaphtoryGraphTest.scala
+++ b/core/src/test/scala/com/raphtory/api/analysis/graphview/RaphtoryGraphTest.scala
@@ -5,8 +5,8 @@ import com.raphtory.algorithms.generic.ConnectedComponents
 import com.raphtory.api.analysis.table.Row
 import com.raphtory.api.analysis.table.TableFilter
 import com.raphtory.api.analysis.table.TableImplementation
+import com.raphtory.api.time.DiscreteInterval
 import com.raphtory.internals.components.querymanager.PointPath
-import com.raphtory.internals.time.DiscreteInterval
 import org.scalatest.funsuite.AnyFunSuite
 
 class RaphtoryGraphTest extends AnyFunSuite {

--- a/docs/source/exts/extractScalaAlgoDocs.py
+++ b/docs/source/exts/extractScalaAlgoDocs.py
@@ -7,9 +7,6 @@ import subprocess
 
 """
 Minimal Sphinx extension to extract Algorithm documentation from Raphtory.
-
-For this extension to discover Raphtory, the environment variable "RAPHTORY_PATH" needs to be set and should point to 
-the root of the Raphtory project.
 """
 
 


### PR DESCRIPTION
- Cleans up the package structure and fixes all links in the scaladocs
- Marks all classes in internals as `private[raphtory]`

Unfortunately, even with `-private` set, it seems that documentation for private classes is not generated, only for private methods in public classes.