### PR TITLE
Added working logger to Algorithms

### DIFF
--- a/core/src/main/scala/com/raphtory/api/analysis/algorithm/BaseAlgorithm.scala
+++ b/core/src/main/scala/com/raphtory/api/analysis/algorithm/BaseAlgorithm.scala
@@ -3,8 +3,21 @@ package com.raphtory.api.analysis.algorithm
 import com.raphtory.api.analysis.graphview.GraphPerspective
 import com.raphtory.api.analysis.table.Row
 import com.raphtory.api.analysis.table.Table
+import com.typesafe.scalalogging.Logger
+import org.slf4j.LoggerFactory
 
 private[api] trait BaseAlgorithm extends Serializable {
+
+  /** Logger instance for writing out log messages */
+
+  private var internalLogger: Logger = _
+
+  def logger =
+    if (internalLogger == null) {
+      internalLogger = Logger(LoggerFactory.getLogger(this.getClass))
+      internalLogger
+    }
+    else internalLogger
 
   /** Input graph type */
   type In <: GraphPerspective

--- a/core/src/main/scala/com/raphtory/api/analysis/algorithm/Generic.scala
+++ b/core/src/main/scala/com/raphtory/api/analysis/algorithm/Generic.scala
@@ -16,9 +16,6 @@ import org.slf4j.LoggerFactory
 trait Generic extends GenericallyApplicable {
   override type Out = GraphPerspective
 
-  /** Logger instance for writing out log messages */
-  val logger: Logger = Logger(LoggerFactory.getLogger(this.getClass))
-
   /** Main algorithm
     *
     * Default implementation returns the graph unchanged.


### PR DESCRIPTION
The Logger object doesn't play too well with serialisers and in the best case is set to null when an algorithm is sent between the client and Raphtory services. 

As such I have set the logger in the base algorithm to be null unless utilised at which point the QueryExecutor or QueryHandler will create one to output with. 

Have tested this both locally and with the cluster and it seems to correctly output.