### PR TITLE
Fix flaky DynamicClassLoader test due to standalone process not ready

### DIFF
--- a/core/src/main/scala/com/raphtory/internals/components/cluster/ClusterManager.scala
+++ b/core/src/main/scala/com/raphtory/internals/components/cluster/ClusterManager.scala
@@ -23,7 +23,7 @@ class ClusterManager(
   private lazy val cluster = topics.clusterComms.endPoint
 
   override private[raphtory] def run(): Unit =
-    logger.info(s"Starting HeadNode")
+    println(s"HeadNode started")
 
   override def handleMessage(msg: ClusterManagement): Unit =
     msg match {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes the startup sequence in the DynamicClassLoader test such that the Standalone instance is guaranteed to be running before trying to connect to it.

### Why are the changes needed?

DynamicGraphLoader test was flaky

### Does this PR introduce any user-facing change? If yes is this documented?

No
### How was this patch tested?

Automatic tests

### Are there any further changes required?

`Raphtory.connect()` currently always succeeds, even if there is no remote instance, making a retry approach impossible.