### PR TITLE
disable failing arrow-core docs

### DIFF
--- a/arrow-core/build.sbt
+++ b/arrow-core/build.sbt
@@ -5,6 +5,8 @@ version := raphtoryVersion
 scalaVersion := raphtoryScalaVersion
 organization := "com.raphtory"
 
+Compile / packageDoc / publishArtifact := false
+
 libraryDependencies ++= Seq(
         "org.apache.arrow"   % "arrow-memory-unsafe"     % "7.0.0",
         "org.apache.arrow"   % "arrow-vector"            % "7.0.0",


### PR DESCRIPTION
### What changes were proposed in this pull request?
arrow-core doc generation is now disabled for publish / publishLocal as it was failing

### Why are the changes needed?
publishLocal was broken

### Does this PR introduce any user-facing change? If yes is this documented?
no

### How was this patch tested?
publishLocal now works and finishes without error generating the required jars

### Are there any further changes required?
No