### PR TITLE
Added catch to BatchHandler to catch and print error for lines in graphbuilder ingestion which fail parsing

### DIFF
--- a/core/src/main/scala/com/raphtory/internals/components/partition/LocalBatchHandler.scala
+++ b/core/src/main/scala/com/raphtory/internals/components/partition/LocalBatchHandler.scala
@@ -51,7 +51,14 @@ private[raphtory] class LocalBatchHandler[T: ClassTag](
   private def runIngestion(): Unit = {
     while (spout.hasNextIterator()) {
       startIngesting()
-      spout.nextIterator().foreach(graphBuilder.parseTuple)
+      spout.nextIterator().foreach(line => {
+        try {
+          graphBuilder.parseTuple(line)
+        }
+        catch {
+          case e: Exception => logger.info(s"Could not parse: ${line}. Fails with exception ${e.toString}")
+        }
+      })
     }
 
     stopIngesting()

--- a/core/src/test/scala/com/raphtory/stateTest/AllCommandsBuilder.scala
+++ b/core/src/test/scala/com/raphtory/stateTest/AllCommandsBuilder.scala
@@ -41,19 +41,15 @@ class AllCommandsBuilder extends GraphBuilder[String] {
 
       //send the srcID and properties to the graph manager
       addVertex(msgTime, srcId, properties)
-      logger.info(s"Adding Vertex and sending $srcId and $properties to graph manager")
     }
-    else {
+    else
       addVertex(msgTime, srcId)
-      logger.info(s"Adding Vertex and sending $srcId to graph manager")
-    }
     // if there are not any properties, just send the srcID
   }
 
   def vertexRemoval(command: JsObject): Unit = {
     val msgTime = command.fields("messageID").toString().toLong
     val srcId   = command.fields("srcID").toString().toInt //extract the srcID
-    logger.info(s"Deleting vertex $srcId")
     deleteVertex(msgTime, srcId)
   }
 
@@ -74,12 +70,9 @@ class AllCommandsBuilder extends GraphBuilder[String] {
       )
 
       addEdge(msgTime, srcId, dstId, properties)
-      logger.info(s"Added Edge with properties $properties")
     }
-    else {
+    else
       addEdge(msgTime, srcId, dstId)
-      logger.info("Added Edge with no properties")
-    }
   }
 
   def edgeRemoval(command: JsObject): Unit = {
@@ -87,7 +80,6 @@ class AllCommandsBuilder extends GraphBuilder[String] {
     val srcId   = command.fields("srcID").toString().toInt //extract the srcID
     val dstId   = command.fields("dstID").toString().toInt //extract the dstID
     deleteEdge(msgTime, srcId, dstId)
-    logger.info(s"Deleted Edge with $srcId and $dstId")
   }
 
 }

--- a/core/src/test/scala/com/raphtory/stateTest/AllCommandsTest.scala
+++ b/core/src/test/scala/com/raphtory/stateTest/AllCommandsTest.scala
@@ -45,11 +45,11 @@ class AllCommandsTest extends BaseRaphtoryAlgoTest[String] {
     }
 
   }
-
-  override def setSpout(): Spout[String] = FileSpout()
+  val filePath                           = "/tmp/testupdates.csv"
+  override def setSpout(): Spout[String] = FileSpout("/tmp/testupdates.csv")
 
   override def setGraphBuilder(): GraphBuilder[String] = new AllCommandsBuilder()
 
   override def liftFileIfNotPresent: Option[(String, URL)] =
-    Some(("/tmp/testupdates.csv", new URL("https://raw.githubusercontent.com/Raphtory/Data/main/testupdates.txt")))
+    Some((filePath, new URL("https://raw.githubusercontent.com/Raphtory/Data/main/testupdates.txt")))
 }

--- a/core/src/test/scala/com/raphtory/stateTest/AllCommandsTest.scala
+++ b/core/src/test/scala/com/raphtory/stateTest/AllCommandsTest.scala
@@ -45,11 +45,10 @@ class AllCommandsTest extends BaseRaphtoryAlgoTest[String] {
     }
 
   }
-  val filePath                           = "/tmp/testupdates.csv"
   override def setSpout(): Spout[String] = FileSpout("/tmp/testupdates.csv")
 
   override def setGraphBuilder(): GraphBuilder[String] = new AllCommandsBuilder()
 
   override def liftFileIfNotPresent: Option[(String, URL)] =
-    Some((filePath, new URL("https://raw.githubusercontent.com/Raphtory/Data/main/testupdates.txt")))
+    Some(("/tmp/testupdates.csv", new URL("https://raw.githubusercontent.com/Raphtory/Data/main/testupdates.txt")))
 }


### PR DESCRIPTION
Added a try/catch to the Batch Ingestor so that tuples that can't be parsed don't kill the pipeline. This unearthed a nasty bug with the All Commands Test which has also been fixed here.