### PR TITLE
Add test to prevent changes on application.conf

### DIFF
--- a/core/src/main/resources/application.conf
+++ b/core/src/main/resources/application.conf
@@ -1,10 +1,10 @@
 raphtory {
-   arrow {
-      flight {
-                batchSize = 1000
-                readBusyWait = 100
-      }
-   }
+  arrow {
+    flight {
+      batchSize = 1000
+      readBusyWait = 100
+    }
+  }
 
   data {
     containsDeletions = true
@@ -47,7 +47,7 @@ raphtory {
   partitions {
     serverCount = 1
     serverCount = ${?RAPHTORY_PARTITIONS_SERVERCOUNT}
-    countPerServer = 2
+    countPerServer = 1
     countPerServer = ${?RAPHTORY_PARTITIONS_COUNTPERSERVER}
     batchMessages = false
     batchMessages = ${?RAPHTORY_PARTITIONS_BATCHMESSAGES}

--- a/core/src/test/scala/com/raphtory/config/DefaultConfigTest.scala
+++ b/core/src/test/scala/com/raphtory/config/DefaultConfigTest.scala
@@ -1,0 +1,14 @@
+package com.raphtory.config
+
+import com.typesafe.config.ConfigFactory
+import munit.CatsEffectSuite
+
+import java.io.File
+
+class DefaultConfigTest extends CatsEffectSuite {
+  test("Default application.conf arguments remain unchanged") {
+    val config = ConfigFactory.parseFile(new File("core/src/main/resources/application.conf")).resolve()
+    assertEquals(config.getInt("raphtory.partitions.countPerServer"), 1)
+    assertEquals(config.getInt("raphtory.partitions.serverCount"), 1)
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add a test to check if the values in core/src/main/resources/application.conf are as expected (1 partition per server and 1 server)

### Why are the changes needed?
This is needed to prevent accidental changes when merging PRs

### Does this PR introduce any user-facing change? If yes is this documented?
No

### How was this patch tested?
This PR just adds a test indeed

### Are there any further changes required?
No
