### PR TITLE
Dev 1025 / Table redesign to allow column names for different basic types

### DIFF
--- a/connectors/aws/src/main/scala/com/raphtory/aws/AwsS3Sink.scala
+++ b/connectors/aws/src/main/scala/com/raphtory/aws/AwsS3Sink.scala
@@ -1,10 +1,18 @@
 package com.raphtory.aws
 
 import com.amazonaws.auth.AWSStaticCredentialsProvider
-import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
-import com.amazonaws.services.s3.model.{AbortMultipartUploadRequest, CompleteMultipartUploadRequest, InitiateMultipartUploadRequest, ObjectMetadata, PartETag, PutObjectRequest, UploadPartRequest}
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import com.amazonaws.services.s3.model.AbortMultipartUploadRequest
+import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest
+import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest
+import com.amazonaws.services.s3.model.ObjectMetadata
+import com.amazonaws.services.s3.model.PartETag
+import com.amazonaws.services.s3.model.PutObjectRequest
+import com.amazonaws.services.s3.model.UploadPartRequest
 import com.raphtory.api.output.format.Format
-import com.raphtory.api.output.sink.{FormatAgnosticSink, SinkConnector}
+import com.raphtory.api.output.sink.FormatAgnosticSink
+import com.raphtory.api.output.sink.SinkConnector
 import com.raphtory.formats.CsvFormat
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.Logger
@@ -15,150 +23,165 @@ import java.nio.charset.StandardCharsets
 import scala.collection.mutable.ListBuffer
 
 /** A [[com.raphtory.api.output.sink.Sink Sink]] that writes a `Table` into files in AWS S3 using the given `format`.
- *
- * This sink creates a directory named after the jobID in your stated S3 output bucket. Each partition on the server then writes into its own file within this directory.
- *
- * @param awsS3OutputFormatBucketName the AWS S3 bucket name to write the table into
- * @param format the format to be used by this sink (`CsvFormat` by default)
- *
- * @example
- * {{{
- * import com.raphtory.algorithms.generic.EdgeList
- * import com.raphtory.aws.AwsS3Sink
- * import com.raphtory.aws.AwsS3Spout
- *
- * val graphBuilder = new YourGraphBuilder()
- * val graph = Raphtory.stream(AwsS3Spout("aws-bucket-name", "aws-bucket-key"), graphBuilder)
- * val bucketName = "bucket-name"
- * val sink = AWSS3Sink(bucketName)
- *
- * graph.execute(EdgeList()).writeTo(sink)
- * }}}
- * @see [[com.raphtory.api.output.sink.Sink Sink]]
- *      [[com.raphtory.api.output.format.Format Format]]
- *      [[com.raphtory.formats.CsvFormat CsvFormat]]
- *      [[com.raphtory.api.analysis.table.Table Table]]
- *      [[com.raphtory.Raphtory Raphtory]]
- */
+  *
+  * This sink creates a directory named after the jobID in your stated S3 output bucket. Each partition on the server then writes into its own file within this directory.
+  *
+  * @param awsS3OutputFormatBucketName the AWS S3 bucket name to write the table into
+  * @param format the format to be used by this sink (`CsvFormat` by default)
+  *
+  * @example
+  * {{{
+  * import com.raphtory.algorithms.generic.EdgeList
+  * import com.raphtory.aws.AwsS3Sink
+  * import com.raphtory.aws.AwsS3Spout
+  *
+  * val graphBuilder = new YourGraphBuilder()
+  * val graph = Raphtory.stream(AwsS3Spout("aws-bucket-name", "aws-bucket-key"), graphBuilder)
+  * val bucketName = "bucket-name"
+  * val sink = AWSS3Sink(bucketName)
+  *
+  * graph.execute(EdgeList()).writeTo(sink)
+  * }}}
+  * @see [[com.raphtory.api.output.sink.Sink Sink]]
+  *      [[com.raphtory.api.output.format.Format Format]]
+  *      [[com.raphtory.formats.CsvFormat CsvFormat]]
+  *      [[com.raphtory.api.analysis.table.Table Table]]
+  *      [[com.raphtory.Raphtory Raphtory]]
+  */
 
 case class AwsS3Sink(awsS3OutputFormatBucketName: String, format: Format = CsvFormat())
-  extends FormatAgnosticSink(format) {
+        extends FormatAgnosticSink(format) {
 
-  override def buildConnector(jobID: String, partitionID: Int, config: Config, itemDelimiter: String, fileExtension: String): SinkConnector =
-
+  override def buildConnector(
+      jobID: String,
+      partitionID: Int,
+      config: Config,
+      itemDelimiter: String,
+      fileExtension: String
+  ): SinkConnector =
     new SinkConnector {
 
       /**
-       * AWS Credentials needed to connect to AWS and build an S3 client.
-       * Access Key, Secret Access Key and Session Token is needed in application.conf.
-       */
+        * AWS Credentials needed to connect to AWS and build an S3 client.
+        * Access Key, Secret Access Key and Session Token is needed in application.conf.
+        */
       private val credentials: AwsCredentials = AwsS3Connector().getAWSCredentials()
-      private val logger: Logger = Logger(LoggerFactory.getLogger(this.getClass))
+      private val logger: Logger              = Logger(LoggerFactory.getLogger(this.getClass))
 
       private val s3Client: AmazonS3 = AmazonS3ClientBuilder
         .standard()
         .withCredentials(
-          new AWSStaticCredentialsProvider(credentials)
+                new AWSStaticCredentialsProvider(credentials)
         )
         .build()
 
       private val request = s3Client.initiateMultipartUpload(
-        new InitiateMultipartUploadRequest(
-          awsS3OutputFormatBucketName, s"$jobID/partition-$partitionID"
-        )
+              new InitiateMultipartUploadRequest(
+                      awsS3OutputFormatBucketName,
+                      s"$jobID/partition-$partitionID"
+              )
       )
 
-      private val etags = ListBuffer[PartETag]()
-      private var partNumber = 1
-      private var streamLimit = 5000000000L
-      private var partSize: Long = 5 * 1024 * 1024
+      private val etags                                    = ListBuffer[PartETag]()
+      private var partNumber                               = 1
+      private var streamLimit                              = 5000000000L
+      private var partSize: Long                           = 5 * 1024 * 1024
       private var uploadRequest: Option[UploadPartRequest] = None
-      private var streamPosition: Long = 0L
+      private var streamPosition: Long                     = 0L
 
       private var stream: ByteArrayOutputStream = new ByteArrayOutputStream()
 
+      override def allowsHeader: Boolean = true
 
       /*
       Write results to respective partition streams and add new line for every line of result
        */
-      override def write(value: String): Unit = {
-           stream.write(value.getBytes(StandardCharsets.UTF_8))
-      }
+      override def write(value: String): Unit =
+        stream.write(value.getBytes(StandardCharsets.UTF_8))
 
       /**
-       * If any of the streams of results are greater than 5GB, multipart upload to AWS will be used,
-       * otherwise a regular one part upload will be used and will skip closeItem(),
-       * going straight to close().
-       */
+        * If any of the streams of results are greater than 5GB, multipart upload to AWS will be used,
+        * otherwise a regular one part upload will be used and will skip closeItem(),
+        * going straight to close().
+        */
 
       override def closeItem(): Unit = {
 
         stream.write(itemDelimiter.getBytes(StandardCharsets.UTF_8))
 
         if (stream.size() > streamLimit) {
-          def makeUploadRequest(stream: ByteArrayOutputStream) = {
+          def makeUploadRequest(stream: ByteArrayOutputStream) =
             // Upload file parts in 5MB parts
             while (streamPosition < stream.size()) {
               //To handle the last part which can be less than 5MB, adjusting part size as needed.
               partSize = Math.min(partSize, stream.size() - streamPosition)
 
-              uploadRequest = Some(new UploadPartRequest()
-                .withBucketName(request.getBucketName)
-                .withKey(request.getKey)
-                .withUploadId(request.getUploadId)
-                .withPartNumber(partNumber)
-                .withPartSize(partSize)
-                .withFileOffset(streamPosition)
-                .withInputStream(stream.toInputStream))
+              uploadRequest = Some(
+                      new UploadPartRequest()
+                        .withBucketName(request.getBucketName)
+                        .withKey(request.getKey)
+                        .withUploadId(request.getUploadId)
+                        .withPartNumber(partNumber)
+                        .withPartSize(partSize)
+                        .withFileOffset(streamPosition)
+                        .withInputStream(stream.toInputStream)
+              )
 
               etags += s3Client.uploadPart(uploadRequest.get).getPartETag
               partNumber += 1
               streamPosition += partSize
               logger.info(s"On part number: $partNumber, stream position in bytes: $streamPosition")
             }
-          }
-           makeUploadRequest(stream)
+          makeUploadRequest(stream)
         }
       }
 
       /**
-       * If multipart upload request has been found, close() will complete
-       * the multipart upload and close the upload.
-       *
-       * If no upload request has been found, a single putObjectRequest will be made to upload
-       * the results to AWS by partition.
-       */
+        * If multipart upload request has been found, close() will complete
+        * the multipart upload and close the upload.
+        *
+        * If no upload request has been found, a single putObjectRequest will be made to upload
+        * the results to AWS by partition.
+        */
 
-      override def close(): Unit = {
+      override def close(): Unit =
         uploadRequest match {
           case Some(value) =>
             s3Client.completeMultipartUpload(
-              new CompleteMultipartUploadRequest(
-                awsS3OutputFormatBucketName,
-                s"$jobID/partition-$partitionID",
-                value.getUploadId,
-                etags.result().asJava
-              )
+                    new CompleteMultipartUploadRequest(
+                            awsS3OutputFormatBucketName,
+                            s"$jobID/partition-$partitionID",
+                            value.getUploadId,
+                            etags.result().asJava
+                    )
             )
             s3Client.abortMultipartUpload(
-              new AbortMultipartUploadRequest(
-                request.getBucketName,
-                request.getKey,
-                request.getUploadId
-              )
+                    new AbortMultipartUploadRequest(
+                            request.getBucketName,
+                            request.getKey,
+                            request.getUploadId
+                    )
             )
 
-          case None =>
+          case None        =>
             var metadata = new ObjectMetadata()
 
-            def setContentLength(metadata: ObjectMetadata, stream: ByteArrayOutputStream): Unit = metadata.setContentLength(stream.size())
+            def setContentLength(metadata: ObjectMetadata, stream: ByteArrayOutputStream): Unit =
+              metadata.setContentLength(stream.size())
 
-            def putObject(stream: ByteArrayOutputStream) = s3Client.putObject(new PutObjectRequest(awsS3OutputFormatBucketName, s"$jobID/partition-$partitionID", stream.toInputStream, metadata))
+            def putObject(stream: ByteArrayOutputStream) =
+              s3Client.putObject(
+                      new PutObjectRequest(
+                              awsS3OutputFormatBucketName,
+                              s"$jobID/partition-$partitionID",
+                              stream.toInputStream,
+                              metadata
+                      )
+              )
 
-                setContentLength(metadata, stream)
-                putObject(stream)
+            setContentLength(metadata, stream)
+            putObject(stream)
 
         }
-      }
     }
 }

--- a/connectors/aws/src/main/scala/com/raphtory/aws/AwsS3Sink.scala
+++ b/connectors/aws/src/main/scala/com/raphtory/aws/AwsS3Sink.scala
@@ -1,18 +1,10 @@
 package com.raphtory.aws
 
 import com.amazonaws.auth.AWSStaticCredentialsProvider
-import com.amazonaws.services.s3.AmazonS3
-import com.amazonaws.services.s3.AmazonS3ClientBuilder
-import com.amazonaws.services.s3.model.AbortMultipartUploadRequest
-import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest
-import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest
-import com.amazonaws.services.s3.model.ObjectMetadata
-import com.amazonaws.services.s3.model.PartETag
-import com.amazonaws.services.s3.model.PutObjectRequest
-import com.amazonaws.services.s3.model.UploadPartRequest
+import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
+import com.amazonaws.services.s3.model.{AbortMultipartUploadRequest, CompleteMultipartUploadRequest, InitiateMultipartUploadRequest, ObjectMetadata, PartETag, PutObjectRequest, UploadPartRequest}
 import com.raphtory.api.output.format.Format
-import com.raphtory.api.output.sink.FormatAgnosticSink
-import com.raphtory.api.output.sink.SinkConnector
+import com.raphtory.api.output.sink.{FormatAgnosticSink, SinkConnector}
 import com.raphtory.formats.CsvFormat
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.Logger
@@ -23,71 +15,65 @@ import java.nio.charset.StandardCharsets
 import scala.collection.mutable.ListBuffer
 
 /** A [[com.raphtory.api.output.sink.Sink Sink]] that writes a `Table` into files in AWS S3 using the given `format`.
-  *
-  * This sink creates a directory named after the jobID in your stated S3 output bucket. Each partition on the server then writes into its own file within this directory.
-  *
-  * @param awsS3OutputFormatBucketName the AWS S3 bucket name to write the table into
-  * @param format the format to be used by this sink (`CsvFormat` by default)
-  *
-  * @example
-  * {{{
-  * import com.raphtory.algorithms.generic.EdgeList
-  * import com.raphtory.aws.AwsS3Sink
-  * import com.raphtory.aws.AwsS3Spout
-  *
-  * val graphBuilder = new YourGraphBuilder()
-  * val graph = Raphtory.stream(AwsS3Spout("aws-bucket-name", "aws-bucket-key"), graphBuilder)
-  * val bucketName = "bucket-name"
-  * val sink = AWSS3Sink(bucketName)
-  *
-  * graph.execute(EdgeList()).writeTo(sink)
-  * }}}
-  * @see [[com.raphtory.api.output.sink.Sink Sink]]
-  *      [[com.raphtory.api.output.format.Format Format]]
-  *      [[com.raphtory.formats.CsvFormat CsvFormat]]
-  *      [[com.raphtory.api.analysis.table.Table Table]]
-  *      [[com.raphtory.Raphtory Raphtory]]
-  */
+ *
+ * This sink creates a directory named after the jobID in your stated S3 output bucket. Each partition on the server then writes into its own file within this directory.
+ *
+ * @param awsS3OutputFormatBucketName the AWS S3 bucket name to write the table into
+ * @param format the format to be used by this sink (`CsvFormat` by default)
+ *
+ * @example
+ * {{{
+ * import com.raphtory.algorithms.generic.EdgeList
+ * import com.raphtory.aws.AwsS3Sink
+ * import com.raphtory.aws.AwsS3Spout
+ *
+ * val graphBuilder = new YourGraphBuilder()
+ * val graph = Raphtory.stream(AwsS3Spout("aws-bucket-name", "aws-bucket-key"), graphBuilder)
+ * val bucketName = "bucket-name"
+ * val sink = AWSS3Sink(bucketName)
+ *
+ * graph.execute(EdgeList()).writeTo(sink)
+ * }}}
+ * @see [[com.raphtory.api.output.sink.Sink Sink]]
+ *      [[com.raphtory.api.output.format.Format Format]]
+ *      [[com.raphtory.formats.CsvFormat CsvFormat]]
+ *      [[com.raphtory.api.analysis.table.Table Table]]
+ *      [[com.raphtory.Raphtory Raphtory]]
+ */
 
 case class AwsS3Sink(awsS3OutputFormatBucketName: String, format: Format = CsvFormat())
-        extends FormatAgnosticSink(format) {
+  extends FormatAgnosticSink(format) {
 
-  override def buildConnector(
-      jobID: String,
-      partitionID: Int,
-      config: Config,
-      itemDelimiter: String,
-      fileExtension: String
-  ): SinkConnector =
+  override def buildConnector(jobID: String, partitionID: Int, config: Config, itemDelimiter: String, fileExtension: String): SinkConnector =
+
     new SinkConnector {
 
       /**
-        * AWS Credentials needed to connect to AWS and build an S3 client.
-        * Access Key, Secret Access Key and Session Token is needed in application.conf.
-        */
+       * AWS Credentials needed to connect to AWS and build an S3 client.
+       * Access Key, Secret Access Key and Session Token is needed in application.conf.
+       */
       private val credentials: AwsCredentials = AwsS3Connector().getAWSCredentials()
-      private val logger: Logger              = Logger(LoggerFactory.getLogger(this.getClass))
+      private val logger: Logger = Logger(LoggerFactory.getLogger(this.getClass))
 
       private val s3Client: AmazonS3 = AmazonS3ClientBuilder
         .standard()
         .withCredentials(
-                new AWSStaticCredentialsProvider(credentials)
+          new AWSStaticCredentialsProvider(credentials)
         )
         .build()
 
       private val request = s3Client.initiateMultipartUpload(
-              new InitiateMultipartUploadRequest(
-                      awsS3OutputFormatBucketName,
-                      s"$jobID/partition-$partitionID"
-              )
+        new InitiateMultipartUploadRequest(
+          awsS3OutputFormatBucketName, s"$jobID/partition-$partitionID"
+        )
       )
 
-      private val etags                                    = ListBuffer[PartETag]()
-      private var partNumber                               = 1
-      private var streamLimit                              = 5000000000L
-      private var partSize: Long                           = 5 * 1024 * 1024
+      private val etags = ListBuffer[PartETag]()
+      private var partNumber = 1
+      private var streamLimit = 5000000000L
+      private var partSize: Long = 5 * 1024 * 1024
       private var uploadRequest: Option[UploadPartRequest] = None
-      private var streamPosition: Long                     = 0L
+      private var streamPosition: Long = 0L
 
       private var stream: ByteArrayOutputStream = new ByteArrayOutputStream()
 
@@ -96,92 +82,84 @@ case class AwsS3Sink(awsS3OutputFormatBucketName: String, format: Format = CsvFo
       /*
       Write results to respective partition streams and add new line for every line of result
        */
-      override def write(value: String): Unit =
-        stream.write(value.getBytes(StandardCharsets.UTF_8))
+      override def write(value: String): Unit = {
+           stream.write(value.getBytes(StandardCharsets.UTF_8))
+      }
 
       /**
-        * If any of the streams of results are greater than 5GB, multipart upload to AWS will be used,
-        * otherwise a regular one part upload will be used and will skip closeItem(),
-        * going straight to close().
-        */
+       * If any of the streams of results are greater than 5GB, multipart upload to AWS will be used,
+       * otherwise a regular one part upload will be used and will skip closeItem(),
+       * going straight to close().
+       */
 
       override def closeItem(): Unit = {
 
         stream.write(itemDelimiter.getBytes(StandardCharsets.UTF_8))
 
         if (stream.size() > streamLimit) {
-          def makeUploadRequest(stream: ByteArrayOutputStream) =
+          def makeUploadRequest(stream: ByteArrayOutputStream) = {
             // Upload file parts in 5MB parts
             while (streamPosition < stream.size()) {
               //To handle the last part which can be less than 5MB, adjusting part size as needed.
               partSize = Math.min(partSize, stream.size() - streamPosition)
 
-              uploadRequest = Some(
-                      new UploadPartRequest()
-                        .withBucketName(request.getBucketName)
-                        .withKey(request.getKey)
-                        .withUploadId(request.getUploadId)
-                        .withPartNumber(partNumber)
-                        .withPartSize(partSize)
-                        .withFileOffset(streamPosition)
-                        .withInputStream(stream.toInputStream)
-              )
+              uploadRequest = Some(new UploadPartRequest()
+                .withBucketName(request.getBucketName)
+                .withKey(request.getKey)
+                .withUploadId(request.getUploadId)
+                .withPartNumber(partNumber)
+                .withPartSize(partSize)
+                .withFileOffset(streamPosition)
+                .withInputStream(stream.toInputStream))
 
               etags += s3Client.uploadPart(uploadRequest.get).getPartETag
               partNumber += 1
               streamPosition += partSize
               logger.info(s"On part number: $partNumber, stream position in bytes: $streamPosition")
             }
-          makeUploadRequest(stream)
+          }
+           makeUploadRequest(stream)
         }
       }
 
       /**
-        * If multipart upload request has been found, close() will complete
-        * the multipart upload and close the upload.
-        *
-        * If no upload request has been found, a single putObjectRequest will be made to upload
-        * the results to AWS by partition.
-        */
+       * If multipart upload request has been found, close() will complete
+       * the multipart upload and close the upload.
+       *
+       * If no upload request has been found, a single putObjectRequest will be made to upload
+       * the results to AWS by partition.
+       */
 
-      override def close(): Unit =
+      override def close(): Unit = {
         uploadRequest match {
           case Some(value) =>
             s3Client.completeMultipartUpload(
-                    new CompleteMultipartUploadRequest(
-                            awsS3OutputFormatBucketName,
-                            s"$jobID/partition-$partitionID",
-                            value.getUploadId,
-                            etags.result().asJava
-                    )
+              new CompleteMultipartUploadRequest(
+                awsS3OutputFormatBucketName,
+                s"$jobID/partition-$partitionID",
+                value.getUploadId,
+                etags.result().asJava
+              )
             )
             s3Client.abortMultipartUpload(
-                    new AbortMultipartUploadRequest(
-                            request.getBucketName,
-                            request.getKey,
-                            request.getUploadId
-                    )
+              new AbortMultipartUploadRequest(
+                request.getBucketName,
+                request.getKey,
+                request.getUploadId
+              )
             )
 
-          case None        =>
+          case None =>
             var metadata = new ObjectMetadata()
 
-            def setContentLength(metadata: ObjectMetadata, stream: ByteArrayOutputStream): Unit =
-              metadata.setContentLength(stream.size())
+            def setContentLength(metadata: ObjectMetadata, stream: ByteArrayOutputStream): Unit = metadata.setContentLength(stream.size())
 
-            def putObject(stream: ByteArrayOutputStream) =
-              s3Client.putObject(
-                      new PutObjectRequest(
-                              awsS3OutputFormatBucketName,
-                              s"$jobID/partition-$partitionID",
-                              stream.toInputStream,
-                              metadata
-                      )
-              )
+            def putObject(stream: ByteArrayOutputStream) = s3Client.putObject(new PutObjectRequest(awsS3OutputFormatBucketName, s"$jobID/partition-$partitionID", stream.toInputStream, metadata))
 
-            setContentLength(metadata, stream)
-            putObject(stream)
+                setContentLength(metadata, stream)
+                putObject(stream)
 
         }
+      }
     }
 }

--- a/core/src/main/scala/com/raphtory/algorithms/filters/DisparityFilter.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/filters/DisparityFilter.scala
@@ -34,7 +34,7 @@ import scala.math.Numeric.Implicits.infixNumericOps
 class DisparityFilter[T: Numeric: Bounded: ClassTag](
     alpha: Double = 0.05,
     weightProperty: String = "weight"
-) extends Generic {
+) extends Generic[Any] {
 
   override def apply(graph: GraphPerspective): graph.Graph =
     graph

--- a/core/src/main/scala/com/raphtory/algorithms/filters/EdgeFilter.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/filters/EdgeFilter.scala
@@ -24,7 +24,7 @@ import com.raphtory.api.analysis.visitor.Edge
   * ```
   */
 
-class EdgeFilter(f: Edge => Boolean, pruneNodes: Boolean = true) extends Generic {
+class EdgeFilter(f: Edge => Boolean, pruneNodes: Boolean = true) extends Generic[Any] {
 
   override def apply(graph: GraphPerspective): graph.Graph =
     graph.edgeFilter(f, pruneNodes)

--- a/core/src/main/scala/com/raphtory/algorithms/filters/EdgeFilterGraphState.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/filters/EdgeFilterGraphState.scala
@@ -25,7 +25,7 @@ import com.raphtory.api.analysis.visitor.Edge
   * ```
   */
 
-class EdgeFilterGraphState(f: (Edge, GraphState) => Boolean, pruneNodes: Boolean = true) extends Generic {
+class EdgeFilterGraphState(f: (Edge, GraphState) => Boolean, pruneNodes: Boolean = true) extends Generic[Any] {
 
   override def apply(graph: GraphPerspective): graph.Graph = graph.edgeFilter(f, pruneNodes)
 }

--- a/core/src/main/scala/com/raphtory/algorithms/filters/EdgeQuantileFilter.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/filters/EdgeQuantileFilter.scala
@@ -56,7 +56,7 @@ class EdgeQuantileFilter[T: Numeric: Bounded: ClassTag](
     upperExclusive: Boolean = false,
     noBins: Int = 1000,
     pruneNodes: Boolean = true
-) extends Generic {
+) extends Generic[Any] {
 
   override def apply(graph: GraphPerspective): graph.Graph = {
     // Check inputs are sound

--- a/core/src/main/scala/com/raphtory/algorithms/filters/UniformEdgeSample.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/filters/UniformEdgeSample.scala
@@ -18,7 +18,7 @@ import scala.util.Random
   * ```
   */
 
-class UniformEdgeSample(p: Float, pruneNodes: Boolean = true) extends Generic {
+class UniformEdgeSample(p: Float, pruneNodes: Boolean = true) extends Generic[Any] {
 
   override def apply(graph: GraphPerspective): graph.Graph =
     graph.edgeFilter(_ => Random.nextFloat() < p, pruneNodes = pruneNodes)

--- a/core/src/main/scala/com/raphtory/algorithms/generic/AdjPlus.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/generic/AdjPlus.scala
@@ -35,7 +35,7 @@ import scala.math.Ordering.Implicits._
   * [](com.raphtory.algorithms.generic.motif.SquareCount)
   * ```
   */
-object AdjPlus extends Generic {
+object AdjPlus extends Generic[Row] {
 
   override def apply(graph: GraphPerspective): graph.Graph =
     graph.step(vertex => vertex.messageAllNeighbours((vertex.ID, vertex.degree))).step { vertex =>
@@ -51,7 +51,7 @@ object AdjPlus extends Generic {
       vertex.setState("adjPlus", adj)
     }
 
-  override def tabularise(graph: GraphPerspective): Table =
+  override def tabularise(graph: GraphPerspective) =
 //    return adjPlus as edge list
     graph
       .step { vertex =>

--- a/core/src/main/scala/com/raphtory/algorithms/generic/CBOD.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/generic/CBOD.scala
@@ -47,8 +47,8 @@ import com.raphtory.api.analysis.table.Table
 class CBOD(
     label: String = "community",
     cutoff: Double = 0.0,
-    labeler: Generic = Identity
-) extends Generic {
+    labeler: Generic[_] = Identity
+) extends Generic[Row] {
 
   // Run CBOD algorithm and sets "outlierscore" state
   override def apply(graph: GraphPerspective): graph.Graph =
@@ -65,7 +65,7 @@ class CBOD(
       }
 
   // extract vertex ID and outlier score for vertices with outlierscore >= threshold
-  override def tabularise(graph: GraphPerspective): Table =
+  override def tabularise(graph: GraphPerspective): Table[Row] =
     graph
       .select { vertex =>
         Row(
@@ -81,7 +81,7 @@ object CBOD {
   def apply(
       label: String = "community",
       cutoff: Double = 0.0,
-      labeler: Generic = Identity
+      labeler: Generic[_] = Identity
   ) =
     new CBOD(label, cutoff, labeler)
 }

--- a/core/src/main/scala/com/raphtory/algorithms/generic/EdgeList.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/generic/EdgeList.scala
@@ -34,11 +34,11 @@ import com.raphtory.api.analysis.table.Table
 class EdgeList(
     properties: Seq[String] = Seq.empty[String],
     defaults: Map[String, Any] = Map.empty[String, Any]
-) extends Generic {
+) extends Generic[Row] {
 
   override def apply(graph: GraphPerspective): graph.Graph = NeighbourNames(graph)
 
-  override def tabularise(graph: GraphPerspective): Table =
+  override def tabularise(graph: GraphPerspective): Table[Row] =
     graph
       .explodeSelect { vertex =>
         val neighbourMap = vertex.getState[Map[vertex.IDType, String]]("neighbourNames")

--- a/core/src/main/scala/com/raphtory/algorithms/generic/MaxFlow.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/generic/MaxFlow.scala
@@ -67,7 +67,7 @@ class MaxFlow[T](
     capacityLabel: String = "weight",
     maxIterations: Int = Int.MaxValue
 )(implicit numeric: Numeric[T])
-        extends Generic {
+        extends Generic[Row] {
 
   override def apply(graph: GraphPerspective): graph.Graph =
     graph
@@ -166,7 +166,7 @@ class MaxFlow[T](
               executeMessagedOnly = true
       )
 
-  override def tabularise(graph: GraphPerspective): Table =
+  override def tabularise(graph: GraphPerspective): Table[Row] =
     graph.explodeSelect(vertex =>
       if (vertex.name() == source)
         List(Row(vertex.getState[mutable.Map[Long, T]]("flow").values.sum))

--- a/core/src/main/scala/com/raphtory/algorithms/generic/NeighbourNames.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/generic/NeighbourNames.scala
@@ -23,7 +23,7 @@ import com.raphtory.api.analysis.graphview.GraphPerspective
   *  [](com.raphtory.algorithms.temporal.TemporalEdgeList)
   *  ```
   */
-object NeighbourNames extends Generic {
+object NeighbourNames extends Generic[Any] {
 
   override def apply(graph: GraphPerspective): graph.Graph =
     graph

--- a/core/src/main/scala/com/raphtory/algorithms/generic/NodeInformation.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/generic/NodeInformation.scala
@@ -54,7 +54,7 @@ import com.raphtory.api.analysis.table.Table
   *   ```
   */
 
-class NodeInformation(initialID: Long, hopsAway: Int = 1) extends Generic {
+class NodeInformation(initialID: Long, hopsAway: Int = 1) extends Generic[Row] {
 
   case class Node(label: String, metadata: NodeData, edges: Array[EdgeInfo])
   case class NodeData(id: String)
@@ -79,7 +79,7 @@ class NodeInformation(initialID: Long, hopsAway: Int = 1) extends Generic {
               true
       )
 
-  override def tabularise(graph: GraphPerspective): Table =
+  override def tabularise(graph: GraphPerspective): Table[Row] =
     graph
       .select { vertex =>
         val vertexID                         = vertex.ID

--- a/core/src/main/scala/com/raphtory/algorithms/generic/NodeList.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/generic/NodeList.scala
@@ -52,7 +52,7 @@ class NodeList(
     properties: Seq[String] = Seq.empty[String],
     defaults: Map[String, Any] = Map.empty[String, Any]
 ) extends NodeListOutput(properties, defaults)
-        with Generic {}
+        with Generic[Row] {}
 
 object NodeList {
 

--- a/core/src/main/scala/com/raphtory/algorithms/generic/TwoHopPaths.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/generic/TwoHopPaths.scala
@@ -51,7 +51,7 @@ import scala.collection.mutable.ArrayBuffer
   *
   *  4. The source node compiles all response messages
   */
-class TwoHopPaths(seeds: Set[String] = Set[String]()) extends Generic {
+class TwoHopPaths(seeds: Set[String] = Set[String]()) extends Generic[Row] {
 
   override def apply(graph: GraphPerspective): graph.Graph =
     graph
@@ -86,7 +86,7 @@ class TwoHopPaths(seeds: Set[String] = Set[String]()) extends Generic {
               true
       )
 
-  override def tabularise(graph: GraphPerspective): Table =
+  override def tabularise(graph: GraphPerspective): Table[Row] =
     graph
       .select(vertex =>
         Row(

--- a/core/src/main/scala/com/raphtory/algorithms/generic/VertexHistogram.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/generic/VertexHistogram.scala
@@ -9,7 +9,7 @@ import com.raphtory.utils.Bounded
 
 import scala.reflect.ClassTag
 
-class VertexHistogram[T: Numeric: Bounded: ClassTag](propertyString: String, noBins: Int = 1000) extends Generic {
+class VertexHistogram[T: Numeric: Bounded: ClassTag](propertyString: String, noBins: Int = 1000) extends Generic[Row] {
 
   override def apply(graph: GraphPerspective): graph.Graph =
     graph
@@ -32,7 +32,7 @@ class VertexHistogram[T: Numeric: Bounded: ClassTag](propertyString: String, noB
         histogram += vertex.getState[T](propertyString)
       }
 
-  override def tabularise(graph: GraphPerspective): Table =
+  override def tabularise(graph: GraphPerspective): Table[Row] =
     graph.globalSelect { state =>
       val rowSeq = Seq(state[T, T]("propertyMin").value, state[T, T]("propertyMax").value) ++ state[
               T,

--- a/core/src/main/scala/com/raphtory/algorithms/generic/community/LPA.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/generic/community/LPA.scala
@@ -82,7 +82,7 @@ class LPA[T: Numeric](
       }
       .iterate(vertex => lpa(vertex, weight, tieBreaker, SP, rnd), maxIter, false)
 
-  override def tabularise(graph: GraphPerspective): Table =
+  override def tabularise(graph: GraphPerspective): Table[Row] =
     graph.select { vertex =>
       Row(
               vertex.name(),

--- a/core/src/main/scala/com/raphtory/algorithms/generic/community/SLPA.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/generic/community/SLPA.scala
@@ -59,7 +59,7 @@ import scala.util.Random
   *  Speaker-listener Interaction Dynamic Process by Jierui Xie, Boleslaw K. Szymanski and Xiaoming Liu (2011)
   *  ```
   */
-class SLPA(iterNumber: Int = 50, speakerRule: Rule, listenerRule: Rule) extends Generic {
+class SLPA(iterNumber: Int = 50, speakerRule: Rule, listenerRule: Rule) extends Generic[Row] {
 
   override def apply(graph: GraphPerspective): graph.Graph =
     graph
@@ -86,7 +86,7 @@ class SLPA(iterNumber: Int = 50, speakerRule: Rule, listenerRule: Rule) extends 
               iterations = iterNumber
       )
 
-  override def tabularise(graph: GraphPerspective): Table =
+  override def tabularise(graph: GraphPerspective): Table[Row] =
     graph.select { vertex =>
       val memory = vertex.getState[mutable.Queue[Long]]("memory")
       Row(vertex.name(), "[" + memory.mkString(" ") + "]")

--- a/core/src/main/scala/com/raphtory/algorithms/generic/dynamic/Node2VecWalk.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/generic/dynamic/Node2VecWalk.scala
@@ -64,7 +64,7 @@ import scala.collection.compat.immutable.ArraySeq
   *
   * [^node2vec]: [node2vec: Scalable Feature Learning for Networks](https://arxiv.org/abs/1607.00653)
   */
-class Node2VecWalk(walkLength: Int = 10, p: Double = 1.0, q: Double = 1.0) extends Generic {
+class Node2VecWalk(walkLength: Int = 10, p: Double = 1.0, q: Double = 1.0) extends Generic[Row] {
   private val rng = new Random() //TODO does this need a seed?
 
   override def apply(graph: GraphPerspective): graph.Graph =
@@ -122,7 +122,7 @@ class Node2VecWalk(walkLength: Int = 10, p: Double = 1.0, q: Double = 1.0) exten
         }
       }
 
-  override def tabularise(graph: GraphPerspective): Table =
+  override def tabularise(graph: GraphPerspective): Table[Row] =
     graph.select(vertex => Row(vertex.getState[ArrayBuffer[String]]("walk").toSeq: _*))
 }
 

--- a/core/src/main/scala/com/raphtory/algorithms/generic/dynamic/RandomWalk.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/generic/dynamic/RandomWalk.scala
@@ -47,7 +47,7 @@ import scala.util.Random
   *
   *  Each row of the table corresponds to a single random walk and columns correspond to the vertex at a given step
   */
-class RandomWalk(walkLength: Int, numWalks: Int, seed: Long = -1) extends Generic {
+class RandomWalk(walkLength: Int, numWalks: Int, seed: Long = -1) extends Generic[Row] {
   protected val rnd: Random = if (seed != -1) new Random(seed) else new Random()
 
   protected def selectNeighbour(vertex: Vertex) = {
@@ -95,7 +95,7 @@ class RandomWalk(walkLength: Int, numWalks: Int, seed: Long = -1) extends Generi
         }
       }
 
-  override def tabularise(graph: GraphPerspective): Table =
+  override def tabularise(graph: GraphPerspective): Table[Row] =
     graph
       .select(vertex => Row(vertex.getState[Array[ArrayBuffer[String]]]("walks")))
       .explode(row => row.getAs[Array[ArrayBuffer[String]]](0).map(r => Row(r.toSeq: _*)).toList)

--- a/core/src/main/scala/com/raphtory/algorithms/generic/gametheory/PrisonersDilemma.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/generic/gametheory/PrisonersDilemma.scala
@@ -133,7 +133,7 @@ class PrisonersDilemma(
     vertex.setState("step", PLAYSTEP)
   }
 
-  override def tabularise(graph: GraphPerspective): Table =
+  override def tabularise(graph: GraphPerspective): Table[Row] =
     graph.select { vertex =>
       val history = vertex.getState[mutable.Queue[Int]]("cooperationHistory")
       Row(vertex.name(), "[" + history.mkString(" ") + "]")

--- a/core/src/main/scala/com/raphtory/algorithms/generic/motif/GlobalClusteringCoefficient.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/generic/motif/GlobalClusteringCoefficient.scala
@@ -26,7 +26,7 @@ import com.raphtory.api.analysis.table.Table
   * ``
   */
 
-object GlobalClusteringCoefficient extends Generic {
+object GlobalClusteringCoefficient extends Generic[Row] {
 
   override def apply(graph: GraphPerspective): graph.Graph =
     GlobalTriangleCount(graph)
@@ -41,7 +41,7 @@ object GlobalClusteringCoefficient extends Generic {
         state("wedges") += k * (k - 1) / 2
       }
 
-  override def tabularise(graph: GraphPerspective): Table =
+  override def tabularise(graph: GraphPerspective): Table[Row] =
     graph.globalSelect { state =>
       val totalCluster: Double = state("totalClustering").value
       // the below is thrice the actual number of triangles, hence none of the usual factor of 3 in the

--- a/core/src/main/scala/com/raphtory/algorithms/generic/motif/GlobalTriangleCount.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/generic/motif/GlobalTriangleCount.scala
@@ -26,7 +26,7 @@ import com.raphtory.api.analysis.table.Table
   * ``
   */
 
-object GlobalTriangleCount extends Generic {
+object GlobalTriangleCount extends Generic[Row] {
 
   override def apply(graph: GraphPerspective): graph.Graph =
     LocalTriangleCount(graph)
@@ -36,7 +36,7 @@ object GlobalTriangleCount extends Generic {
         state("triangles") += tri
       }
 
-  override def tabularise(graph: GraphPerspective): Table =
+  override def tabularise(graph: GraphPerspective): Table[Row] =
     graph.globalSelect { state =>
       val totalTri: Int = state("triangles").value
       Row(totalTri / 3)

--- a/core/src/main/scala/com/raphtory/algorithms/generic/motif/SquareCount.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/generic/motif/SquareCount.scala
@@ -12,7 +12,7 @@ case class SecondStep[VertexID](p: VertexID, q: VertexID, adj: Array[VertexID])
 case class CountMessage(count: Long)
 case class WedgeMessage[VertexID](p: VertexID, s: Array[VertexID])
 
-object AccumulateCounts extends Generic {
+object AccumulateCounts extends Generic[Any] {
 
   override def apply(graph: GraphPerspective): graph.Graph =
     graph
@@ -41,7 +41,7 @@ object AccumulateCounts extends Generic {
       }
 }
 
-object CountPR extends Generic {
+object CountPR extends Generic[Any] {
 
   override def apply(graph: GraphPerspective): graph.Graph = {
     val counts = AccumulateCounts
@@ -65,7 +65,7 @@ object CountPR extends Generic {
   }
 }
 
-object CountQR extends Generic {
+object CountQR extends Generic[Any] {
 
   override def apply(graph: GraphPerspective): graph.Graph =
     AccumulateCounts(
@@ -88,7 +88,7 @@ object CountQR extends Generic {
     )
 }
 
-object CountPQ extends Generic {
+object CountPQ extends Generic[Any] {
 
   override def apply(graph: GraphPerspective): graph.Graph =
     graph

--- a/core/src/main/scala/com/raphtory/algorithms/generic/motif/ThreeNodeMotifs.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/generic/motif/ThreeNodeMotifs.scala
@@ -54,7 +54,7 @@ import scala.collection.mutable.ArrayBuffer
   *  | ----------------- | ------------------------- | --- | -------------------------- |
   *  | {s}`name: String` | {s}`motifCounts(0): Long` | ... | {s}`motifCounts(12): Long` |
   */
-object ThreeNodeMotifs extends Generic {
+object ThreeNodeMotifs extends Generic[Row] {
   //  edge direction constants
   val inoutEdge = 0
   val outEdge   = 1
@@ -157,7 +157,7 @@ object ThreeNodeMotifs extends Generic {
         vertex.setState("motifCounts", motifCounts)
       }
 
-  override def tabularise(graph: GraphPerspective): Table =
+  override def tabularise(graph: GraphPerspective): Table[Row] =
     graph.select { vertex =>
       val motifCounts = vertex.getState[ArrayBuffer[Long]]("motifCounts")
       val row         = vertex.name() +: motifCounts

--- a/core/src/main/scala/com/raphtory/algorithms/temporal/Ancestors.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/temporal/Ancestors.scala
@@ -48,7 +48,7 @@ class Ancestors(
     delta: Long = Long.MaxValue,
     directed: Boolean = true,
     strict: Boolean = true
-) extends Generic {
+) extends Generic[Row] {
 
   override def apply(graph: GraphPerspective): graph.Graph =
     graph
@@ -84,7 +84,7 @@ class Ancestors(
               iterations = 100
       )
 
-  override def tabularise(graph: GraphPerspective): Table =
+  override def tabularise(graph: GraphPerspective): Table[Row] =
     graph.select(vertex => Row(vertex.name(), vertex.getStateOrElse[Boolean]("ancestor", false)))
 
 }

--- a/core/src/main/scala/com/raphtory/algorithms/temporal/Descendants.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/temporal/Descendants.scala
@@ -48,7 +48,7 @@ class Descendants(
     delta: Long = Long.MaxValue,
     directed: Boolean = true,
     strict: Boolean = true
-) extends Generic {
+) extends Generic[Row] {
 
   override def apply(graph: GraphPerspective): graph.Graph =
     graph
@@ -83,7 +83,7 @@ class Descendants(
               iterations = 100
       )
 
-  override def tabularise(graph: GraphPerspective): Table =
+  override def tabularise(graph: GraphPerspective): Table[Row] =
     graph.select(vertex => Row(vertex.name(), vertex.getStateOrElse[Boolean]("descendant", false)))
 }
 

--- a/core/src/main/scala/com/raphtory/algorithms/temporal/TemporalEdgeList.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/temporal/TemporalEdgeList.scala
@@ -35,9 +35,9 @@ import com.raphtory.api.analysis.table.Table
 class TemporalEdgeList(
     properties: Seq[String] = Seq.empty[String],
     defaults: Map[String, Any] = Map.empty[String, Any]
-) extends Generic {
+) extends Generic[Row] {
 
-  override def tabularise(graph: GraphPerspective): Table =
+  override def tabularise(graph: GraphPerspective): Table[Row] =
     NeighbourNames(graph.reducedView).multilayerView
       .explodeSelect { vertex =>
         val neighbourMap = vertex.getState[Map[Long, String]]("neighbourNames")

--- a/core/src/main/scala/com/raphtory/algorithms/temporal/TemporalNodeList.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/temporal/TemporalNodeList.scala
@@ -39,9 +39,9 @@ import com.raphtory.api.analysis.table.Table
 class TemporalNodeList(
     properties: Seq[String] = Seq.empty[String],
     defaults: Map[String, Any] = Map.empty[String, Any]
-) extends Generic {
+) extends Generic[Row] {
 
-  override def tabularise(graph: GraphPerspective): Table =
+  override def tabularise(graph: GraphPerspective): Table[Row] =
     graph.multilayerView
       .select { vertex =>
         Row(

--- a/core/src/main/scala/com/raphtory/algorithms/temporal/community/MultilayerLPA.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/temporal/community/MultilayerLPA.scala
@@ -69,7 +69,7 @@ class MultilayerLPA(
     layerSize: Long,
     omega: Double = 1.0,
     seed: Long = -1
-) extends GenericReduction {
+) extends GenericReduction[Row] {
 
   private val rnd: Random = if (seed == -1) new scala.util.Random else new scala.util.Random(seed)
   private val SP          = 0.2f // Stickiness probability
@@ -176,7 +176,7 @@ class MultilayerLPA(
       )
   }
 
-  override def tabularise(graph: ReducedGraphPerspective): Table =
+  override def tabularise(graph: ReducedGraphPerspective): Table[Row] =
     graph
       .select { vertex =>
         Row(

--- a/core/src/main/scala/com/raphtory/algorithms/temporal/dynamic/GenericTaint.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/temporal/dynamic/GenericTaint.scala
@@ -47,7 +47,7 @@ import com.raphtory.api.analysis.table.Table
   *  | {s}`name: String` | {s}`edge.ID: Long` | {s}`event.time: Long` | {s}`name: String` |
   */
 class GenericTaint(startTime: Long, infectedNodes: Set[String], stopNodes: Set[String] = Set())
-        extends GenericReduction {
+        extends GenericReduction[Row] {
 
   override def apply(graph: GraphPerspective): graph.ReducedGraph =
     graph.reducedView
@@ -140,7 +140,7 @@ class GenericTaint(startTime: Long, infectedNodes: Set[String], stopNodes: Set[S
       )
   // get all vertexes and their status
 
-  override def tabularise(graph: ReducedGraphPerspective): Table =
+  override def tabularise(graph: ReducedGraphPerspective): Table[Row] =
     graph
       .select(vertex =>
         Row(

--- a/core/src/main/scala/com/raphtory/algorithms/temporal/motif/MotifAlpha.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/temporal/motif/MotifAlpha.scala
@@ -4,6 +4,7 @@ import com.raphtory.algorithms.generic.NodeList
 import com.raphtory.api.analysis.algorithm.GenericReduction
 import com.raphtory.api.analysis.algorithm.NodeListOutput
 import com.raphtory.api.analysis.graphview.GraphPerspective
+import com.raphtory.api.analysis.table.Row
 
 /**
   * {s}`MotifAlpha()`
@@ -34,7 +35,7 @@ import com.raphtory.api.analysis.graphview.GraphPerspective
   *  | ----------------- | ----------------------- |
   *  | {s}`name: String` | {s}`motifAlpha: Int`    |
   */
-object MotifAlpha extends NodeListOutput(Seq("motifAlpha")) with GenericReduction {
+object MotifAlpha extends NodeListOutput(Seq("motifAlpha")) with GenericReduction[Row] {
 
   override def apply(graph: GraphPerspective): graph.ReducedGraph =
     graph.reducedView.step { vertex =>

--- a/core/src/main/scala/com/raphtory/algorithms/temporal/views/MultilayerView.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/temporal/views/MultilayerView.scala
@@ -7,7 +7,7 @@ import com.raphtory.api.analysis.visitor.Vertex
 
 class MultilayerView(
     interlayerEdgeBuilder: Vertex => Seq[InterlayerEdge]
-) extends MultilayerProjection {
+) extends MultilayerProjection[Any] {
 
   override def apply(graph: GraphPerspective): graph.MultilayerGraph =
     graph.multilayerView(interlayerEdgeBuilder)

--- a/core/src/main/scala/com/raphtory/api/analysis/algorithm/BaseAlgorithm.scala
+++ b/core/src/main/scala/com/raphtory/api/analysis/algorithm/BaseAlgorithm.scala
@@ -4,7 +4,7 @@ import com.raphtory.api.analysis.graphview.GraphPerspective
 import com.raphtory.api.analysis.table.Row
 import com.raphtory.api.analysis.table.Table
 
-private[api] trait BaseAlgorithm extends Serializable {
+private[api] trait BaseAlgorithm[T] extends Serializable {
 
   /** Input graph type */
   type In <: GraphPerspective
@@ -24,9 +24,9 @@ private[api] trait BaseAlgorithm extends Serializable {
     *
     * @param graph Graph that results from the call to `apply`
     */
-  def tabularise(graph: Out): Table = graph.globalSelect(_ => Row())
+  def tabularise(graph: Out): Table[T] = graph.globalSelect(_ => Row().asInstanceOf[T]) // TODO: have a thought
 
-  private[raphtory] def run(graph: In): Table = tabularise(apply(graph))
+  private[raphtory] def run(graph: In): Table[T] = tabularise(apply(graph))
 
   /** The name of the algorithm (returns the simple class name by default) */
   def name: String = {
@@ -39,17 +39,17 @@ private[api] trait BaseAlgorithm extends Serializable {
     *
     *  @param other next algorithm to run
     */
-  def ->(other: Generic): BaseAlgorithm
+  def ->[Q](other: Generic[Q]): BaseAlgorithm[Q]
 }
 
 /** Trait that is extended by all algorithms that can be applied to any graph view */
-trait GenericallyApplicable extends BaseAlgorithm {
+trait GenericallyApplicable[T] extends BaseAlgorithm[T] {
   override type In = GraphPerspective
 }
 
-abstract private class ChainedAlgorithm[A <: BaseAlgorithm, B <: BaseAlgorithm](
+abstract private class ChainedAlgorithm[T, Q, A <: BaseAlgorithm[T], B <: BaseAlgorithm[Q]](
     val first: A,
     val second: B
-) extends BaseAlgorithm {
+) extends BaseAlgorithm[Q] {
   override def name: String = first.name + ":" + second.name
 }

--- a/core/src/main/scala/com/raphtory/api/analysis/algorithm/Generic.scala
+++ b/core/src/main/scala/com/raphtory/api/analysis/algorithm/Generic.scala
@@ -3,6 +3,7 @@ package com.raphtory.api.analysis.algorithm
 import com.raphtory.api.analysis.graphview.GraphPerspective
 import com.raphtory.api.analysis.graphview.MultilayerGraphPerspective
 import com.raphtory.api.analysis.graphview.ReducedGraphPerspective
+import com.raphtory.api.analysis.table.Row
 import com.raphtory.api.analysis.table.Table
 import com.typesafe.scalalogging.Logger
 import org.slf4j.LoggerFactory
@@ -13,7 +14,7 @@ import org.slf4j.LoggerFactory
   *                   clearing all messages in-between. The `tabularise` method of the chained algorithm calls only
   *                   the `tabularise` method of `other`.
   */
-trait Generic extends GenericallyApplicable {
+trait Generic[T] extends GenericallyApplicable[T] {
   override type Out = GraphPerspective
 
   /** Logger instance for writing out log messages */
@@ -35,12 +36,12 @@ trait Generic extends GenericallyApplicable {
     * $chainBody
     * @param other Algorithm to apply after this one
     */
-  override def ->(other: Generic): Generic =
-    new ChainedAlgorithm(this, other) with Generic {
+  override def ->[Q](other: Generic[Q]): Generic[Q] =
+    new ChainedAlgorithm[T, Q, Generic[T], Generic[Q]](this, other) with Generic[Q] {
 
-      override def apply(graph: GraphPerspective): graph.Graph =
+      override def apply(graph: GraphPerspective): graph.Graph   =
         second(first(graph).clearMessages())
-      override def tabularise(graph: GraphPerspective): Table  = second.tabularise(graph)
+      override def tabularise(graph: GraphPerspective): Table[Q] = second.tabularise(graph)
     }
 
   /** Chain this algorithm with a [[MultilayerProjection]] to create a new [[MultilayerProjection]]
@@ -48,12 +49,12 @@ trait Generic extends GenericallyApplicable {
     * $chainBody
     * @param other Algorithm to apply after this one
     */
-  def ->(other: MultilayerProjection): MultilayerProjection =
-    new ChainedAlgorithm(this, other) with MultilayerProjection {
+  def ->[Q](other: MultilayerProjection[Q]): MultilayerProjection[Q] =
+    new ChainedAlgorithm[T, Q, Generic[T], MultilayerProjection[Q]](this, other) with MultilayerProjection[Q] {
 
-      override def apply(graph: GraphPerspective): graph.MultilayerGraph =
+      override def apply(graph: GraphPerspective): graph.MultilayerGraph   =
         second(first(graph).clearMessages())
-      override def tabularise(graph: MultilayerGraphPerspective): Table  = second.tabularise(graph)
+      override def tabularise(graph: MultilayerGraphPerspective): Table[Q] = second.tabularise(graph)
     }
 
   /** Chain this algorithm with a [[GenericReduction]] to create a new [[GenericReduction]]
@@ -61,11 +62,11 @@ trait Generic extends GenericallyApplicable {
     * $chainBody
     * @param other Algorithm to apply after this one
     */
-  def ->(other: GenericReduction): GenericReduction =
-    new ChainedAlgorithm(this, other) with GenericReduction {
+  def ->[Q](other: GenericReduction[Q]): GenericReduction[Q] =
+    new ChainedAlgorithm[T, Q, Generic[T], GenericReduction[Q]](this, other) with GenericReduction[Q] {
 
-      override def apply(graph: GraphPerspective): graph.ReducedGraph =
+      override def apply(graph: GraphPerspective): graph.ReducedGraph   =
         second(first(graph).clearMessages())
-      override def tabularise(graph: ReducedGraphPerspective): Table  = second.tabularise(graph)
+      override def tabularise(graph: ReducedGraphPerspective): Table[Q] = second.tabularise(graph)
     }
 }

--- a/core/src/main/scala/com/raphtory/api/analysis/algorithm/GenericReduction.scala
+++ b/core/src/main/scala/com/raphtory/api/analysis/algorithm/GenericReduction.scala
@@ -3,6 +3,7 @@ package com.raphtory.api.analysis.algorithm
 import com.raphtory.api.analysis.graphview.GraphPerspective
 import com.raphtory.api.analysis.graphview.MultilayerGraphPerspective
 import com.raphtory.api.analysis.graphview.ReducedGraphPerspective
+import com.raphtory.api.analysis.table.Row
 import com.raphtory.api.analysis.table.Table
 
 /** Base class for writing graph algorithms that return reduced views.
@@ -14,7 +15,7 @@ import com.raphtory.api.analysis.table.Table
   *                   clearing all messages in-between. The `tabularise` method of the chained algorithm calls only
   *                   the `tabularise` method of `other`.
   */
-trait GenericReduction extends GenericallyApplicable {
+trait GenericReduction[T] extends GenericallyApplicable[T] {
   override type Out = ReducedGraphPerspective
 
   /** Main algorithm
@@ -31,12 +32,12 @@ trait GenericReduction extends GenericallyApplicable {
     * $chainBody
     * @param other Algorithm to apply after this one
     */
-  def ->(other: Generic): GenericReduction =
-    new ChainedAlgorithm(this, other) with GenericReduction {
+  def ->[Q](other: Generic[Q]): GenericReduction[Q] =
+    new ChainedAlgorithm[T, Q, GenericReduction[T], Generic[Q]](this, other) with GenericReduction[Q] {
 
-      override def apply(graph: GraphPerspective): graph.ReducedGraph =
+      override def apply(graph: GraphPerspective): graph.ReducedGraph   =
         second(first(graph).clearMessages())
-      override def tabularise(graph: ReducedGraphPerspective): Table  = second.tabularise(graph)
+      override def tabularise(graph: ReducedGraphPerspective): Table[Q] = second.tabularise(graph)
     }
 
   /** Chain this algorithm with a [[GenericReduction]] algorithm
@@ -44,12 +45,12 @@ trait GenericReduction extends GenericallyApplicable {
     * $chainBody
     * @param other Algorithm to apply after this one
     */
-  def ->(other: GenericReduction): GenericReduction =
-    new ChainedAlgorithm(this, other) with GenericReduction {
+  def ->[Q](other: GenericReduction[Q]): GenericReduction[Q] =
+    new ChainedAlgorithm[T, Q, GenericReduction[T], GenericReduction[Q]](this, other) with GenericReduction[Q] {
 
-      override def apply(graph: GraphPerspective): graph.ReducedGraph =
+      override def apply(graph: GraphPerspective): graph.ReducedGraph   =
         second(first(graph).clearMessages())
-      override def tabularise(graph: ReducedGraphPerspective): Table  = second.tabularise(graph)
+      override def tabularise(graph: ReducedGraphPerspective): Table[Q] = second.tabularise(graph)
     }
 
   /** Chain this algorithm with a [[MultilayerProjection]] algorithm
@@ -57,12 +58,12 @@ trait GenericReduction extends GenericallyApplicable {
     * $chainBody
     * @param other Algorithm to apply after this one
     */
-  def ->(other: MultilayerProjection): MultilayerProjection =
-    new ChainedAlgorithm(this, other) with MultilayerProjection {
+  def ->[Q](other: MultilayerProjection[Q]): MultilayerProjection[Q] =
+    new ChainedAlgorithm[T, Q, GenericReduction[T], MultilayerProjection[Q]](this, other) with MultilayerProjection[Q] {
 
-      override def apply(graph: GraphPerspective): graph.MultilayerGraph =
+      override def apply(graph: GraphPerspective): graph.MultilayerGraph   =
         second(first(graph).clearMessages())
-      override def tabularise(graph: MultilayerGraphPerspective): Table  = second.tabularise(graph)
+      override def tabularise(graph: MultilayerGraphPerspective): Table[Q] = second.tabularise(graph)
     }
 
 }

--- a/core/src/main/scala/com/raphtory/api/analysis/algorithm/Identity.scala
+++ b/core/src/main/scala/com/raphtory/api/analysis/algorithm/Identity.scala
@@ -8,4 +8,4 @@ package com.raphtory.api.analysis.algorithm
   *  title="com.raphtory.algorithms.generic.CBOD"
   * >CBOD</a>
   */
-object Identity extends Generic {}
+object Identity extends Generic[Any] {}

--- a/core/src/main/scala/com/raphtory/api/analysis/algorithm/Multilayer.scala
+++ b/core/src/main/scala/com/raphtory/api/analysis/algorithm/Multilayer.scala
@@ -2,6 +2,7 @@ package com.raphtory.api.analysis.algorithm
 
 import com.raphtory.api.analysis.graphview.MultilayerGraphPerspective
 import com.raphtory.api.analysis.graphview.ReducedGraphPerspective
+import com.raphtory.api.analysis.table.Row
 import com.raphtory.api.analysis.table.Table
 
 /** Base class for writing graph algorithms that act on multilayer views and return multilayer views.
@@ -13,7 +14,7 @@ import com.raphtory.api.analysis.table.Table
   *                   clearing all messages in-between. The `tabularise` method of the chained algorithm calls only
   *                   the `tabularise` method of `other`.
   */
-trait Multilayer extends BaseAlgorithm {
+trait Multilayer[T] extends BaseAlgorithm[T] {
   override type In  = MultilayerGraphPerspective
   override type Out = MultilayerGraphPerspective
 
@@ -28,12 +29,12 @@ trait Multilayer extends BaseAlgorithm {
     * $chainBody
     * @param other Algorithm to apply after this one
     */
-  override def ->(other: Generic): Multilayer =
-    new ChainedAlgorithm(this, other) with Multilayer {
+  override def ->[Q](other: Generic[Q]): Multilayer[Q] =
+    new ChainedAlgorithm[T, Q, Multilayer[T], Generic[Q]](this, other) with Multilayer[Q] {
 
       override def apply(graph: MultilayerGraphPerspective): graph.MultilayerGraph =
         second(first(graph).clearMessages())
-      override def tabularise(graph: MultilayerGraphPerspective): Table            = second.tabularise(graph)
+      override def tabularise(graph: MultilayerGraphPerspective): Table[Q]         = second.tabularise(graph)
     }
 
   /** Chain this algorithm with a [[GenericReduction]] algorithm
@@ -41,12 +42,12 @@ trait Multilayer extends BaseAlgorithm {
     * $chainBody
     * @param other Algorithm to apply after this one
     */
-  def ->(other: GenericReduction): MultilayerReduction =
-    new ChainedAlgorithm(this, other) with MultilayerReduction {
+  def ->[Q](other: GenericReduction[Q]): MultilayerReduction[Q] =
+    new ChainedAlgorithm[T, Q, Multilayer[T], GenericReduction[Q]](this, other) with MultilayerReduction[Q] {
 
       override def apply(graph: MultilayerGraphPerspective): graph.ReducedGraph =
         second(first(graph).clearMessages())
-      override def tabularise(graph: ReducedGraphPerspective): Table            = second.tabularise(graph)
+      override def tabularise(graph: ReducedGraphPerspective): Table[Q]         = second.tabularise(graph)
     }
 
   /** Chain this algorithm with a [[MultilayerReduction]] algorithm
@@ -54,12 +55,12 @@ trait Multilayer extends BaseAlgorithm {
     * $chainBody
     * @param other Algorithm to apply after this one
     */
-  def ->(other: MultilayerReduction): MultilayerReduction =
-    new ChainedAlgorithm(this, other) with MultilayerReduction {
+  def ->[Q](other: MultilayerReduction[Q]): MultilayerReduction[Q] =
+    new ChainedAlgorithm[T, Q, Multilayer[T], MultilayerReduction[Q]](this, other) with MultilayerReduction[Q] {
 
       override def apply(graph: MultilayerGraphPerspective): graph.ReducedGraph =
         second(first(graph).clearMessages())
-      override def tabularise(graph: ReducedGraphPerspective): Table            = second.tabularise(graph)
+      override def tabularise(graph: ReducedGraphPerspective): Table[Q]         = second.tabularise(graph)
     }
 
   /** Chain this algorithm with a [[MultilayerProjection]] algorithm
@@ -67,12 +68,12 @@ trait Multilayer extends BaseAlgorithm {
     * $chainBody
     * @param other Algorithm to apply after this one
     */
-  def ->(other: MultilayerProjection): Multilayer =
-    new ChainedAlgorithm(this, other) with Multilayer {
+  def ->[Q](other: MultilayerProjection[Q]): Multilayer[Q] =
+    new ChainedAlgorithm[T, Q, Multilayer[T], MultilayerProjection[Q]](this, other) with Multilayer[Q] {
 
       override def apply(graph: MultilayerGraphPerspective): graph.MultilayerGraph =
         second(first(graph).clearMessages())
-      override def tabularise(graph: MultilayerGraphPerspective): Table            = second.tabularise(graph)
+      override def tabularise(graph: MultilayerGraphPerspective): Table[Q]         = second.tabularise(graph)
     }
 
   /** Chain this algorithm with another Multilayer algorithm
@@ -80,11 +81,11 @@ trait Multilayer extends BaseAlgorithm {
     * $chainBody
     * @param other Algorithm to apply after this one
     */
-  def ->(other: Multilayer): Multilayer =
-    new ChainedAlgorithm(this, other) with Multilayer {
+  def ->[Q](other: Multilayer[Q]): Multilayer[Q] =
+    new ChainedAlgorithm[T, Q, Multilayer[T], Multilayer[Q]](this, other) with Multilayer[Q] {
 
       override def apply(graph: MultilayerGraphPerspective): graph.MultilayerGraph =
         second(first(graph).clearMessages())
-      override def tabularise(graph: MultilayerGraphPerspective): Table            = second.tabularise(graph)
+      override def tabularise(graph: MultilayerGraphPerspective): Table[Q]         = second.tabularise(graph)
     }
 }

--- a/core/src/main/scala/com/raphtory/api/analysis/algorithm/MultilayerProjection.scala
+++ b/core/src/main/scala/com/raphtory/api/analysis/algorithm/MultilayerProjection.scala
@@ -3,6 +3,7 @@ package com.raphtory.api.analysis.algorithm
 import com.raphtory.api.analysis.graphview.GraphPerspective
 import com.raphtory.api.analysis.graphview.MultilayerGraphPerspective
 import com.raphtory.api.analysis.graphview.ReducedGraphPerspective
+import com.raphtory.api.analysis.table.Row
 import com.raphtory.api.analysis.table.Table
 
 /** Base class for writing graph algorithms that return multilayer views.
@@ -13,7 +14,7 @@ import com.raphtory.api.analysis.table.Table
   *                   clearing all messages in-between. The `tabularise` method of the chained algorithm calls only
   *                   the `tabularise` method of `other`.
   */
-trait MultilayerProjection extends GenericallyApplicable {
+trait MultilayerProjection[T] extends GenericallyApplicable[T] {
   override type Out = MultilayerGraphPerspective
 
   /** Default implementation returns the graph unchanged
@@ -28,12 +29,12 @@ trait MultilayerProjection extends GenericallyApplicable {
     * $chainBody
     * @param other Algorithm to apply after this one
     */
-  override def ->(other: Generic): MultilayerProjection =
-    new ChainedAlgorithm(this, other) with MultilayerProjection {
+  override def ->[Q](other: Generic[Q]): MultilayerProjection[Q] =
+    new ChainedAlgorithm[T, Q, MultilayerProjection[T], Generic[Q]](this, other) with MultilayerProjection[Q] {
 
-      override def apply(graph: GraphPerspective): graph.MultilayerGraph =
+      override def apply(graph: GraphPerspective): graph.MultilayerGraph   =
         second(first(graph).clearMessages())
-      override def tabularise(graph: MultilayerGraphPerspective): Table  = second.tabularise(graph)
+      override def tabularise(graph: MultilayerGraphPerspective): Table[Q] = second.tabularise(graph)
     }
 
   /** Chain this algorithm with a [[GenericReduction]] algorithm
@@ -41,12 +42,12 @@ trait MultilayerProjection extends GenericallyApplicable {
     * $chainBody
     * @param other Algorithm to apply after this one
     */
-  def ->(other: GenericReduction): GenericReduction =
-    new ChainedAlgorithm(this, other) with GenericReduction {
+  def ->[Q](other: GenericReduction[Q]): GenericReduction[Q] =
+    new ChainedAlgorithm[T, Q, MultilayerProjection[T], GenericReduction[Q]](this, other) with GenericReduction[Q] {
 
-      override def apply(graph: GraphPerspective): graph.ReducedGraph =
+      override def apply(graph: GraphPerspective): graph.ReducedGraph   =
         second(first(graph).clearMessages())
-      override def tabularise(graph: ReducedGraphPerspective): Table  = second.tabularise(graph)
+      override def tabularise(graph: ReducedGraphPerspective): Table[Q] = second.tabularise(graph)
     }
 
   /** Chain this algorithm with a [[Multilayer]] algorithm
@@ -54,12 +55,12 @@ trait MultilayerProjection extends GenericallyApplicable {
     * $chainBody
     * @param other Algorithm to apply after this one
     */
-  def ->(other: Multilayer): MultilayerProjection =
-    new ChainedAlgorithm(this, other) with MultilayerProjection {
+  def ->[Q](other: Multilayer[Q]): MultilayerProjection[Q] =
+    new ChainedAlgorithm[T, Q, MultilayerProjection[T], Multilayer[Q]](this, other) with MultilayerProjection[Q] {
 
-      override def apply(graph: GraphPerspective): graph.MultilayerGraph =
+      override def apply(graph: GraphPerspective): graph.MultilayerGraph   =
         second(first(graph).clearMessages())
-      override def tabularise(graph: MultilayerGraphPerspective): Table  = second.tabularise(graph)
+      override def tabularise(graph: MultilayerGraphPerspective): Table[Q] = second.tabularise(graph)
     }
 
   /** Chain this algorithm with a [[MultilayerProjection]] algorithm
@@ -67,12 +68,13 @@ trait MultilayerProjection extends GenericallyApplicable {
     * $chainBody
     * @param other Algorithm to apply after this one
     */
-  def ->(other: MultilayerProjection): MultilayerProjection =
-    new ChainedAlgorithm(this, other) with MultilayerProjection {
+  def ->[Q](other: MultilayerProjection[Q]): MultilayerProjection[Q] =
+    new ChainedAlgorithm[T, Q, MultilayerProjection[T], MultilayerProjection[Q]](this, other)
+      with MultilayerProjection[Q] {
 
-      override def apply(graph: GraphPerspective): graph.MultilayerGraph =
+      override def apply(graph: GraphPerspective): graph.MultilayerGraph   =
         second(first(graph).clearMessages())
-      override def tabularise(graph: MultilayerGraphPerspective): Table  = second.tabularise(graph)
+      override def tabularise(graph: MultilayerGraphPerspective): Table[Q] = second.tabularise(graph)
     }
 
   /** Chain this algorithm with a [[MultilayerReduction]] algorithm
@@ -80,12 +82,12 @@ trait MultilayerProjection extends GenericallyApplicable {
     * $chainBody
     * @param other Algorithm to apply after this one
     */
-  def ->(other: MultilayerReduction): GenericReduction =
-    new ChainedAlgorithm(this, other) with GenericReduction {
+  def ->[Q](other: MultilayerReduction[Q]): GenericReduction[Q] =
+    new ChainedAlgorithm[T, Q, MultilayerProjection[T], MultilayerReduction[Q]](this, other) with GenericReduction[Q] {
 
-      override def apply(graph: GraphPerspective): graph.ReducedGraph =
+      override def apply(graph: GraphPerspective): graph.ReducedGraph   =
         second(first(graph).clearMessages())
-      override def tabularise(graph: ReducedGraphPerspective): Table  = second.tabularise(graph)
+      override def tabularise(graph: ReducedGraphPerspective): Table[Q] = second.tabularise(graph)
     }
 
 }

--- a/core/src/main/scala/com/raphtory/api/analysis/algorithm/NodeListOutput.scala
+++ b/core/src/main/scala/com/raphtory/api/analysis/algorithm/NodeListOutput.scala
@@ -6,9 +6,9 @@ import com.raphtory.api.analysis.table.Table
 abstract class NodeListOutput(
     properties: Seq[String] = Seq.empty[String],
     defaults: Map[String, Any] = Map.empty[String, Any]
-) extends BaseAlgorithm {
+) extends BaseAlgorithm[Row] {
 
-  override def tabularise(graph: Out): Table =
+  override def tabularise(graph: Out): Table[Row] =
     graph.select { vertex =>
       val row = vertex.name() +: properties.map(name =>
         vertex.getStateOrElse(name, defaults.getOrElse(name, None), includeProperties = true)

--- a/core/src/main/scala/com/raphtory/api/analysis/graphview/GraphPerspective.scala
+++ b/core/src/main/scala/com/raphtory/api/analysis/graphview/GraphPerspective.scala
@@ -222,25 +222,25 @@ trait GraphPerspective {
     *
     * @param f function to extract data from vertex (run once for each vertex)
     */
-  def select(f: Vertex => Row): Table
+  def select[T](f: Vertex => T): Table[T]
 
   /** Write output to table with access to global graph state
     *
     * @param f function to extract data from vertex and graph state (run once for each vertex)
     */
-  def select(f: (Vertex, GraphState) => Row): Table
+  def select[T](f: (Vertex, GraphState) => T): Table[T]
 
   /** Write global graph state to table (this creates a table with a single row)
     *
     * @param f function to extract data from graph state (runs only once)
     */
-  def globalSelect(f: GraphState => Row): Table
+  def globalSelect[T](f: GraphState => T): Table[T]
 
   /** Write output to table with multiple rows per vertex
     *
     * @param f function to extract data from vertex
     */
-  def explodeSelect(f: Vertex => List[Row]): Table
+  def explodeSelect[T](f: Vertex => List[T]): Table[T]
 
 //  TODO: Implement GraphState version of explodeSelect
 
@@ -318,10 +318,10 @@ private[api] trait ConcreteGraphPerspective[V <: visitor.Vertex, G <: ConcreteGr
       iterations: Int,
       executeMessagedOnly: Boolean
   ): Graph
-  def select(f: Vertex => Row): Table
-  def select(f: (Vertex, GraphState) => Row): Table
-  def globalSelect(f: GraphState => Row): Table
-  def explodeSelect(f: Vertex => List[Row]): Table
+  def select[T](f: Vertex => T): Table[T]
+  def select[T](f: (Vertex, GraphState) => T): Table[T]
+  def globalSelect[T](f: GraphState => T): Table[T]
+  def explodeSelect[T](f: Vertex => List[T]): Table[T]
   def clearMessages(): Graph
 }
 

--- a/core/src/main/scala/com/raphtory/api/analysis/graphview/GraphView.scala
+++ b/core/src/main/scala/com/raphtory/api/analysis/graphview/GraphView.scala
@@ -6,6 +6,7 @@ import com.raphtory.api.analysis.algorithm.GenericallyApplicable
 import com.raphtory.api.analysis.algorithm.Multilayer
 import com.raphtory.api.analysis.algorithm.MultilayerProjection
 import com.raphtory.api.analysis.algorithm.MultilayerReduction
+import com.raphtory.api.analysis.table.Row
 import com.raphtory.api.analysis.table.Table
 
 /** Core interface for the analysis API.
@@ -27,7 +28,7 @@ trait GraphView extends GraphPerspective {
     * @return Transformed graph
     * @note `transform` keeps track of the name of the applied algorithm and clears the message queues at the end of the algorithm
     */
-  def transform(algorithm: Generic): Graph
+  def transform(algorithm: Generic[_]): Graph
 
   /** Apply a [[com.raphtory.api.analysis.algorithm.MultilayerProjection MultilayerProjection]] algorithm to the graph
     *
@@ -35,7 +36,7 @@ trait GraphView extends GraphPerspective {
     * @return Transformed graph
     * @note `transform` keeps track of the name of the applied algorithm and clears the message queues at the end of the algorithm
     */
-  def transform(algorithm: MultilayerProjection): MultilayerGraph
+  def transform(algorithm: MultilayerProjection[_]): MultilayerGraph
 
   /** Apply a [[com.raphtory.api.analysis.algorithm.GenericReduction GenericReduction]] algorithm to the graph
     *
@@ -43,7 +44,7 @@ trait GraphView extends GraphPerspective {
     * @return Transformed graph
     * @note `transform` keeps track of the name of the applied algorithm and clears the message queues at the end of the algorithm
     */
-  def transform(algorithm: GenericReduction): ReducedGraph
+  def transform(algorithm: GenericReduction[_]): ReducedGraph
 
   /** Run a [[com.raphtory.api.analysis.algorithm.GenericallyApplicable GenericallyApplicable]] algorithm on the graph and return results
     *
@@ -51,7 +52,7 @@ trait GraphView extends GraphPerspective {
     *  @return Table with algorithm results
     *  @note `execute` keeps track of the name of the applied algorithm
     */
-  def execute(algorithm: GenericallyApplicable): Table
+  def execute[T](algorithm: GenericallyApplicable[T]): Table[T]
 }
 
 /** Extends [[GraphView]] with variants of the `transform` and `execute` methods specific to multilayer graphs
@@ -66,7 +67,7 @@ trait MultilayerGraphView extends MultilayerGraphPerspective with GraphView {
     * @return Transformed graph
     * @note `transform` keeps track of the name of the applied algorithm and clears the message queues at the end of the algorithm
     */
-  def transform(algorithm: Multilayer): Graph
+  def transform(algorithm: Multilayer[_]): Graph
 
   /** Apply a `MultilayerReduction` algorithm to the graph
     *
@@ -74,7 +75,7 @@ trait MultilayerGraphView extends MultilayerGraphPerspective with GraphView {
     * @return Transformed graph
     * @note `transform` keeps track of the name of the applied algorithm and clears the message queues at the end of the algorithm
     */
-  def transform(algorithm: MultilayerReduction): ReducedGraph
+  def transform(algorithm: MultilayerReduction[_]): ReducedGraph
 
   /** Run a `Multilayer` algorithm on the graph and return results
     *
@@ -82,7 +83,7 @@ trait MultilayerGraphView extends MultilayerGraphPerspective with GraphView {
     *  @return Table with algorithm results
     *  @note `execute` keeps track of the name of the applied algorithm
     */
-  def execute(algorithm: Multilayer): Table
+  def execute[T](algorithm: Multilayer[T]): Table[T]
 
   /** Run a `MultilayerReduction` algorithm on the graph and return results
     *
@@ -90,5 +91,5 @@ trait MultilayerGraphView extends MultilayerGraphPerspective with GraphView {
     *  @return Table with algorithm results
     *  @note `execute` keeps track of the name of the applied algorithm
     */
-  def execute(algorithm: MultilayerReduction): Table
+  def execute[T](algorithm: MultilayerReduction[T]): Table[T]
 }

--- a/core/src/main/scala/com/raphtory/api/analysis/table/Table.scala
+++ b/core/src/main/scala/com/raphtory/api/analysis/table/Table.scala
@@ -5,20 +5,20 @@ import com.raphtory.api.querytracker.QueryProgressTracker
 import com.raphtory.internals.components.querymanager.QueryManagement
 sealed private[raphtory] trait TableFunction extends QueryManagement
 
-final private[raphtory] case class TableFilter(f: (Row) => Boolean)     extends TableFunction
-final private[raphtory] case class Explode(f: Row => IterableOnce[Row]) extends TableFunction
+final private[raphtory] case class TableFilter(f: Any => Boolean)       extends TableFunction
+final private[raphtory] case class Explode(f: Any => IterableOnce[Any]) extends TableFunction
 private[raphtory] case object WriteToOutput                             extends TableFunction
 
 /**  Interface for table operations
   *
   * @see [[Row]], [[com.raphtory.api.output.sink.Sink Sink]], [[com.raphtory.api.querytracker.QueryProgressTracker QueryProgressTracker]]
   */
-trait Table {
+trait Table[T] {
 
   /** Add a filter operation to table
     * @param f function that runs once for each row (only rows for which `f ` returns `true` are kept)
     */
-  def filter(f: Row => Boolean): Table
+  def filter(f: T => Boolean): Table[T]
 
   /** Explode table rows
     *
@@ -27,7 +27,7 @@ trait Table {
     *
     * @param f function that runs once for each row of the table and maps it to new rows
     */
-  def explode(f: Row => IterableOnce[Row]): Table
+  def explode[Q](f: T => IterableOnce[Q]): Table[Q]
 
   /** Write out data and
     * return [[com.raphtory.api.querytracker.QueryProgressTracker QueryProgressTracker]]

--- a/core/src/main/scala/com/raphtory/api/output/sink/MessageSinkConnector.scala
+++ b/core/src/main/scala/com/raphtory/api/output/sink/MessageSinkConnector.scala
@@ -13,6 +13,8 @@ abstract class MessageSinkConnector extends SinkConnector {
     */
   protected def sendAsync(message: String): Unit
 
+  final override def allowsHeader: Boolean = false
+
   final override def write(value: String): Unit = stringBuilder.append(value)
 
   final override def closeItem(): Unit = {

--- a/core/src/main/scala/com/raphtory/api/output/sink/Sink.scala
+++ b/core/src/main/scala/com/raphtory/api/output/sink/Sink.scala
@@ -51,7 +51,7 @@ trait SinkExecutor {
     * handle synchronization.
     * @param row the row of data to write out
     */
-  protected def writeRow(row: Row): Unit
+  protected def writeRow(row: Any): Unit
 
   /** Closes the writing of the current graph perspective.
     * This method gets called every time all the rows from one graph perspective have been successfully written out so
@@ -66,5 +66,5 @@ trait SinkExecutor {
   def close(): Unit
 
   /** Thread safe version of `writeRow` used internally by Raphtory to write a `row`. */
-  final private[raphtory] def threadSafeWriteRow(row: Row): Unit = synchronized(writeRow(row))
+  final private[raphtory] def threadSafeWriteRow(row: Any): Unit = synchronized(writeRow(row))
 }

--- a/core/src/main/scala/com/raphtory/api/output/sink/SinkConnector.scala
+++ b/core/src/main/scala/com/raphtory/api/output/sink/SinkConnector.scala
@@ -19,6 +19,9 @@ package com.raphtory.api.output.sink
   */
 trait SinkConnector {
 
+  /** Returns true if the connector supports writing a header in the output */
+  def allowsHeader: Boolean
+
   /** Appends a `value` to the current item
     * @param value the value to append
     */
@@ -29,4 +32,13 @@ trait SinkConnector {
 
   /** Ensures that the output of this sink completed and frees up all the resources used by it. */
   def close(): Unit
+
+  /** Writes a header for the output if this connector support it as specified by `allowsHeader`
+    * @param header the header to be written at the beginning
+    */
+  final def writeHeader(header: String): Unit =
+    if (allowsHeader) {
+      write(header)
+      closeItem()
+    }
 }

--- a/core/src/main/scala/com/raphtory/formats/CsvFormat.scala
+++ b/core/src/main/scala/com/raphtory/formats/CsvFormat.scala
@@ -24,7 +24,7 @@ import com.typesafe.config.Config
   * 10,5,id3,24
   * }}}
   */
-case class CsvFormat(delimiter: String = ",") extends Format {
+case class CsvFormat(delimiter: String = ",", header: Boolean = false) extends Format {
   override def defaultDelimiter: String = "\n"
   override def defaultExtension: String = "csv"
 
@@ -35,24 +35,50 @@ case class CsvFormat(delimiter: String = ",") extends Format {
       config: Config
   ): SinkExecutor =
     new SinkExecutor {
-      var currentPerspective: Perspective = _
+      private var currentPerspective: Perspective = _
+      private var firstRow                        = true
 
       override def setupPerspective(perspective: Perspective): Unit =
         currentPerspective = perspective
 
-      override protected def writeRow(row: Row): Unit = {
-        val value = currentPerspective.window match {
-          case Some(w) =>
-            s"${currentPerspective.timestamp}$delimiter$w$delimiter${row.getValues().mkString(delimiter)}"
-          case None    =>
-            s"${currentPerspective.timestamp}$delimiter${row.getValues().mkString(delimiter)}"
+      override protected def writeRow(row: Any): Unit = {
+        if (header && firstRow) {
+          val userFields = row match {
+            case row: Row           => (1 to row.getValues().length).mkString(delimiter)
+            case row: Seq[Any]      => (1 to row.length).mkString(delimiter)
+            case row: Map[Any, Any] => row.keys.mkString(delimiter)
+            case row: Product       => row.productElementNames.mkString(delimiter)
+            case _                  => "value"
+          }
+          val header     = currentPerspective.window match {
+            case Some(window) => s"timestamp${delimiter}window$delimiter$userFields"
+            case None         => s"timestamp$delimiter$userFields"
+          }
+          connector.writeHeader(header)
+          firstRow = false
         }
-        connector.write(value)
+        val rowValues = getRowString(row) // TODO: check if the number of values per row are consistent
+        val line      = currentPerspective.window match {
+          case Some(window) =>
+            s"${currentPerspective.timestamp},$window,$rowValues"
+          case None         =>
+            s"${currentPerspective.timestamp},$rowValues" // TODO: add empty field in empty position here
+        }
+        connector.write(line)
         connector.closeItem()
       }
 
       override def closePerspective(): Unit = {}
 
       override def close(): Unit                                    = connector.close()
+
+      private def getRowString(row: Any): String =
+        row match {
+          case row: Row           => row.getValues().mkString(delimiter)
+          case row: Seq[Any]      => row.mkString(delimiter)
+          case row: Map[Any, Any] => row.values.mkString(delimiter)
+          case row: Product       => row.productIterator.mkString(delimiter)
+          case row                => row.toString
+        }
     }
 }

--- a/core/src/main/scala/com/raphtory/internals/graph/LensInterface.scala
+++ b/core/src/main/scala/com/raphtory/internals/graph/LensInterface.scala
@@ -16,17 +16,17 @@ private[raphtory] trait LensInterface {
   def getFullGraphSize: Int
   def setFullGraphSize(size: Int): Unit
 
-  def executeSelect(f: _ => Row)(onComplete: => Unit): Unit
+  def executeSelect(f: _ => Any)(onComplete: => Unit): Unit
 
   def executeSelect(
-      f: (_, GraphState) => Row,
+      f: (_, GraphState) => Any,
       graphState: GraphState
   )(onComplete: => Unit): Unit
-  def executeSelect(f: GraphState => Row, graphState: GraphState)(onComplete: => Unit): Unit
-  def explodeSelect(f: _ => IterableOnce[Row])(onComplete: => Unit): Unit
-  def filteredTable(f: Row => Boolean)(onComplete: => Unit): Unit
-  def explodeTable(f: Row => IterableOnce[Row])(onComplete: => Unit): Unit
-  def writeDataTable(f: Row => Unit)(onComplete: => Unit): Unit
+  def executeSelect(f: GraphState => Any, graphState: GraphState)(onComplete: => Unit): Unit
+  def explodeSelect(f: _ => IterableOnce[Any])(onComplete: => Unit): Unit
+  def filteredTable(f: Any => Boolean)(onComplete: => Unit): Unit
+  def explodeTable(f: Any => IterableOnce[Any])(onComplete: => Unit): Unit
+  def writeDataTable(f: Any => Unit)(onComplete: => Unit): Unit
 
   def explodeView(
       interlayerEdgeBuilder: Option[Vertex => Seq[InterlayerEdge]]

--- a/core/src/main/scala/com/raphtory/sinks/FileSink.scala
+++ b/core/src/main/scala/com/raphtory/sinks/FileSink.scala
@@ -50,6 +50,7 @@ case class FileSink(filePath: String, format: Format = CsvFormat()) extends Form
       private val file          = s"$workDirectory/partition-$partitionID.$fileExtension"
       private val fileWriter    = new FileWriter(file)
 
+      override def allowsHeader: Boolean      = true
       override def write(value: String): Unit = fileWriter.write(value)
       override def closeItem(): Unit          = fileWriter.write(itemDelimiter)
       override def close(): Unit              = fileWriter.close()

--- a/core/src/main/scala/com/raphtory/sinks/PrintSink.scala
+++ b/core/src/main/scala/com/raphtory/sinks/PrintSink.scala
@@ -42,6 +42,7 @@ case class PrintSink(format: Format = CsvFormat()) extends FormatAgnosticSink(fo
       fileExtension: String
   ): SinkConnector =
     new SinkConnector {
+      override def allowsHeader: Boolean      = true
       override def write(value: String): Unit = System.out.print(value)
       override def closeItem(): Unit          = System.out.print(itemDelimiter)
       override def close(): Unit = {}

--- a/core/src/test/scala/com/raphtory/BaseCorrectnessTest.scala
+++ b/core/src/test/scala/com/raphtory/BaseCorrectnessTest.scala
@@ -14,7 +14,7 @@ import com.raphtory.spouts.SequenceSpout
 import scala.collection.mutable
 
 case class TestQuery(
-    algorithm: GenericallyApplicable,
+    algorithm: GenericallyApplicable[_],
     timestamp: Long,
     windows: List[Long] = List.empty[Long]
 )

--- a/core/src/test/scala/com/raphtory/BaseRaphtoryAlgoTest.scala
+++ b/core/src/test/scala/com/raphtory/BaseRaphtoryAlgoTest.scala
@@ -83,7 +83,7 @@ abstract class BaseRaphtoryAlgoTest[T: ClassTag: TypeTag](deleteResultAfterFinis
     consumer.receive
 
   private def algorithmTestInternal(
-      algorithm: GenericallyApplicable,
+      algorithm: GenericallyApplicable[_],
       start: Long,
       end: Long,
       increment: Long,
@@ -105,7 +105,7 @@ abstract class BaseRaphtoryAlgoTest[T: ClassTag: TypeTag](deleteResultAfterFinis
     }
 
   def algorithmTest(
-      algorithm: GenericallyApplicable,
+      algorithm: GenericallyApplicable[_],
       start: Long,
       end: Long,
       increment: Long,
@@ -116,7 +116,7 @@ abstract class BaseRaphtoryAlgoTest[T: ClassTag: TypeTag](deleteResultAfterFinis
     algorithmTestInternal(algorithm, start, end, increment, windows, sink)(graph)
 
   def algorithmPointTest(
-      algorithm: GenericallyApplicable,
+      algorithm: GenericallyApplicable[_],
       timestamp: Long,
       windows: List[Long] = List[Long](),
       sink: Sink = defaultSink,

--- a/core/src/test/scala/com/raphtory/GlobalState.scala
+++ b/core/src/test/scala/com/raphtory/GlobalState.scala
@@ -14,7 +14,7 @@ import com.raphtory.api.analysis.visitor.Vertex
   *  TODO add in tests for accumulators of different types - test default values and not refreshing the value on a new superstep
   */
 
-class GlobalState extends Generic {
+class GlobalState extends Generic[Row] {
 
   override def apply(graph: GraphPerspective): graph.Graph =
     graph
@@ -38,7 +38,7 @@ class GlobalState extends Generic {
           graphState("name length multiplier") += totalNameLength.toLong
       }
 
-  override def tabularise(graph: GraphPerspective): Table =
+  override def tabularise(graph: GraphPerspective): Table[Row] =
     graph.globalSelect(graphState =>
       Row(
               graphState("name length max").value,

--- a/core/src/test/scala/com/raphtory/GraphState.scala
+++ b/core/src/test/scala/com/raphtory/GraphState.scala
@@ -5,9 +5,9 @@ import com.raphtory.api.analysis.graphview.GraphPerspective
 import com.raphtory.api.analysis.table.Row
 import com.raphtory.api.analysis.table.Table
 
-class GraphState() extends Generic {
+class GraphState() extends Generic[GraphState.VertexState] {
 
-  override def tabularise(graph: GraphPerspective): Table =
+  override def tabularise(graph: GraphPerspective): Table[GraphState.VertexState] =
     graph.select { vertex =>
       val inDeg            = vertex.inDegree
       val outDeg           = vertex.outDegree
@@ -33,7 +33,7 @@ class GraphState() extends Generic {
         .map(edge => edge.getPropertySet().toArray.map(x => edge.getPropertyHistory(x).size).sum)
         .sum
 
-      Row(
+      GraphState.VertexState(
               vertex.ID,
               inDeg,
               outDeg,
@@ -55,5 +55,25 @@ class GraphState() extends Generic {
 }
 
 object GraphState {
+
+  case class VertexState(
+      id: Any,
+      inDeg: Int,
+      outDeg: Int,
+      degSum: Int,
+      vertexDeletions: Long,
+      vertexCreations: Long,
+      outEdgeDeletions: Long,
+      outEdgeCreations: Long,
+      inEdgeDeletions: Long,
+      inEdgeCreations: Long,
+      properties: Int,
+      propertyHistory: Int,
+      outEdgeProperties: Int,
+      outEdgePropertyHistory: Int,
+      inEdgeProperties: Int,
+      inEdgePropertyHistory: Int
+  )
+
   def apply() = new GraphState()
 }

--- a/core/src/test/scala/com/raphtory/TimeSeriesGraphState.scala
+++ b/core/src/test/scala/com/raphtory/TimeSeriesGraphState.scala
@@ -5,9 +5,9 @@ import com.raphtory.api.analysis.graphview.GraphPerspective
 import com.raphtory.api.analysis.table.Row
 import com.raphtory.api.analysis.table.Table
 
-class TimeSeriesGraphState() extends Generic {
+class TimeSeriesGraphState() extends Generic[Row] {
 
-  override def tabularise(graph: GraphPerspective): Table =
+  override def tabularise(graph: GraphPerspective): Table[Row] =
     graph.select { vertex =>
       val propertyhistory =
         vertex.getPropertySet().toArray.map(x => vertex.getTimeSeriesPropertyHistory(x).size).sum

--- a/core/src/test/scala/com/raphtory/algorithms/MultilayerViewTest.scala
+++ b/core/src/test/scala/com/raphtory/algorithms/MultilayerViewTest.scala
@@ -14,7 +14,7 @@ import com.raphtory.api.analysis.visitor.PropertyMergeStrategy
 import com.raphtory.api.input.Spout
 import com.raphtory.spouts.SequenceSpout
 
-class WriteValue extends GenericReduction {
+class WriteValue extends GenericReduction[Any] {
 
   override def apply(graph: GraphPerspective): graph.ReducedGraph =
     graph.multilayerView

--- a/core/src/test/scala/com/raphtory/api/FailureTest.scala
+++ b/core/src/test/scala/com/raphtory/api/FailureTest.scala
@@ -9,10 +9,11 @@ import com.raphtory.sinks.FileSink
 import com.raphtory.spouts.SequenceSpout
 import com.raphtory.BasicGraphBuilder
 import com.raphtory.Raphtory
+import com.raphtory.api.analysis.table.Row
 import com.raphtory.internals.communication.EndPoint
 import munit.CatsEffectSuite
 
-class FailingAlgo extends Generic {
+class FailingAlgo extends Generic[Row] {
 
   override def apply(graph: GraphPerspective): graph.Graph =
     graph.step(_ => throw new Exception("Algorithm failed"))

--- a/core/src/test/scala/com/raphtory/api/analysis/graphstate/AccumulatorTest.scala
+++ b/core/src/test/scala/com/raphtory/api/analysis/graphstate/AccumulatorTest.scala
@@ -15,7 +15,7 @@ import com.raphtory.api.analysis.visitor.Vertex
 import com.raphtory.api.input.Spout
 import com.raphtory.spouts.ResourceSpout
 
-object CountNodes extends Generic {
+object CountNodes extends Generic[Row] {
 
   override def apply(graph: GraphPerspective): graph.Graph =
     graph
@@ -26,13 +26,13 @@ object CountNodes extends Generic {
         globalState("nodeCount") += 1
       }
 
-  override def tabularise(graph: GraphPerspective): Table =
+  override def tabularise(graph: GraphPerspective): Table[Row] =
     graph
       .globalSelect(graphState => Row(graphState("nodeCount").value))
 
 }
 
-object CountNodesTwice extends Generic {
+object CountNodesTwice extends Generic[Row] {
 
   override def apply(graph: GraphPerspective): graph.Graph =
     graph
@@ -49,19 +49,19 @@ object CountNodesTwice extends Generic {
         globalState("nodeCountDoubled") += 1
       }
 
-  override def tabularise(graph: GraphPerspective): Table =
+  override def tabularise(graph: GraphPerspective): Table[Row] =
     graph
       .globalSelect { graphState: GraphState =>
         Row(graphState("nodeCount").value, graphState("nodeCountDoubled").value)
       }
 }
 
-object CheckNodeCount extends Generic {
+object CheckNodeCount extends Generic[Row] {
 
   override def apply(graph: GraphPerspective): graph.Graph =
     CountNodes(graph)
 
-  override def tabularise(graph: GraphPerspective): Table =
+  override def tabularise(graph: GraphPerspective): Table[Row] =
     graph.globalSelect { graphState =>
       val n: Int = graphState("nodeCount").value
       Row(graphState.nodeCount == n)

--- a/core/src/test/scala/com/raphtory/api/analysis/graphview/HistoryTest.scala
+++ b/core/src/test/scala/com/raphtory/api/analysis/graphview/HistoryTest.scala
@@ -15,12 +15,12 @@ import com.raphtory.TestQuery
 
 import scala.util.Random
 
-class WindowedOutEdgeHistory(after: Long, before: Long) extends GenericReduction {
+class WindowedOutEdgeHistory(after: Long, before: Long) extends GenericReduction[Row] {
 
   override def apply(graph: GraphPerspective): graph.ReducedGraph =
     NeighbourNames(graph.reducedView)
 
-  override def tabularise(graph: ReducedGraphPerspective): Table =
+  override def tabularise(graph: ReducedGraphPerspective): Table[Row] =
     graph.explodeSelect { vertex =>
       vertex
         .getOutEdges(after, before)
@@ -34,12 +34,12 @@ class WindowedOutEdgeHistory(after: Long, before: Long) extends GenericReduction
     }
 }
 
-class WindowedInEdgeHistory(after: Long, before: Long) extends GenericReduction {
+class WindowedInEdgeHistory(after: Long, before: Long) extends GenericReduction[Row] {
 
   override def apply(graph: GraphPerspective): graph.ReducedGraph =
     NeighbourNames(graph.reducedView)
 
-  override def tabularise(graph: ReducedGraphPerspective): Table =
+  override def tabularise(graph: ReducedGraphPerspective): Table[Row] =
     graph.explodeSelect { vertex =>
       vertex
         .getInEdges(after, before)

--- a/core/src/test/scala/com/raphtory/api/analysis/graphview/RaphtoryGraphTest.scala
+++ b/core/src/test/scala/com/raphtory/api/analysis/graphview/RaphtoryGraphTest.scala
@@ -33,7 +33,7 @@ class RaphtoryGraphTest extends FunSuite {
       .transform(ConnectedComponents())
       .select(vertex => Row(vertex.getState("new")))
       .filter(_.getInt(0) == 1)
-    val query = table.asInstanceOf[TableImplementation].query
+    val query = table.asInstanceOf[TableImplementation[_]].query
 
     assertEquals(query.timelineStart, 100L)
     assertEquals(query.timelineEnd, 499L)

--- a/core/src/test/scala/com/raphtory/api/analysis/graphview/TestIteration.scala
+++ b/core/src/test/scala/com/raphtory/api/analysis/graphview/TestIteration.scala
@@ -7,7 +7,7 @@ import com.raphtory.api.analysis.table.Row
 import com.raphtory.api.analysis.table.Table
 import com.raphtory.api.analysis.visitor.Vertex
 
-class CountIterations(num_iters_before_vote: Int, num_iters: Int) extends Generic {
+class CountIterations(num_iters_before_vote: Int, num_iters: Int) extends Generic[Row] {
 
   override def apply(graph: GraphPerspective): graph.Graph =
     graph
@@ -28,7 +28,7 @@ class CountIterations(num_iters_before_vote: Int, num_iters: Int) extends Generi
         graphState("maxIterations") += vertex.getState("iterations")
       }
 
-  override def tabularise(graph: GraphPerspective): Table =
+  override def tabularise(graph: GraphPerspective): Table[Row] =
     graph.globalSelect(graphState => Row(graphState("maxIterations").value))
 }
 

--- a/core/src/test/scala/com/raphtory/formats/CsvFormatTest.scala
+++ b/core/src/test/scala/com/raphtory/formats/CsvFormatTest.scala
@@ -1,0 +1,39 @@
+package com.raphtory.formats
+
+class CsvFormatTest extends FormatTest {
+
+  private val rowOutput =
+    """100,id1,34
+      |100,id2,24
+      |200,200,id1,56
+      |200,200,id2,67
+      |""".stripMargin
+
+  private val rowOutputWithHeader =
+    """timestamp,1,2
+      |100,id1,34
+      |100,id2,24
+      |200,200,id1,56
+      |200,200,id2,67
+      |""".stripMargin
+
+  private val caseClassOutputWithHeader =
+    """timestamp,name,age
+      |100,John,25
+      |""".stripMargin
+
+  test("CsvFormat output for row table matches data") {
+    val output = formatTable(CsvFormat(), rowTable, jobID, partitionID)
+    assertEquals(output, rowOutput)
+  }
+
+  test("CsvFormat output for row table prints correct header") {
+    val output = formatTable(CsvFormat(header = true), rowTable, jobID, partitionID)
+    assertEquals(output, rowOutputWithHeader)
+  }
+
+  test("CsvFormat output for case class table matches data") {
+    val output = formatTable(CsvFormat(header = true), caseClassTable, jobID, partitionID)
+    assertEquals(output, caseClassOutputWithHeader)
+  }
+}

--- a/core/src/test/scala/com/raphtory/formats/FormatTest.scala
+++ b/core/src/test/scala/com/raphtory/formats/FormatTest.scala
@@ -1,0 +1,44 @@
+package com.raphtory.formats
+
+import com.raphtory.Raphtory
+import com.raphtory.api.analysis.table.Row
+import com.raphtory.api.output.format.Format
+import com.raphtory.api.time.DiscreteInterval
+import com.raphtory.internals.graph.Perspective
+import munit.FunSuite
+
+class FormatTest extends FunSuite {
+  protected val jobID       = "job-id"
+  protected val partitionID = 13
+
+  protected val rowTable = List(
+          (Perspective(100, None, 0, 100), List(Row("id1", 34), Row("id2", 24))),
+          (
+                  Perspective(200, Some(DiscreteInterval(200)), 0, 200),
+                  List(Row("id1", 56), Row("id2", 67))
+          )
+  )
+
+  case class Person(name: String, age: Int)
+  protected val caseClassTable = List((Perspective(100, None, 0, 100), List(Person("John", 25))))
+
+  protected def formatTable(
+      format: Format,
+      table: List[(Perspective, List[Any])],
+      jobID: String,
+      partitionID: Int
+  ): String = {
+    val sink     = StringSink(format = format)
+    val executor = sink.executor(jobID, partitionID, Raphtory.getDefaultConfig())
+
+    table foreach {
+      case (perspective, rows) =>
+        executor.setupPerspective(perspective)
+        rows foreach (row => executor.threadSafeWriteRow(row))
+        executor.closePerspective()
+    }
+    executor.close()
+
+    sink.output
+  }
+}

--- a/core/src/test/scala/com/raphtory/formats/StringSink.scala
+++ b/core/src/test/scala/com/raphtory/formats/StringSink.scala
@@ -20,6 +20,7 @@ case class StringSink(format: Format) extends FormatAgnosticSink(format) {
       fileExtension: String
   ): SinkConnector =
     new SinkConnector {
+      override def allowsHeader: Boolean      = true
       override def write(value: String): Unit = stringWriter.write(value)
       override def closeItem(): Unit          = stringWriter.write(itemDelimiter)
       override def close(): Unit = {}

--- a/core/src/test/scala/com/raphtory/generic/OrderingTest.scala
+++ b/core/src/test/scala/com/raphtory/generic/OrderingTest.scala
@@ -21,7 +21,7 @@ import scala.util.Random
 import scala.math.Ordering.Implicits._
 import scala.reflect.ClassTag
 
-class CheckHistory extends Generic {
+class CheckHistory extends Generic[Row] {
 
   override def apply(graph: GraphPerspective): graph.Graph =
     graph
@@ -40,7 +40,7 @@ class CheckHistory extends Generic {
         graphState("vertexHistoryOrdered") += sorted
       }
 
-  override def tabularise(graph: GraphPerspective): Table =
+  override def tabularise(graph: GraphPerspective): Table[Row] =
     graph.globalSelect(graphState =>
       Row(graphState("vertexHistoryOrdered").value, graphState("edgeHistoryOrdered").value)
     )

--- a/examples/ethereum/src/main/scala/com/raphtory/ethereum/analysis/TaintTracking.scala
+++ b/examples/ethereum/src/main/scala/com/raphtory/ethereum/analysis/TaintTracking.scala
@@ -7,7 +7,7 @@ import com.raphtory.api.analysis.graphview.ReducedGraphPerspective
 import com.raphtory.api.analysis.table.Row
 import com.raphtory.api.analysis.table.Table
 
-class Taint(startTime: Long, infectedNodes: Set[String], stopNodes: Set[String] = Set()) extends GenericReduction {
+class Taint(startTime: Long, infectedNodes: Set[String], stopNodes: Set[String] = Set()) extends GenericReduction[Row] {
 
   override def apply(graph: GraphPerspective): graph.ReducedGraph =
     graph.reducedView
@@ -138,7 +138,7 @@ class Taint(startTime: Long, infectedNodes: Set[String], stopNodes: Set[String] 
               true
       )
 
-  override def tabularise(graph: ReducedGraphPerspective): Table =
+  override def tabularise(graph: ReducedGraphPerspective): Table[Row] =
     graph
       .select(vertex =>
         Row(

--- a/examples/lotr/src/main/scala/com/raphtory/examples/lotr/analysis/DegreesSeparation.scala
+++ b/examples/lotr/src/main/scala/com/raphtory/examples/lotr/analysis/DegreesSeparation.scala
@@ -5,7 +5,7 @@ import com.raphtory.api.analysis.graphview.GraphPerspective
 import com.raphtory.api.analysis.table.Row
 import com.raphtory.api.analysis.table.Table
 
-class DegreesSeparation(name: String = "Gandalf") extends Generic {
+class DegreesSeparation(name: String = "Gandalf") extends Generic[Row] {
 
   final val SEPARATION = "SEPARATION"
 
@@ -32,11 +32,9 @@ class DegreesSeparation(name: String = "Gandalf") extends Generic {
               executeMessagedOnly = true
       )
 
-  override def tabularise(graph: GraphPerspective): Table =
+  override def tabularise(graph: GraphPerspective): Table[Row] =
     graph
-      .select(vertex =>
-        Row(vertex.getPropertyOrElse("name", "unknown"), vertex.getStateOrElse[Int](SEPARATION, -1))
-      )
+      .select(vertex => Row(vertex.getPropertyOrElse("name", "unknown"), vertex.getStateOrElse[Int](SEPARATION, -1)))
   //.filter(row=> row.getInt(1) > -1)
 }
 

--- a/examples/twitter/src/main/scala/com/raphtory/examples/twitter/higgsdataset/analysis/MemberRank.scala
+++ b/examples/twitter/src/main/scala/com/raphtory/examples/twitter/higgsdataset/analysis/MemberRank.scala
@@ -14,7 +14,7 @@ import com.raphtory.api.analysis.visitor.Edge
   * the effects of bots further.
   */
 
-class MemberRank() extends Generic {
+class MemberRank() extends Generic[Row] {
 
   case class Score(negativeScore: Double = 0.0, positiveScore: Double = 0.0) {
 
@@ -93,7 +93,7 @@ class MemberRank() extends Generic {
     *   5) New Negative Score
     *   6) New Positive Score
     */
-  override def tabularise(graph: GraphPerspective): Table =
+  override def tabularise(graph: GraphPerspective): Table[Row] =
     graph.select { vertex =>
       Row(
               vertex.getPropertyOrElse("name", vertex.ID),

--- a/examples/twitter/src/main/scala/com/raphtory/examples/twitter/higgsdataset/analysis/TemporalMemberRank.scala
+++ b/examples/twitter/src/main/scala/com/raphtory/examples/twitter/higgsdataset/analysis/TemporalMemberRank.scala
@@ -11,7 +11,7 @@ import com.raphtory.api.analysis.table.Table
   * This algorithm takes vertices with big differences in their raw scores and MemberRank scores
   * and checks the in edge creations over time.
   */
-class TemporalMemberRank() extends GenericReduction {
+class TemporalMemberRank() extends GenericReduction[Row] {
 
   case class NeighbourAndTime[T](id: T, time: Long)
 
@@ -46,7 +46,7 @@ class TemporalMemberRank() extends GenericReduction {
       vertex.setState("times", times)
     }
 
-  override def tabularise(graph: ReducedGraphPerspective): Table =
+  override def tabularise(graph: ReducedGraphPerspective): Table[Row] =
     graph
       .select { vertex =>
         Row(


### PR DESCRIPTION
- [x] Add support for headers to sink connector
- [x] Redesign `Table` to support generic types
- [x] Add header to CsvFormat for different types: `Row`, `Map`, `Product` (case classes)
- [x] Allow algorithms to benefit from generic types
- [ ] Add runtime checks to CsvFormat (?)
- [ ] Change `Table` to something else, like Collection, Stream, DataSet, DataStream, and Make Table an alias for Collection[Row] (?)
- [ ] Update docs

This PR needs to introduce a lot of changes in the Algorithm API. It would fit better if algorithms were defined just as functions instead of with overriding. We need probably to have a thought on this when redesigning the API.