### PR TITLE
Fix examples after refactor

### DIFF
--- a/connectors/aws/src/test/scala/com/raphtory/aws/LotrGraphBuilder.scala
+++ b/connectors/aws/src/test/scala/com/raphtory/aws/LotrGraphBuilder.scala
@@ -3,7 +3,7 @@ package com.raphtory.aws
 import com.raphtory.api.input.GraphBuilder
 import com.raphtory.api.input.ImmutableProperty
 import com.raphtory.api.input.Properties
-import com.raphtory.internals.graph.Type
+import com.raphtory.api.input.Type
 
 class LOTRGraphBuilder() extends GraphBuilder[String] {
 

--- a/examples/raphtory-example-ethereum/src/main/scala/com/raphtory/ethereum/graphbuilder/EthereumGraphBuilder.scala
+++ b/examples/raphtory-example-ethereum/src/main/scala/com/raphtory/ethereum/graphbuilder/EthereumGraphBuilder.scala
@@ -5,11 +5,7 @@ import com.raphtory.api.input.GraphBuilder
 import com.raphtory.api.input.ImmutableProperty
 import com.raphtory.api.input.Properties
 import com.raphtory.ethereum.EthereumTransaction
-import com.raphtory.internals.graph.Type
-
-import java.io.BufferedReader
-import java.io.FileReader
-import scala.collection.mutable
+import com.raphtory.api.input.Type
 
 class EthereumTxGraphBuilder() extends GraphBuilder[EthereumTransaction] {
 


### PR DESCRIPTION
- `Type` was moved during refactoring but examples were not updated 