### PR TITLE
Bump version of get-latest-tag action

### DIFF
--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -88,7 +88,7 @@ jobs:
         if: needs.configure.outputs.type == 'master'
       - name: Get latest tag
         id: bumped-tag
-        uses: actions-ecosystem/action-get-latest-tag@v1
+        uses: actions-ecosystem/action-get-latest-tag@v1.6.0
         with:
           semver_only: true
         if: needs.configure.outputs.type == 'master'


### PR DESCRIPTION
GH action has had a bugfix applies. Bumping to that version