### PR TITLE
Redesign ZookeeperIDManager to allow safer id reallocation for partitions

### DIFF
--- a/core/src/main/scala/com/raphtory/internals/communication/connectors/PulsarConnector.scala
+++ b/core/src/main/scala/com/raphtory/internals/communication/connectors/PulsarConnector.scala
@@ -94,7 +94,7 @@ private[raphtory] class PulsarConnector(config: Config) extends Connector {
       .toSeq
 
     new CancelableListener {
-      var consumers: Seq[Consumer[Array[Byte]]] = _
+      var consumers: Seq[Consumer[Array[Byte]]] = Seq()
       override def start(): Unit                = consumers = consumerBuilders map (_.subscribe())
       override def close(): Unit                =
         consumers foreach { consumer =>

--- a/core/src/main/scala/com/raphtory/internals/management/ComponentFactory.scala
+++ b/core/src/main/scala/com/raphtory/internals/management/ComponentFactory.scala
@@ -40,9 +40,9 @@ private[raphtory] class ComponentFactory(
     else {
       val zookeeperAddress     = conf.getString("raphtory.zookeeper.address")
       val zkBuilderIDManager   =
-        new ZookeeperIDManager(zookeeperAddress, s"/$deploymentID/builderCount")
+        new ZookeeperIDManager(zookeeperAddress, deploymentID, "builderCount")
       val zkPartitionIDManager =
-        new ZookeeperIDManager(zookeeperAddress, s"/$deploymentID/partitionCount")
+        new ZookeeperIDManager(zookeeperAddress, deploymentID, "partitionCount")
       (zkBuilderIDManager, zkPartitionIDManager)
     }
 
@@ -170,6 +170,7 @@ private[raphtory] class ComponentFactory(
       Partitions(x.map(_._1).toList, x.map(_._2).toList, x.map(_._3).toList)
     }
 
+    logger.info(s"Created partitions with ids: ${partitionIDs.toList}.")
     partitions
   }
 

--- a/core/src/main/scala/com/raphtory/internals/management/id/IDManager.scala
+++ b/core/src/main/scala/com/raphtory/internals/management/id/IDManager.scala
@@ -2,6 +2,5 @@ package com.raphtory.internals.management.id
 
 private[raphtory] trait IDManager {
   def getNextAvailableID(): Option[Int]
-  def resetID(): Unit
   def stop(): Unit
 }

--- a/core/src/main/scala/com/raphtory/internals/management/id/LocalIDManager.scala
+++ b/core/src/main/scala/com/raphtory/internals/management/id/LocalIDManager.scala
@@ -6,6 +6,5 @@ private[raphtory] class LocalIDManager extends IDManager {
   private val nextId = new AtomicInteger(0)
 
   override def getNextAvailableID(): Option[Int] = Some(nextId.getAndIncrement())
-  override def resetID(): Unit                   = nextId.set(0)
   override def stop(): Unit = {}
 }

--- a/core/src/main/scala/com/raphtory/internals/storage/pojograph/messaging/VertexMessageHandler.scala
+++ b/core/src/main/scala/com/raphtory/internals/storage/pojograph/messaging/VertexMessageHandler.scala
@@ -54,7 +54,14 @@ private[raphtory] class VertexMessageHandler(
       receivedMessages.incrementAndGet()
     }
     else { //sending to a remote partition
-      val producer = endPoints.get(destinationPartition)
+      val producer = endPoints match {
+        case Some(endPoints) => endPoints(destinationPartition)
+        case None            =>
+          val msg =
+            s"Trying to send message to partition $destinationPartition from partition ${pojoGraphLens.partitionID} but no endPoints were provided"
+          logger.error(msg)
+          throw new IllegalStateException(msg)
+      }
       if (messageBatch) {
         val cache = messageCache(producer)
         cache.synchronized {


### PR DESCRIPTION
The idea is having this zknode hierarchy for every set of ids we want to allocate. When we call `ZookeeperIDManager.getNextAvailableId` it tries to allocate one the ids that might exist creating an ephemeral (red color) zknode under the corresponding zknode. If it succeed, returns that id. If not, keeps trying with other ids. Once the partition disappears, the `allocated` zknode goes away and gets therefore available to be allocated for other partitions.

<img width="615" alt="Screenshot 2022-06-16 at 13 43 14" src="https://user-images.githubusercontent.com/38461987/174073178-9d49e67f-6dfa-413d-93ba-9a8b582bb3f2.png">


This PR also cleans up the building of the partitions managing the ids.