### PR TITLE
Feature/dev 1174 pip installer

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -55,3 +55,37 @@ java -cp core/target/scala-2.13/*.jar com.raphtory.python.PyRaphtory \
   --py python/pyraphtory/sample.py \
   --connect="raphtory.pulsar.admin.address=http://localhost:8080,raphtory.pulsar.broker.address=pulsar://127.0.0.1:6650,raphtory.zookeeper.address=127.0.0.1:2181"
 ```
+
+## publishing to pypi with poetry 
+
+We must manually comment out (#) the `# include = ["lib/core-*.jar"]` line in the pyproject.toml 
+before  pushing to pypi, otherwise it rejects due to the jar being too large
+
+### Prod 
+
+#### First config poetry
+
+    poetry config repositories.pypi https://pypi.org/
+
+##### with dry run
+    poetry publish -r pypi -u USERNAME -p PASSWORD --dry-run
+
+##### without dry run
+note you must change version name upon each push
+
+    poetry publish -r pypi -u USERNAME -p PASSWORD
+
+### Legacy test env 
+
+#### First config poetry 
+
+    poetry config repositories.testpypi https://test.pypi.org/legacy/
+
+##### with dry run 
+    poetry publish -r testpypi -u USERNAME -p PASSWORD --dry-run
+
+##### without dry run 
+note you must change version name upon each push
+
+    poetry publish -r testpypi -u USERNAME -p PASSWORD
+

--- a/python/README.md
+++ b/python/README.md
@@ -2,90 +2,93 @@
 
 Pyraphtory is the new version of the Raphtory python API. It is in experimental stage, so everything might change.
 
-## Running the PyRaphtory sample locally
-
 At the core of this iteration is the `com.raphtory.python.PyRaphtory` class that is able to start a Raphtory instance
-with python support or connect to an existing Raphtory Cluster (more on that later)
+with python support or connect to an existing Raphtory Cluster.
 
-### Prelude
+## Installation
 
-1. get the Raphtory source code say in `git clone https://github.com/Raphtory/Raphtory.git $HOME/Source/Raphtory`
-2. install `make` and `python3`
+There are two ways to install PyRaphtory.
 
-### Setup a python virtual environment with dependencies
+1. Conda - Using the autoinstaller (This will install java, scala, sbt, raphtory and pyraphtory)
 
-1. The pemja library we use looks for JAVA_HOME environment variable so make sure that points to a JDK location
-1. Create an python virtual environment called (anything you want) `raphtory` and activete it
-1. Install [poetry](https://python-poetry.org/)
-1. Run the commands below
+2. Source - Will build everything from scratch.
 
-```bash
-make sbt-build
-```
+### Conda
 
-```bash
-#go to raphtory source root (eg. cd $HOME/Source/Raphtory)
-cd <where you have checked out Raphtory>
-make python-build
-```
+TBD
+
+### From Source
+
+#### Requirements
+
+- Temurin Java 11 - 11.0.16-tem
+    - Please ensure `JAVA_HOME` environment variable is set and points to a JDK location
+- scala 2.13
+- sbt 1.5.5
+- python 3.10
+- make
+- [poetry](https://python-poetry.org/)
+- [Apache Pulsar](https://pulsar.apache.org/)
+
+#### Installation guide
+
+1. Clone Raphtory `git clone https://github.com/Raphtory/Raphtory.git` and `cd` into the root
+2. Build Raphtory via `make sbt-build`
+3. Build and install pyraphtory via `make python-build`
+
+####  Running PyRaphtory
+
+1. Start pulsar via `pulsar standalone`
+2. (in a different shell) run pyraphtory examples 
+3. TBD once examples are complete
 
 
-### Run the PyRaphtory class
+# Developer notes
 
-1. start pulsar and proxy `make local-pulsar`
-2. (in a different shell) run pyraphtory
+## Publishing to pypi with poetry
 
-```bash
-curl -o /tmp/lotr.csv https://raw.githubusercontent.com/Raphtory/Data/main/lotr.csv
-# using make
-make INPUT=/tmp/lotr.csv PYFILE=python/pyraphtory/sample.py BUILDER=LotrGraphBuilder pyraphtory-local
-# or directly in bash
-java -cp core/target/scala-2.13/*.jar com.raphtory.python.PyRaphtory --file=$(INPUT) --py=$(PYFILE) --builder=$(BUILDER) --mode=$(MODE)
-```
+We must manually comment out (#) the `# include = ["lib/core-*.jar"]` line in the pyproject.toml
+before  pushing to pypi, otherwise pypi will reject the library due to the jar being too large.
 
-## Connect to a running cluster (advanced)
+Note: You must change version name upon each push, to overwrites the previous version
 
-1. Follow the `Prelude` and `Setup a python virtual environment with dependencies` from the `Running the PyRaphtory sample locally` guide.
-2. Open the Makefile and inspect the `run-local-cluster` step, ensure the data is available for the spout and the python file is available for the builder
-3. Open the `bin/docker/raphtory/docker-compose.yml` file and edit `RAPHTORY_SPOUT_FILE`, `PYRAPHTORY_GB_FILE`, `PYRAPHTORY_GB_CLASS` environment variables
-4. run
-
-```bash
-java -cp core/target/scala-2.13/*.jar com.raphtory.python.PyRaphtory \
-  --py python/pyraphtory/sample.py \
-  --connect="raphtory.pulsar.admin.address=http://localhost:8080,raphtory.pulsar.broker.address=pulsar://127.0.0.1:6650,raphtory.zookeeper.address=127.0.0.1:2181"
-```
-
-## publishing to pypi with poetry 
-
-We must manually comment out (#) the `# include = ["lib/core-*.jar"]` line in the pyproject.toml 
-before  pushing to pypi, otherwise it rejects due to the jar being too large
-
-### Prod 
+### PyPi Production environment
 
 #### First config poetry
 
     poetry config repositories.pypi https://pypi.org/
 
-##### with dry run
+##### With dry run
+
+`--dry-run` will not publish the package, it will just build the package locally
+
     poetry publish -r pypi -u USERNAME -p PASSWORD --dry-run
 
-##### without dry run
-note you must change version name upon each push
+##### Without dry run
 
     poetry publish -r pypi -u USERNAME -p PASSWORD
 
-### Legacy test env 
+### PyPi Test Environment
 
-#### First config poetry 
+#### First config poetry
 
     poetry config repositories.testpypi https://test.pypi.org/legacy/
 
-##### with dry run 
+##### With dry run
+
+`--dry-run` will not publish the package, it will just build the package locally
+
     poetry publish -r testpypi -u USERNAME -p PASSWORD --dry-run
 
-##### without dry run 
-note you must change version name upon each push
+##### Without dry run
 
     poetry publish -r testpypi -u USERNAME -p PASSWORD
 
+## Links
+
+- PyPi https://pypi.org/project/pyraphtory/
+- Github https://github.com/Raphtory/Raphtory/
+- Website https://raphtory.github.io/
+- Slack https://raphtory.slack.com
+- Documentation https://raphtory.readthedocs.io/
+- Bug reports/Feature request https://github.com/raphtory/raphtory/issues

--- a/python/pyraphtory/README.md
+++ b/python/pyraphtory/README.md
@@ -2,52 +2,93 @@
 
 Pyraphtory is the new version of the Raphtory python API. It is in experimental stage, so everything might change.
 
-## Running the PyRaphtory sample locally
-
 At the core of this iteration is the `com.raphtory.python.PyRaphtory` class that is able to start a Raphtory instance
-with python support or connect to an existing Raphtory Cluster (more on that later)
+with python support or connect to an existing Raphtory Cluster.
 
-## Install
+## Installation
 
-Please install via conda. Please see the [Raphtory](https://github.com/raphtory/raphtory) Github for more information.
+There are two ways to install PyRaphtory.
+
+1. Conda - Using the autoinstaller (This will install java, scala, sbt, raphtory and pyraphtory)
+
+2. Source - Will build everything from scratch.
+
+### Conda
+
+TBD
+
+### From Source
+
+#### Requirements
+
+- Temurin Java 11 - 11.0.16-tem
+    - Please ensure `JAVA_HOME` environment variable is set and points to a JDK location
+- scala 2.13
+- sbt 1.5.5
+- python 3.10
+- make
+- [poetry](https://python-poetry.org/)
+- [Apache Pulsar](https://pulsar.apache.org/)
+
+#### Installation guide
+
+1. Clone Raphtory `git clone https://github.com/Raphtory/Raphtory.git` and `cd` into the root
+2. Build Raphtory via `make sbt-build`
+3. Build and install pyraphtory via `make python-build`
+
+####  Running PyRaphtory
+
+1. Start pulsar via `pulsar standalone`
+2. (in a different shell) run pyraphtory examples
+3. TBD once examples are complete
 
 
-### Run the PyRaphtory class
+# Developer notes
 
-1. start pulsar and proxy `make local-pulsar`
-2. (in a different shell) run pyraphtory
+## Publishing to pypi with poetry
 
-```bash
-curl -o /tmp/lotr.csv https://raw.githubusercontent.com/Raphtory/Data/main/lotr.csv
-# using make
-make INPUT=/tmp/lotr.csv PYFILE=python/pyraphtory/sample.py BUILDER=LotrGraphBuilder pyraphtory-local
-# or directly in bash
-java -cp core/target/scala-2.13/*.jar com.raphtory.python.PyRaphtory --file=$(INPUT) --py=$(PYFILE) --builder=$(BUILDER) --mode=$(MODE)
-```
+We must manually comment out (#) the `# include = ["lib/core-*.jar"]` line in the pyproject.toml
+before  pushing to pypi, otherwise pypi will reject the library due to the jar being too large.
 
-## Connect to a running cluster (advanced)
+Note: You must change version name upon each push, to overwrites the previous version
 
-1. Follow the `Prelude` and `Setup a python virtual environment with dependencies` from the `Running the PyRaphtory sample locally` guide.
-2. Open the Makefile and inspect the `run-local-cluster` step, ensure the data is available for the spout and the python file is available for the builder
-3. Open the `bin/docker/raphtory/docker-compose.yml` file and edit `RAPHTORY_SPOUT_FILE`, `PYRAPHTORY_GB_FILE`, `PYRAPHTORY_GB_CLASS` environment variables
-4. run
+### PyPi Production environment
 
-```bash
-java -cp core/target/scala-2.13/*.jar com.raphtory.python.PyRaphtory \
-  --py python/pyraphtory/sample.py \
-  --connect="raphtory.pulsar.admin.address=http://localhost:8080,raphtory.pulsar.broker.address=pulsar://127.0.0.1:6650,raphtory.zookeeper.address=127.0.0.1:2181"
-```
+#### First config poetry
+
+    poetry config repositories.pypi https://pypi.org/
+
+##### With dry run
+
+`--dry-run` will not publish the package, it will just build the package locally
+
+    poetry publish -r pypi -u USERNAME -p PASSWORD --dry-run
+
+##### Without dry run
+
+    poetry publish -r pypi -u USERNAME -p PASSWORD
+
+### PyPi Test Environment
+
+#### First config poetry
+
+    poetry config repositories.testpypi https://test.pypi.org/legacy/
+
+##### With dry run
+
+`--dry-run` will not publish the package, it will just build the package locally
+
+    poetry publish -r testpypi -u USERNAME -p PASSWORD --dry-run
+
+##### Without dry run
+
+    poetry publish -r testpypi -u USERNAME -p PASSWORD
 
 ## Links
 
-PyPi https://pypi.org/project/pyraphtory/
-
-Github https://github.com/Raphtory/Raphtory/
-
-Website https://raphtory.github.io/
-
-Slack https://raphtory.slack.com
-
-Documentation https://raphtory.readthedocs.io/
-
-Bug reports/Feature request https://github.com/raphtory/raphtory/issues
+- PyPi https://pypi.org/project/pyraphtory/
+- Github https://github.com/Raphtory/Raphtory/
+- Website https://raphtory.github.io/
+- Slack https://raphtory.slack.com
+- Documentation https://raphtory.readthedocs.io/
+- Bug reports/Feature request https://github.com/raphtory/raphtory/issues

--- a/python/pyraphtory/README.md
+++ b/python/pyraphtory/README.md
@@ -1,0 +1,53 @@
+# Getting started with `pyraphtory`
+
+Pyraphtory is the new version of the Raphtory python API. It is in experimental stage, so everything might change.
+
+## Running the PyRaphtory sample locally
+
+At the core of this iteration is the `com.raphtory.python.PyRaphtory` class that is able to start a Raphtory instance
+with python support or connect to an existing Raphtory Cluster (more on that later)
+
+## Install
+
+Please install via conda. Please see the [Raphtory](https://github.com/raphtory/raphtory) Github for more information.
+
+
+### Run the PyRaphtory class
+
+1. start pulsar and proxy `make local-pulsar`
+2. (in a different shell) run pyraphtory
+
+```bash
+curl -o /tmp/lotr.csv https://raw.githubusercontent.com/Raphtory/Data/main/lotr.csv
+# using make
+make INPUT=/tmp/lotr.csv PYFILE=python/pyraphtory/sample.py BUILDER=LotrGraphBuilder pyraphtory-local
+# or directly in bash
+java -cp core/target/scala-2.13/*.jar com.raphtory.python.PyRaphtory --file=$(INPUT) --py=$(PYFILE) --builder=$(BUILDER) --mode=$(MODE)
+```
+
+## Connect to a running cluster (advanced)
+
+1. Follow the `Prelude` and `Setup a python virtual environment with dependencies` from the `Running the PyRaphtory sample locally` guide.
+2. Open the Makefile and inspect the `run-local-cluster` step, ensure the data is available for the spout and the python file is available for the builder
+3. Open the `bin/docker/raphtory/docker-compose.yml` file and edit `RAPHTORY_SPOUT_FILE`, `PYRAPHTORY_GB_FILE`, `PYRAPHTORY_GB_CLASS` environment variables
+4. run
+
+```bash
+java -cp core/target/scala-2.13/*.jar com.raphtory.python.PyRaphtory \
+  --py python/pyraphtory/sample.py \
+  --connect="raphtory.pulsar.admin.address=http://localhost:8080,raphtory.pulsar.broker.address=pulsar://127.0.0.1:6650,raphtory.zookeeper.address=127.0.0.1:2181"
+```
+
+## Links
+
+PyPi https://pypi.org/project/pyraphtory/
+
+Github https://github.com/Raphtory/Raphtory/
+
+Website https://raphtory.github.io/
+
+Slack https://raphtory.slack.com
+
+Documentation https://raphtory.readthedocs.io/
+
+Bug reports/Feature request https://github.com/raphtory/raphtory/issues

--- a/python/pyraphtory/pyproject.toml
+++ b/python/pyraphtory/pyproject.toml
@@ -12,7 +12,7 @@ maintainers = [
     "Pometry <admin@pometry.com>"
 ]
 license = "Apache-2.0"
-# include = ["lib/core-*.jar"]
+include = ["lib/core-*.jar"]
 readme = "README.md"
 homepage = "https://raphtory.com/"
 repository = "https://github.com/rahptory/raphtory"

--- a/python/pyraphtory/pyproject.toml
+++ b/python/pyraphtory/pyproject.toml
@@ -1,15 +1,34 @@
 [tool.poetry]
 name = "pyraphtory"
-version = "0.1.0"
-description = ""
-authors = ["Fabian Murariu <murariu.fabian@gmail.com>"]
-
-include = ["lib/core-*.jar"]
+version = "0.0.1"
+description = "Raphtory - Temporal Graph Analytics Platform. This is the Python version of the library."
+authors = [
+    "Fabian Murariu <admin@pometry.com>",
+    "Lucas Jeub <admin@pometry.com>",
+    "Ben Steer <admin@pometry.com>",
+    "Haaroon Yousaf <admin@pometry.com>"
+]
+maintainers = [
+    "Pometry <admin@pometry.com>"
+]
+license = "Apache-2.0"
+# include = ["lib/core-*.jar"]
+readme = "README.md"
+homepage = "https://raphtory.com/"
+repository = "https://github.com/rahptory/raphtory"
+documentation = "https://docs.raphtory.com/"
+keywords = ["raphtory", "pyraphtory", "graph", "analytics", "temporal"]
+classifiers = [
+    "Topic :: Scientific/Engineering",
+    "Topic :: Utilities",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: System :: Distributed Computing"
+]
 
 [tool.poetry.dependencies]
 python = ">=3.10 <3.11"
-# pemja = ">=0.2.5"
-pemja = {git = "https://github.com/alibaba/pemja.git", branch="main"}
+pemja =">=0.2.5"
+# pemja = {git = "https://github.com/alibaba/pemja.git", branch="main"}
 cloudpickle=">=0.4"
 pandas=">=1.4.3"
 py4j="^0.10"


### PR DESCRIPTION
added more information to pyproject.toml, added readme, pushed to pypi legacy
note we must ignore the `include=` line in the `pyproject.toml` before pushing to pypi, otherwise it rejects due to the jar being too large