### PR TITLE
Fix TableOutputTracker having potentially inconsistent number of partitions

### DIFF
--- a/core/src/main/scala/com/raphtory/api/analysis/table/TableOutputTracker.scala
+++ b/core/src/main/scala/com/raphtory/api/analysis/table/TableOutputTracker.scala
@@ -54,9 +54,9 @@ case class TableOutputTracker(jobID: String, topics: TopicRepository, conf: Conf
   private def handleOutputMessage(msg: OutputMessages): Unit = {
     logger.debug(s"received message $msg")
     msg match {
-      case RowOutput(perspective, row) =>
+      case RowOutput(perspective, row)                  =>
         resultsInProgress.getOrElseUpdate(perspective, ArrayBuffer.empty[Row]).append(row)
-      case EndPerspective(perspective) =>
+      case EndPerspective(perspective, totalPartitions) =>
         perspectiveDoneCounts(perspective) = perspectiveDoneCounts.getOrElse(perspective, 0) + 1
         if (perspectiveDoneCounts(perspective) == totalPartitions) {
           perspectiveDoneCounts.remove(perspective)
@@ -67,7 +67,7 @@ case class TableOutputTracker(jobID: String, topics: TopicRepository, conf: Conf
               completedResults.add(TableOutput(getJobId, perspective, Array.empty, conf, topics))
           }
         }
-      case EndOutput                   =>
+      case EndOutput(totalPartitions)                   =>
         jobsDone += 1
         if (jobsDone == totalPartitions) {
           completedResults.add(EndOutput)

--- a/core/src/main/scala/com/raphtory/internals/components/output/TableOutputSink.scala
+++ b/core/src/main/scala/com/raphtory/internals/components/output/TableOutputSink.scala
@@ -11,12 +11,13 @@ import com.typesafe.config.Config
 import com.typesafe.scalalogging.Logger
 import org.slf4j.LoggerFactory
 
-sealed private[raphtory] trait OutputMessages                                    extends QueryManagement
-final private[raphtory] case class RowOutput(perspective: Perspective, row: Row) extends OutputMessages
-final private[raphtory] case class EndPerspective(perspective: Perspective)      extends OutputMessages
-private[raphtory] case object EndOutput                                          extends OutputMessages
+sealed private[raphtory] trait OutputMessages                                                     extends QueryManagement
+final private[raphtory] case class RowOutput(perspective: Perspective, row: Row)                  extends OutputMessages
+final private[raphtory] case class EndPerspective(perspective: Perspective, totalPartitions: Int) extends OutputMessages
+private[raphtory] case class EndOutput(totalPartitions: Int)                                      extends OutputMessages
 
-private[raphtory] class TableOutputSinkExecutor(endPoint: EndPoint[OutputMessages]) extends SinkExecutor {
+private[raphtory] class TableOutputSinkExecutor(endPoint: EndPoint[OutputMessages], totalPartitions: Int)
+        extends SinkExecutor {
   private var currentPerspective: Perspective = _
 
   override def setupPerspective(perspective: Perspective): Unit = {
@@ -33,17 +34,21 @@ private[raphtory] class TableOutputSinkExecutor(endPoint: EndPoint[OutputMessage
 
   override def closePerspective(): Unit = {
     logger.debug(s"closing perspective $currentPerspective")
-    endPoint.sendSync(EndPerspective(currentPerspective))
+    endPoint.sendSync(EndPerspective(currentPerspective, totalPartitions))
   }
 
   override def close(): Unit = {
     logger.debug("closing output")
-    endPoint.sendSync(EndOutput)
+    endPoint.sendSync(EndOutput(totalPartitions))
   }
 }
 
 private[raphtory] case object TableOutputSink extends Sink {
 
-  override def executor(jobID: String, partitionID: Int, config: Config, topics: TopicRepository): SinkExecutor =
-    new TableOutputSinkExecutor(topics.output(jobID).endPoint)
+  override def executor(jobID: String, partitionID: Int, config: Config, topics: TopicRepository): SinkExecutor = {
+    val partitionServers: Int    = config.getInt("raphtory.partitions.serverCount")
+    val partitionsPerServer: Int = config.getInt("raphtory.partitions.countPerServer")
+    val totalPartitions: Int     = partitionServers * partitionsPerServer
+    new TableOutputSinkExecutor(topics.output(jobID).endPoint, totalPartitions)
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Send number of partitions in output tracking messages to avoid hang in case where local and remote config are different

### Why are the changes needed?
Remote connection hangs

### Does this PR introduce any user-facing change? If yes is this documented?
No

### How was this patch tested?
integration tests

### Are there any further changes required?
Better way to sync number of partitions?