### PR TITLE
Fix vertex messaging synchronisation between query executors

### DIFF
--- a/core/src/main/resources/application.conf
+++ b/core/src/main/resources/application.conf
@@ -214,6 +214,38 @@ raphtory {
           size                  = ${?RAPHTORY_PULSAR_TOPICS_JOB_OPERATIONS_RETENTION_SIZE}
         }
       }
+      vertex.messages.sync {
+              tenant                  = "public"
+              tenant                  = ${?RAPHTORY_PULSAR_TOPICS_TENANT}
+              tenant                  = ${?RAPHTORY_PULSAR_TOPICS_VERTEX_MESSAGES_TENANT}
+              namespace               = ${raphtory.deploy.id}
+              namespace               = ${?RAPHTORY_PULSAR_TOPICS_NAMESPACE}
+              namespace               = ${?RAPHTORY_PULSAR_TOPICS_VERTEX_MESSAGES_NAMESPACE}
+              persistence             = true
+              persistence             = ${?RAPHTORY_PULSAR_TOPICS_VERTEX_MESSAGES_PERSISTENCE}
+              retention {
+                time                  = ${raphtory.pulsar.retention.time}
+                time                  = ${?RAPHTORY_PULSAR_TOPICS_VERTEX_MESSAGES_RETENTION_TIME}
+                size                  = ${raphtory.pulsar.retention.size}
+                size                  = ${?RAPHTORY_PULSAR_TOPICS_VERTEX_MESSAGES_RETENTION_SIZE}
+              }
+            }
+            job.operations {
+              tenant                  = "public"
+              tenant                  = ${?RAPHTORY_PULSAR_TOPICS_TENANT}
+              tenant                  = ${?RAPHTORY_PULSAR_TOPICS_JOB_OPERATIONS_TENANT}
+              namespace               = ${raphtory.deploy.id}
+              namespace               = ${?RAPHTORY_PULSAR_TOPICS_NAMESPACE}
+              namespace               = ${?RAPHTORY_PULSAR_TOPICS_JOB_OPERATIONS_NAMESPACE}
+              persistence             = true
+              persistence             = ${?RAPHTORY_PULSAR_TOPICS_JOB_OPERATIONS_PERSISTENCE}
+              retention {
+                time                  = ${raphtory.pulsar.retention.time}
+                time                  = ${?RAPHTORY_PULSAR_TOPICS_JOB_OPERATIONS_RETENTION_TIME}
+                size                  = ${raphtory.pulsar.retention.size}
+                size                  = ${?RAPHTORY_PULSAR_TOPICS_JOB_OPERATIONS_RETENTION_SIZE}
+              }
+            }
     }
   }
 

--- a/core/src/main/scala/com/raphtory/internals/communication/CancelableListener.scala
+++ b/core/src/main/scala/com/raphtory/internals/communication/CancelableListener.scala
@@ -1,5 +1,7 @@
 package com.raphtory.internals.communication
 
+import scala.util.Try
+
 private[raphtory] trait CancelableListener {
   def start(): Unit
   def close(): Unit
@@ -13,7 +15,7 @@ private[raphtory] object CancelableListener {
 
       override def close(): Unit =
         listeners foreach (listener => {
-          listener.close()
+          Try(listener.close())
         })
     }
 }

--- a/core/src/main/scala/com/raphtory/internals/communication/TopicRepository.scala
+++ b/core/src/main/scala/com/raphtory/internals/communication/TopicRepository.scala
@@ -1,7 +1,11 @@
 package com.raphtory.internals.communication
 
-import com.raphtory.internals.components.querymanager.{EndQuery, Query, QueryManagement, WatermarkTime}
+import com.raphtory.internals.components.querymanager.EndQuery
+import com.raphtory.internals.components.querymanager.Query
+import com.raphtory.internals.components.querymanager.QueryManagement
+import com.raphtory.internals.components.querymanager.WatermarkTime
 import com.raphtory.internals.graph.GraphAlteration._
+import com.raphtory.internals.components.querymanager.VertexMessagesSync
 import com.typesafe.config.Config
 
 private[raphtory] class TopicRepository(
@@ -19,11 +23,12 @@ private[raphtory] class TopicRepository(
   protected def watermarkConnector: Connector        = defaultConnector
   protected def queryPrepConnector: Connector        = defaultConnector
 
-  protected def queryTrackConnector: Connector     = defaultConnector
-  protected def rechecksConnector: Connector       = defaultConnector
-  protected def jobStatusConnector: Connector      = defaultConnector
-  protected def vertexMessagesConnector: Connector = defaultConnector
-  def jobOperationsConnector: Connector            = defaultConnector // accessed within the queryHandler
+  protected def queryTrackConnector: Connector         = defaultConnector
+  protected def rechecksConnector: Connector           = defaultConnector
+  protected def jobStatusConnector: Connector          = defaultConnector
+  protected def vertexMessagesConnector: Connector     = defaultConnector
+  protected def vertexMessagesSyncConnector: Connector = defaultConnector
+  def jobOperationsConnector: Connector                = defaultConnector // accessed within the queryHandler
 
   // Configuration
   private val spoutAddress: String     = conf.getString("raphtory.spout.topic")
@@ -69,6 +74,14 @@ private[raphtory] class TopicRepository(
             numPartitions,
             vertexMessagesConnector,
             "vertex.messages",
+            s"$depId-$jobId"
+    )
+
+  final def vertexMessagesSync(jobId: String): ShardingTopic[VertexMessagesSync] =
+    ShardingTopic[VertexMessagesSync](
+            numPartitions,
+            vertexMessagesSyncConnector,
+            "vertex.messages.sync",
             s"$depId-$jobId"
     )
 

--- a/core/src/main/scala/com/raphtory/internals/communication/TopicRepository.scala
+++ b/core/src/main/scala/com/raphtory/internals/communication/TopicRepository.scala
@@ -3,9 +3,10 @@ package com.raphtory.internals.communication
 import com.raphtory.internals.components.querymanager.EndQuery
 import com.raphtory.internals.components.querymanager.Query
 import com.raphtory.internals.components.querymanager.QueryManagement
+import com.raphtory.internals.components.querymanager.VertexMessagesSync
+import com.raphtory.internals.components.querymanager.VertexMessaging
 import com.raphtory.internals.components.querymanager.WatermarkTime
 import com.raphtory.internals.graph.GraphAlteration._
-import com.raphtory.internals.components.querymanager.VertexMessagesSync
 import com.typesafe.config.Config
 
 private[raphtory] class TopicRepository(
@@ -69,8 +70,8 @@ private[raphtory] class TopicRepository(
   final def jobStatus(jobId: String): ExclusiveTopic[QueryManagement] =
     ExclusiveTopic[QueryManagement](jobStatusConnector, "job.status", s"$depId-$jobId")
 
-  final def vertexMessages(jobId: String): ShardingTopic[QueryManagement] =
-    ShardingTopic[QueryManagement](
+  final def vertexMessages(jobId: String): ShardingTopic[VertexMessaging] =
+    ShardingTopic[VertexMessaging](
             numPartitions,
             vertexMessagesConnector,
             "vertex.messages",

--- a/core/src/main/scala/com/raphtory/internals/communication/repositories/PulsarAkkaTopicRepository.scala
+++ b/core/src/main/scala/com/raphtory/internals/communication/repositories/PulsarAkkaTopicRepository.scala
@@ -14,14 +14,15 @@ private[raphtory] object PulsarAkkaTopicRepository {
       akkaConnector   <- AkkaTopicRepository.makeConnector[IO]
       pulsarConnector <- PulsarConnector[IO](config)
     } yield new TopicRepository(pulsarConnector, config, Array(akkaConnector, pulsarConnector)) {
-      override def jobOperationsConnector: Connector    = akkaConnector
-      override def jobStatusConnector: Connector        = akkaConnector
-      override def queryPrepConnector: Connector        = akkaConnector
-      override def completedQueriesConnector: Connector = akkaConnector
-      override def watermarkConnector: Connector        = akkaConnector
-      override def rechecksConnector: Connector         = akkaConnector
-      override def queryTrackConnector: Connector       = akkaConnector
-      override def submissionsConnector: Connector      = akkaConnector
+      override def jobOperationsConnector: Connector      = akkaConnector
+      override def jobStatusConnector: Connector          = akkaConnector
+      override def queryPrepConnector: Connector          = akkaConnector
+      override def completedQueriesConnector: Connector   = akkaConnector
+      override def watermarkConnector: Connector          = akkaConnector
+      override def rechecksConnector: Connector           = akkaConnector
+      override def queryTrackConnector: Connector         = akkaConnector
+      override def submissionsConnector: Connector        = akkaConnector
+      override def vertexMessagesSyncConnector: Connector = akkaConnector
     }
 
 }

--- a/core/src/main/scala/com/raphtory/internals/components/querymanager/AnalysisMessages.scala
+++ b/core/src/main/scala/com/raphtory/internals/components/querymanager/AnalysisMessages.scala
@@ -37,7 +37,9 @@ private[raphtory] case object RecheckTime                 extends QueryManagemen
 private[raphtory] case object RecheckEarliestTime         extends QueryManagement
 private[raphtory] case class CheckMessages(jobId: String) extends QueryManagement
 
-sealed private[raphtory] trait GenericVertexMessage[VertexID] extends QueryManagement {
+sealed private[raphtory] trait VertexMessaging extends QueryManagement
+
+sealed private[raphtory] trait GenericVertexMessage[VertexID] extends VertexMessaging {
   def superstep: Int
   def vertexId: VertexID
 }
@@ -48,7 +50,7 @@ private[raphtory] case class VertexMessage[+T, VertexID](
     data: T
 ) extends GenericVertexMessage[VertexID]
 
-private[raphtory] case class VertexMessageBatch(data: Array[GenericVertexMessage[_]]) extends QueryManagement
+private[raphtory] case class VertexMessageBatch(data: Array[GenericVertexMessage[_]]) extends VertexMessaging
 
 private[raphtory] case class FilteredEdgeMessage[VertexID](
     superstep: Int,

--- a/core/src/main/scala/com/raphtory/internals/components/querymanager/AnalysisMessages.scala
+++ b/core/src/main/scala/com/raphtory/internals/components/querymanager/AnalysisMessages.scala
@@ -68,6 +68,8 @@ private[raphtory] case class FilteredOutEdgeMessage[VertexID](
     sourceId: VertexID
 ) extends GenericVertexMessage[VertexID]
 
+private[raphtory] case class VertexMessagesSync(superstep: Int, partitionID: Int, count: Long)
+
 private[raphtory] case class Query(
     name: String = "",
     points: PointSet = NullPointSet,

--- a/core/src/main/scala/com/raphtory/internals/components/querymanager/AnalysisMessages.scala
+++ b/core/src/main/scala/com/raphtory/internals/components/querymanager/AnalysisMessages.scala
@@ -70,7 +70,7 @@ private[raphtory] case class FilteredOutEdgeMessage[VertexID](
     sourceId: VertexID
 ) extends GenericVertexMessage[VertexID]
 
-private[raphtory] case class VertexMessagesSync(superstep: Int, partitionID: Int, count: Long)
+private[raphtory] case class VertexMessagesSync(partitionID: Int, count: Long)
 
 private[raphtory] case class Query(
     name: String = "",
@@ -114,16 +114,16 @@ private[raphtory] case class MetaDataSet(perspectiveID: Int)                    
 private[raphtory] case class GraphFunctionComplete(
     perspectiveID: Int,
     partitionID: Int,
-    receivedMessages: Int,
-    sentMessages: Int,
+    receivedMessages: Long,
+    sentMessages: Long,
     votedToHalt: Boolean = false
 ) extends PerspectiveStatus
 
 private[raphtory] case class GraphFunctionCompleteWithState(
     perspectiveID: Int,
     partitionID: Int,
-    receivedMessages: Int,
-    sentMessages: Int,
+    receivedMessages: Long,
+    sentMessages: Long,
     votedToHalt: Boolean = false,
     graphState: GraphStateImplementation
 ) extends PerspectiveStatus

--- a/core/src/main/scala/com/raphtory/internals/graph/LensInterface.scala
+++ b/core/src/main/scala/com/raphtory/internals/graph/LensInterface.scala
@@ -13,7 +13,7 @@ import com.raphtory.internals.storage.pojograph.messaging.VertexMessageHandler
 private[raphtory] trait LensInterface {
 
   def partitionID(): Int
-
+  def localNodeCount: Int
   def getFullGraphSize: Int
   def setFullGraphSize(size: Int): Unit
 
@@ -51,7 +51,6 @@ private[raphtory] trait LensInterface {
       f: (_, GraphState) => Unit,
       graphState: GraphState
   )(onComplete: => Unit): Unit
-  def getMessageHandler(): VertexMessageHandler
   def checkVotes(): Boolean
   def sendMessage(msg: GenericVertexMessage[_]): Unit
   def vertexVoted(): Unit

--- a/core/src/main/scala/com/raphtory/internals/management/Scheduler.scala
+++ b/core/src/main/scala/com/raphtory/internals/management/Scheduler.scala
@@ -4,6 +4,7 @@ import cats.effect.IO
 import cats.effect.unsafe.IORuntime
 import com.raphtory.internals.components.Component
 
+import java.util.concurrent.CompletableFuture
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 
@@ -15,6 +16,9 @@ private[raphtory] class Scheduler {
 
   def execute[T](component: Component[T]): Unit =
     IO.blocking(component.run()).unsafeToFuture()
+
+  def executeCompletable[T](task: => Unit): CompletableFuture[Unit] =
+    IO.blocking(task).unsafeToCompletableFuture()
 
   def scheduleOnce(delay: FiniteDuration, task: => Unit): () => Future[Unit] = {
     val (_, cancel) = (IO.sleep(delay) *> IO.blocking(task)).unsafeToFutureCancelable()

--- a/core/src/main/scala/com/raphtory/internals/storage/pojograph/PojoGraphLens.scala
+++ b/core/src/main/scala/com/raphtory/internals/storage/pojograph/PojoGraphLens.scala
@@ -32,8 +32,6 @@ final private[raphtory] case class PojoGraphLens(
     private val storage: GraphPartition,
     private val conf: Config,
     private val messageSender: GenericVertexMessage[_] => Unit,
-    private val sentMessages: AtomicInteger,
-    private val receivedMessages: AtomicInteger,
     private val errorHandler: (Throwable) => Unit,
     private val scheduler: Scheduler
 ) extends GraphLens(jobId, start, end)

--- a/core/src/main/scala/com/raphtory/internals/storage/pojograph/PojoGraphLens.scala
+++ b/core/src/main/scala/com/raphtory/internals/storage/pojograph/PojoGraphLens.scala
@@ -31,7 +31,7 @@ final private[raphtory] case class PojoGraphLens(
     var superStep: Int,
     private val storage: GraphPartition,
     private val conf: Config,
-    private val neighbours: Option[Map[Int, EndPoint[QueryManagement]]],
+    private val messageSender: GenericVertexMessage[_] => Unit,
     private val sentMessages: AtomicInteger,
     private val receivedMessages: AtomicInteger,
     private val errorHandler: (Throwable) => Unit,
@@ -46,9 +46,6 @@ final private[raphtory] case class PojoGraphLens(
   private var exploded: Boolean = false
 
   var needsFiltering = false //used in PojoExEdge
-
-  private val messageHandler: VertexMessageHandler =
-    VertexMessageHandler(conf, neighbours, this, sentMessages, receivedMessages)
 
   val partitionID: Int = storage.getPartitionID
 
@@ -74,7 +71,7 @@ final private[raphtory] case class PojoGraphLens(
     logger.trace(s"Set Graph Size to '$fullGraphSize'.")
   }
 
-  def getSize: Int = vertices.length
+  def localNodeCount: Int = vertices.length
 
   private var dataTable: Iterator[RowImplementation] = Iterator()
 
@@ -225,11 +222,9 @@ final private[raphtory] case class PojoGraphLens(
     scheduler.executeInParallel(tasks, onComplete, errorHandler)
   }
 
-  def getMessageHandler(): VertexMessageHandler = messageHandler
-
   def checkVotes(): Boolean = vertexCount.get() == voteCount.get()
 
-  def sendMessage(msg: GenericVertexMessage[_]): Unit = messageHandler.sendMessage(msg)
+  def sendMessage(msg: GenericVertexMessage[_]): Unit = messageSender(msg)
 
   def vertexVoted(): Unit = voteCount.incrementAndGet()
 

--- a/core/src/test/scala/com/raphtory/SamplingTest.scala
+++ b/core/src/test/scala/com/raphtory/SamplingTest.scala
@@ -1,6 +1,6 @@
 package com.raphtory
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Random
@@ -8,7 +8,7 @@ import com.raphtory.utils.Sampling._
 
 import scala.collection.compat.immutable.ArraySeq
 
-class SamplingTest extends AnyFunSuite {
+class SamplingTest extends FunSuite {
 
   def testDistribution(
       weights: Array[Double],

--- a/core/src/test/scala/com/raphtory/api/FailureTest.scala
+++ b/core/src/test/scala/com/raphtory/api/FailureTest.scala
@@ -1,16 +1,17 @@
-package com.raphtory.generic
+package com.raphtory.api
 
 import cats.effect.IO
-import cats.effect.unsafe.implicits.global
-import com.raphtory.BaseCorrectnessTest
-import com.raphtory.BasicGraphBuilder
-import com.raphtory.Raphtory
 import com.raphtory.api.analysis.algorithm.Generic
-import com.raphtory.api.analysis.graphview.Alignment
 import com.raphtory.api.analysis.graphview.GraphPerspective
+import com.raphtory.internals.communication.repositories.PulsarAkkaTopicRepository
+import com.raphtory.internals.components.querymanager.GraphFunctionComplete
+import com.raphtory.internals.components.querymanager.QueryManagement
 import com.raphtory.sinks.FileSink
 import com.raphtory.spouts.SequenceSpout
-import org.scalatest.funsuite.AnyFunSuite
+import com.raphtory.BasicGraphBuilder
+import com.raphtory.Raphtory
+import com.raphtory.internals.communication.EndPoint
+import munit.CatsEffectSuite
 
 class FailingAlgo extends Generic {
 
@@ -18,8 +19,8 @@ class FailingAlgo extends Generic {
     graph.step(_ => throw new Exception("Algorithm failed"))
 }
 
-class FailureTest extends AnyFunSuite {
-  test("test failure propagation") {
+class FailureTest extends CatsEffectSuite {
+  test("test failure propagation for failure in algorithm step") {
     Raphtory
       .streamIO(
               spout = SequenceSpout("1,1,1"),
@@ -42,7 +43,5 @@ class FailureTest extends AnyFunSuite {
           ) // if query failed to terminate after 20 seconds, assuming infinite loop
         }
       }
-      .unsafeRunSync()
-
   }
 }

--- a/core/src/test/scala/com/raphtory/api/analysis/graphview/RaphtoryGraphTest.scala
+++ b/core/src/test/scala/com/raphtory/api/analysis/graphview/RaphtoryGraphTest.scala
@@ -10,13 +10,13 @@ import com.raphtory.internals.components.querymanager.PointPath
 import com.raphtory.internals.components.querymanager.Query
 import com.typesafe.config.Config
 import org.scalatest.BeforeAndAfterAll
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 /** This test uses a mock TemporalGraph as starting point
   * to check if the objects within this hierarchy create the Query object correctly.
   * It doesn't deploy or connect to anything.
   */
-class RaphtoryGraphTest extends AnyFunSuite {
+class RaphtoryGraphTest extends FunSuite {
 
   private def createMockGraph(config: Map[String, String] = Map()) =
     new TemporalGraph(Query(), null, Raphtory.getDefaultConfig(config))
@@ -35,12 +35,12 @@ class RaphtoryGraphTest extends AnyFunSuite {
       .filter(_.getInt(0) == 1)
     val query = table.asInstanceOf[TableImplementation].query
 
-    assert(query.timelineStart === 100)
-    assert(query.timelineEnd === 499)
-    assert(query.points.asInstanceOf[PointPath].increment === DiscreteInterval(100))
-    assert(query.windows === List(DiscreteInterval(50)))
+    assertEquals(query.timelineStart, 100L)
+    assertEquals(query.timelineEnd, 499L)
+    assertEquals(query.points.asInstanceOf[PointPath].increment, DiscreteInterval(100))
+    assertEquals(query.windows, List(DiscreteInterval(50)))
 
-    assert(query.graphFunctions.length === 6)
+    assertEquals(query.graphFunctions.length, 6)
     assert(query.graphFunctions(0).isInstanceOf[Step])
     assert(query.graphFunctions(1).isInstanceOf[Step])
     assert(query.graphFunctions(2).isInstanceOf[Step])
@@ -48,7 +48,7 @@ class RaphtoryGraphTest extends AnyFunSuite {
     assert(query.graphFunctions(4).isInstanceOf[ClearChain])
     assert(query.graphFunctions(5).isInstanceOf[Select])
 
-    assert(query.tableFunctions.length === 1)
+    assertEquals(query.tableFunctions.length, 1)
     assert(query.tableFunctions.head.isInstanceOf[TableFilter])
   }
 

--- a/core/src/test/scala/com/raphtory/fileSpoutTest/FileSpoutTest.scala
+++ b/core/src/test/scala/com/raphtory/fileSpoutTest/FileSpoutTest.scala
@@ -1,9 +1,7 @@
 package com.raphtory.fileSpoutTest
 
 import com.raphtory.utils.FileUtils
-import org.scalatest.BeforeAndAfter
-import org.scalatest.BeforeAndAfterAll
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import java.io.File
 import java.util.UUID
@@ -12,7 +10,7 @@ import java.nio.file.Path
 import java.nio.file.attribute.PosixFilePermissions
 import java.util
 
-class FileSpoutTest extends AnyFunSuite with BeforeAndAfterAll {
+class FileSpoutTest extends FunSuite {
 
   val tempDir       = Files.createTempDirectory("FileSpoutTest").toFile.getAbsolutePath
   val ownerWritable = PosixFilePermissions.fromString("-w-------")
@@ -26,7 +24,7 @@ class FileSpoutTest extends AnyFunSuite with BeforeAndAfterAll {
   }
   test("FileUtils.validatePath should throw if file does not exist") {
     val randomName = "/" + UUID.randomUUID().toString + ".hy"
-    assertThrows[java.io.FileNotFoundException](FileUtils.validatePath(randomName))
+    intercept[java.io.FileNotFoundException](FileUtils.validatePath(randomName))
   }
 //  test("FileUtils.validatePath should throw if file cannot be read"){
 //    // make a temp file
@@ -38,7 +36,7 @@ class FileSpoutTest extends AnyFunSuite with BeforeAndAfterAll {
   }
   test("FileUtils.createOrCleanDirectory should be allowed to make new temp folders") {
     val newDir = tempDir + "/" + UUID.randomUUID().toString
-    assert(FileUtils.createOrCleanDirectory(newDir).getAbsolutePath === newDir)
+    assertEquals(FileUtils.createOrCleanDirectory(newDir).getAbsolutePath, newDir)
     tempDirs.add(newDir)
   }
 //  test("FileUtils.createOrCleanDirectory should be allowed to clean existing temp folders"){

--- a/core/src/test/scala/com/raphtory/graph/PerspectiveControllerTest.scala
+++ b/core/src/test/scala/com/raphtory/graph/PerspectiveControllerTest.scala
@@ -4,11 +4,11 @@ import com.raphtory.api.analysis.graphview.Alignment
 import com.raphtory.internals.components.querymanager.PointPath
 import com.raphtory.internals.components.querymanager.Query
 import com.raphtory.internals.graph.PerspectiveController
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 import com.raphtory.internals.time.IntervalParser.{parse => parseInterval}
 import com.raphtory.internals.time.DateTimeParser.{defaultParse => parseDateTime}
 
-class PerspectiveControllerTest extends AnyFunSuite {
+class PerspectiveControllerTest extends FunSuite {
   test("A range of perspectives is correctly generated") {
     val increment  = parseInterval("2 months")
     val start      = parseDateTime("2021-01-01 00:00:00")
@@ -24,13 +24,13 @@ class PerspectiveControllerTest extends AnyFunSuite {
     val controller = PerspectiveController(0, Long.MaxValue, query)
 
     val firstPerspective = controller.nextPerspective().get
-    assert(firstPerspective.actualStart === start)
-    assert(firstPerspective.actualEnd === middle - 1)
+    assertEquals(firstPerspective.actualStart, start)
+    assertEquals(firstPerspective.actualEnd, middle - 1)
 
     val secondPerspective = controller.nextPerspective().get
-    assert(secondPerspective.actualStart === middle)
-    assert(secondPerspective.actualEnd === end - 1)
+    assertEquals(secondPerspective.actualStart, middle)
+    assertEquals(secondPerspective.actualEnd, end - 1)
 
-    assert(controller.nextPerspective() === None)
+    assertEquals(controller.nextPerspective(), None)
   }
 }

--- a/core/src/test/scala/com/raphtory/time/IntervalParserTest.scala
+++ b/core/src/test/scala/com/raphtory/time/IntervalParserTest.scala
@@ -2,21 +2,22 @@ package com.raphtory.time
 
 import com.raphtory.internals.time.IntervalParser
 import com.raphtory.internals.time.InvalidIntervalException
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import java.time.Duration
 import java.time.Period
 
-class IntervalParserTest extends AnyFunSuite {
+class IntervalParserTest extends FunSuite {
   test("Duration with days is correctly parsed") {
     val interval = IntervalParser.parse("2 days and 1 hour")
-    assert(interval.size === Duration.ofDays(2).plus(Duration.ofHours(1)))
+    assertEquals(interval.size, Duration.ofDays(2).plus(Duration.ofHours(1)))
   }
 
   test("Duration without days is correctly parsed") {
     val interval = IntervalParser.parse("3 hours, 4 minutes, 45 seconds, and 670 millis")
-    assert(
-            interval.size === Duration
+    assertEquals(
+            interval.size,
+            Duration
               .ofHours(3)
               .plus(Duration.ofMinutes(4))
               .plus(Duration.ofSeconds(45))
@@ -26,8 +27,9 @@ class IntervalParserTest extends AnyFunSuite {
 
   test("Period is correctly parsed") {
     val interval = IntervalParser.parse("10 years 2 months 1 week and 3 days")
-    assert(
-            interval.size === Period
+    assertEquals(
+            interval.size,
+            Period
               .ofYears(10)
               .plus(Period.ofMonths(2))
               .plus(Period.ofWeeks(1))
@@ -36,7 +38,7 @@ class IntervalParserTest extends AnyFunSuite {
   }
 
   test("Unknown units cause an exception") {
-    assertThrows[InvalidIntervalException] {
+    intercept[InvalidIntervalException] {
       IntervalParser.parse("3 weeeks")
     }
   }

--- a/examples/raphtory-example-ethereum/src/main/scala/com/raphtory/ethereum/LocalRunner.scala
+++ b/examples/raphtory-example-ethereum/src/main/scala/com/raphtory/ethereum/LocalRunner.scala
@@ -1,5 +1,6 @@
 package com.raphtory.ethereum
 
+import cats.effect.IO
 import com.raphtory.Raphtory
 import com.raphtory.algorithms.generic.ConnectedComponents
 import com.raphtory.ethereum.graphbuilder.EthereumGraphBuilder
@@ -236,11 +237,16 @@ object LocalRunner extends App {
   // val graphQuery = new TaintAlgorithm(startTime, infectedNodes, stopNodes)
   val fileOutput   = FileSink("/tmp/ethereum/Taint")
   val pulsarOutput = PulsarSink("TaintTracking")
-  graph
-    .at(1575013446)
-    .past()
-    .execute(Taint(startTime, infectedNodes, stopNodes))
-    .writeTo(pulsarOutput)
+  graph.use { graph =>
+    IO.blocking(
+            graph
+              .at(1575013446)
+              .past()
+              .execute(Taint(startTime, infectedNodes, stopNodes))
+              .writeTo(pulsarOutput)
+              .waitForJob()
+    )
+  }
   // graph.pointQuery(ConnectedComponents(), FileOutputFormat("/tmp/ethereum/connected_components"), 1591951621)
 
   // Range query, run the same command over certain time periods


### PR DESCRIPTION
- QueryExecutors now check that they have received all vertex messages before sending GraphFunctionComplete
- QueryHandler checks message counts and fails if they don't match
- moved all remaining tests to MUnit