### PR TITLE
Feature/python cleanup

### DIFF
--- a/python/pyraphtory/pyraphtory/algorithm.py
+++ b/python/pyraphtory/pyraphtory/algorithm.py
@@ -1,5 +1,4 @@
 from pyraphtory.graph import TemporalGraph, Row, Table
-from pyraphtory.interop import ScalaProxyBase, find_class, to_python
 
 
 class PyAlgorithm(object):
@@ -25,25 +24,3 @@ class PyAlgorithm(object):
         :return: Table with output from this algorithm
         """
         return graph.global_select(lambda s: Row())
-
-
-class BuiltinAlgorithm(ScalaProxyBase):
-    """Proxy object for looking up built-in algorithms based on path
-
-    (This actually could be used for looking up other classes as well if needed)
-    """
-    @property
-    def _jvm_object(self):
-        return find_class(self._path)
-
-    def __init__(self, path: str):
-        self._path = path
-
-    def __call__(self, *args, **kwargs):
-        return to_python(self._jvm_object).apply(*args, **kwargs)
-
-    def __getattr__(self, item):
-        return BuiltinAlgorithm(".".join((self._path, item)))
-
-    def __getitem__(self, item):
-        return to_python(self._jvm_object).apply[item]

--- a/python/pyraphtory/pyraphtory/builder.py
+++ b/python/pyraphtory/pyraphtory/builder.py
@@ -1,12 +1,12 @@
-from pyraphtory.interop import logger, assign_id, GenericScalaProxy, ScalaClassProxy
-
-
-class Type(ScalaClassProxy):
-    _classname = "com.raphtory.api.input.Type"
+from pyraphtory.interop import ScalaClassProxy
 
 
 class GraphBuilder(ScalaClassProxy):
     _classname = "com.raphtory.api.input.GraphBuilder"
+
+
+class Type(ScalaClassProxy):
+    _classname = "com.raphtory.api.input.Type"
 
 
 class StringProperty(ScalaClassProxy):
@@ -20,12 +20,6 @@ class ImmutableProperty(ScalaClassProxy):
 class Properties(ScalaClassProxy):
     _classname = "com.raphtory.api.input.Properties"
 
+
 class Source(ScalaClassProxy):
     _classname = "com.raphtory.api.input.Source"
-
-
-class GraphBuilder(ScalaClassProxy):
-    _classname = "com.raphtory.api.input.GraphBuilder"
-
-
-

--- a/python/pyraphtory/pyraphtory/context.py
+++ b/python/pyraphtory/pyraphtory/context.py
@@ -1,7 +1,8 @@
-from pyraphtory import interop, algorithm
+import pyraphtory.interop
+from pyraphtory import interop
 
 
 class PyRaphtory(interop.ScalaClassProxy):
     _classname = "com.raphtory.Raphtory$"
 
-    algorithms = algorithm.BuiltinAlgorithm("com.raphtory.algorithms")
+    algorithms = interop.ScalaPackage("com.raphtory.algorithms")

--- a/python/pyraphtory/pyraphtory/interop.py
+++ b/python/pyraphtory/pyraphtory/interop.py
@@ -560,3 +560,23 @@ class Function1(ScalaClassProxy):
 class Function2(ScalaClassProxy):
     """Proxy object for wrapping python functions with 2 arguments"""
     _classname = "com.raphtory.internals.management.PythonFunction2"
+
+
+class ScalaPackage(ScalaProxyBase):
+    """Proxy object for looking up scala classes based on path
+    """
+    @property
+    def _jvm_object(self):
+        return find_class(self._path)
+
+    def __init__(self, path: str):
+        self._path = path
+
+    def __call__(self, *args, **kwargs):
+        return to_python(self._jvm_object).apply(*args, **kwargs)
+
+    def __getattr__(self, item):
+        return ScalaPackage(".".join((self._path, item)))
+
+    def __getitem__(self, item):
+        return to_python(self._jvm_object).apply[item]

--- a/python/pyraphtory/pyraphtory/vertex.py
+++ b/python/pyraphtory/pyraphtory/vertex.py
@@ -43,7 +43,6 @@ class GraphState(GenericScalaProxy):
         return self.apply(key)
 
     def new_int_max(self, *args, **kwargs):
-        # TODO: This segfaults in pemja for some reason
         return super().new_max[Long, Bounded.long_bounds()](*args, **kwargs)
 
     def new_float_max(self, *args, **kwargs):


### PR DESCRIPTION
### What changes were proposed in this pull request?

The main change is a renaming and moving of the python `algorithm.BuiltinAlgorithm` class to `interop.ScalaPackage` as it is useful for accessing any scala class based on path. 

### Why are the changes needed?

Old name was misleading as this wrapper is very useful for accessing things that are not algorithms. Especially useful when using custom scala code from python.

### Does this PR introduce any user-facing change? If yes is this documented?

Yes. Python documentation still needs to be written.

### How was this patch tested?

Python sample script still runs



