### PR TITLE
Feature/extend filters

### DIFF
--- a/core/src/main/scala/com/raphtory/algorithms/generic/filters/DisparityFilter.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/generic/filters/DisparityFilter.scala
@@ -9,7 +9,7 @@ import scala.reflect.ClassTag
 import scala.language.implicitConversions
 import scala.math.Numeric.Implicits.infixNumericOps
 
-class DisparityFilter[T: Numeric : Bounded: ClassTag](alpha: Float=0.05f, weightProperty:String) extends Generic {
+class DisparityFilter[T: Numeric : Bounded: ClassTag](alpha: Double=0.05, weightProperty:String) extends Generic {
 
   override def apply(graph: GraphPerspective): graph.Graph = {
     graph.step{
@@ -24,11 +24,11 @@ class DisparityFilter[T: Numeric : Bounded: ClassTag](alpha: Float=0.05f, weight
           val weightMap = messages.groupBy(_._1).mapValues(_.head._3)
 
           val k1 = vertex.degree
-          val s1 = vertex.weightedTotalDegree[T](weightProperty = weightProperty)
+          val s1 = vertex.weightedTotalDegree[T](weightProperty = weightProperty).toDouble
           vertex.getInEdges().foreach{
             edge =>
               val k2 = degreeMap(edge.src)
-              val s2 = weightMap(edge.src)
+              val s2 = weightMap(edge.src).toDouble
               val wgt = edge.weight[T](weightProperty = weightProperty)
 
               val (pij, pji) = (wgt.toDouble/s1, wgt.toDouble/s2)
@@ -42,5 +42,5 @@ class DisparityFilter[T: Numeric : Bounded: ClassTag](alpha: Float=0.05f, weight
 }
 
 object DisparityFilter {
-  def apply[T: Numeric: Bounded: ClassTag](alpha: Float=0.05f, weightProperty:String) = new DisparityFilter[T](alpha,weightProperty)
+  def apply[T: Numeric: Bounded: ClassTag](alpha: Double=0.05, weightProperty:String) = new DisparityFilter[T](alpha,weightProperty)
 }

--- a/core/src/main/scala/com/raphtory/algorithms/generic/filters/DisparityFilter.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/generic/filters/DisparityFilter.scala
@@ -9,7 +9,29 @@ import scala.reflect.ClassTag
 import scala.language.implicitConversions
 import scala.math.Numeric.Implicits.infixNumericOps
 
-class DisparityFilter[T: Numeric : Bounded: ClassTag](alpha: Double=0.05, weightProperty:String) extends Generic {
+/**
+  * {s}`DisparityFilter(alpha: Double=0.05, weightProperty:String="weight")`
+  * : Filtered view of a weighted graph based on Edge Disparity.
+  *
+  *  This creates a filtered view of a weighted graph where only "statistically significant" edges remain. For a description of this method,
+  *  please refer to: Serrano, M. Ángeles, Marián Boguná, and Alessandro Vespignani. "Extracting the multiscale backbone of complex weighted networks."
+  *  Proceedings of the National Academy of Sciences 106.16 (2009): 6483-6488. Note that this implementation is aimed at undirected networks.
+  *
+  * ## Parameters
+  *
+  *  {s}`alpha: Double = 0.05`
+  *  : Significance level to use. A smaller {s}`alpha` value means more edges will be removed
+  *
+  *  {s}`weightString: String = "weight"`
+  *  : String name of the property/state, defaulting to "weight". As with other weighted algorithms in Raphtory, if no weight property
+  *  is there but multi-edges are present, the number of occurrences of each edge is treated as the weight.
+  *
+  * ```{seealso}
+  * [](com.raphtory.algorithms.generic.filters.EdgeQuantileFilter)
+  * ```
+  */
+
+class DisparityFilter[T: Numeric : Bounded: ClassTag](alpha: Double=0.05, weightProperty:String="weight") extends Generic {
 
   override def apply(graph: GraphPerspective): graph.Graph = {
     graph.step{
@@ -42,5 +64,5 @@ class DisparityFilter[T: Numeric : Bounded: ClassTag](alpha: Double=0.05, weight
 }
 
 object DisparityFilter {
-  def apply[T: Numeric: Bounded: ClassTag](alpha: Double=0.05, weightProperty:String) = new DisparityFilter[T](alpha,weightProperty)
+  def apply[T: Numeric: Bounded: ClassTag](alpha: Double=0.05, weightProperty:String="weight") = new DisparityFilter[T](alpha,weightProperty)
 }

--- a/core/src/main/scala/com/raphtory/algorithms/generic/filters/DisparityFilter.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/generic/filters/DisparityFilter.scala
@@ -1,0 +1,46 @@
+package com.raphtory.algorithms.generic.filters
+
+import com.raphtory.api.analysis.algorithm.Generic
+import com.raphtory.api.analysis.graphview.GraphPerspective
+import com.raphtory.utils.Bounded
+
+import scala.reflect.ClassTag
+
+import scala.language.implicitConversions
+import scala.math.Numeric.Implicits.infixNumericOps
+
+class DisparityFilter[T: Numeric : Bounded: ClassTag](alpha: Float=0.05f, weightProperty:String) extends Generic {
+
+  override def apply(graph: GraphPerspective): graph.Graph = {
+    graph.step{
+      vertex =>
+        // out neighbours means no need to send double messages
+        vertex.messageOutNeighbours(vertex.ID, vertex.degree, vertex.weightedTotalDegree[T](weightProperty=weightProperty))
+    }
+      .step{
+        vertex =>
+          val messages = vertex.messageQueue[(vertex.IDType, Int, T)]
+          val degreeMap = messages.groupBy(_._1).mapValues(_.head._2)
+          val weightMap = messages.groupBy(_._1).mapValues(_.head._3)
+
+          val k1 = vertex.degree
+          val s1 = vertex.weightedTotalDegree[T](weightProperty = weightProperty)
+          vertex.getInEdges().foreach{
+            edge =>
+              val k2 = degreeMap(edge.src)
+              val s2 = weightMap(edge.src)
+              val wgt = edge.weight[T](weightProperty = weightProperty)
+
+              val (pij, pji) = (wgt.toDouble/s1, wgt.toDouble/s2)
+              val (aij, aji) = (Math.pow(1.0-pij, k1 -1), Math.pow(1.0-pji,k2-1))
+              if (aij < alpha || aji < alpha)
+                edge.remove()
+          }
+      }
+  }
+
+}
+
+object DisparityFilter {
+  def apply[T: Numeric: Bounded: ClassTag](alpha: Float=0.05f, weightProperty:String) = new DisparityFilter[T](alpha,weightProperty)
+}

--- a/core/src/main/scala/com/raphtory/algorithms/generic/filters/UniformEdgeSample.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/generic/filters/UniformEdgeSample.scala
@@ -1,0 +1,29 @@
+package com.raphtory.algorithms.generic.filters
+
+import com.raphtory.api.analysis.algorithm.Generic
+import com.raphtory.api.analysis.graphview.GraphPerspective
+
+import scala.util.Random
+
+/**
+  * {s} `UniformEdgeSample(p:Float, pruneNodes:Boolean=true)`
+  *   : Filtered view of the graph achieved by taking a uniform random sample of the edges
+  *
+  *   This retains each edge of the graph with probability p. Additionally, if pruneNodes is set to true,
+  *   nodes which become isolated by this edge removal are also removed.
+  *
+  * ```{seealso}
+  * [](com.raphtory.algorithms.generic.filters.EdgeFilter)
+  * [](com.raphtory.algorithms.generic.filters.UniformVertexSample)
+  * ```
+  */
+
+class UniformEdgeSample(p:Float, pruneNodes:Boolean=true) extends Generic{
+  override def apply(graph: GraphPerspective): graph.Graph = {
+    graph.edgeFilter(_=> Random.nextFloat()<p, pruneNodes = pruneNodes)
+  }
+}
+
+object UniformEdgeSample {
+  def apply(p:Float,pruneNodes:Boolean=true) = new UniformEdgeSample(p,pruneNodes)
+}

--- a/core/src/main/scala/com/raphtory/algorithms/generic/filters/UniformVertexSample.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/generic/filters/UniformVertexSample.scala
@@ -1,0 +1,31 @@
+package com.raphtory.algorithms.generic.filters
+
+import com.raphtory.algorithms.generic.NodeList
+import com.raphtory.api.analysis.graphview.GraphPerspective
+
+import scala.util.Random
+
+/**
+  * {s} `UniformVertexSample(p:Float)`
+  *   : Filtered view of the graph achieved by taking a uniform random sample of the vertices
+  *
+  *   This retains each vertex of the graph with probability p, and edges between those retained vertices.
+  *   Also known as induced subgraph sampling.
+  *
+  * ```{seealso}
+  * [](com.raphtory.algorithms.generic.filters.VertexFilter)
+  * [](com.raphtory.algorithms.generic.filters.UniformEdgeSample)
+  * ```
+  */
+
+class UniformVertexSample(p:Float) extends NodeList(){
+
+  override def apply(graph: GraphPerspective): graph.Graph = {
+    graph.vertexFilter(_ => Random.nextFloat() < p)
+  }
+
+}
+
+object UniformVertexSample {
+  def apply(p:Float) = new UniformVertexSample(p)
+}


### PR DESCRIPTION
I added some more filters to the `filters` module:
* `UniformVertexSample` samples each vertex with uniform probability `p`
* `UniformEdgeSample` samples each edge with uniform probability `p`. As with other edge filters, one can optionally remove nodes which become degree zero from this process.
* `DisparityFilter`: this one is a bit more difficult to explain in a PR but it's a more local filtering of weighted networks keeping only "statistically significant" edges. Roughly speaking, compares the edge weights coming from a vertex to what you'd get if you took all the weight from that vertex and partitioned it randomly across those edges, and keep only the edges whose weights are more than what you'd expect at random.

Any feedback or suggested improvements are very welcome! 😊 