### PR TITLE
Replace grpc_health_probe with a direct gRPC call in tests

### DIFF
--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -42,8 +42,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Install grpc-health-probe
-        run: curl -L https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.14/grpc_health_probe-linux-amd64 -o /usr/local/bin/grpc-health-probe && chmod u+x /usr/local/bin/grpc-health-probe
       - name: Install Pulsar
         run: |
           export PULSAR_VERSION=2.9.0 && \

--- a/test/src/test/scala/test/raphtory/DynamicClassLoaderTest.scala
+++ b/test/src/test/scala/test/raphtory/DynamicClassLoaderTest.scala
@@ -8,6 +8,7 @@ import com.raphtory.api.analysis.algorithm.Generic
 import com.raphtory.api.analysis.graphview.TemporalGraph
 import com.raphtory.api.input._
 import com.raphtory.internals.context.RaphtoryContext
+import com.raphtory.internals.context.RaphtoryIOContext
 import com.raphtory.spouts.FileSpout
 import com.raphtory.TestUtils
 import com.raphtory.api.analysis.table.Row
@@ -152,14 +153,15 @@ class DynamicClassLoaderTest extends CatsEffectSuite {
 
   lazy val localContextFixture: Fixture[RaphtoryContext] = ResourceSuiteLocalFixture(
           "local",
-          Resource.eval(IO(new RaphtoryContext(RaphtoryServiceBuilder.standalone[IO](defaultConf), defaultConf)))
+          RaphtoryIOContext.localIO()
   )
 
   lazy val remoteContextFixture: Fixture[RaphtoryContext] = ResourceSuiteLocalFixture(
           "remote",
           for {
-            _ <- remoteProcess
-          } yield new RaphtoryContext(RaphtoryServiceBuilder.client[IO](defaultConf), defaultConf)
+            _       <- remoteProcess
+            context <- RaphtoryIOContext.remoteIO()
+          } yield context
   )
 
   def fetchContext(context: Context): Fixture[RaphtoryContext] =

--- a/test/src/test/scala/test/raphtory/DynamicClassLoaderTest.scala
+++ b/test/src/test/scala/test/raphtory/DynamicClassLoaderTest.scala
@@ -17,6 +17,11 @@ import com.raphtory.internals.management.GraphConfig.ConfigBuilder
 import com.raphtory.sinks.PrintSink
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.Logger
+import grpc.health.v1.health.Health
+import grpc.health.v1.health.HealthCheckRequest
+import grpc.health.v1.health.HealthCheckResponse
+import higherkindness.mu.rpc.ChannelForAddress
+import higherkindness.mu.rpc.healthcheck.HealthService
 import munit.CatsEffectSuite
 import org.slf4j.LoggerFactory
 import test.raphtory.algorithms.MaxFlowTest
@@ -24,6 +29,7 @@ import test.raphtory.algorithms.MinimalTestAlgorithm
 import test.raphtory.algorithms.TestAlgorithmWithExternalDependency
 
 import java.net.URL
+import scala.concurrent.duration.DurationInt
 import scala.reflect.runtime.universe
 import scala.reflect.runtime.universe._
 import scala.sys.process._
@@ -85,19 +91,18 @@ class DynamicClassLoaderTest extends CatsEffectSuite {
 
   private val compiledAlgo: Generic = tb.compile(tb.parse(minimalTestCode))().asInstanceOf[Generic]
 
+  private val defaultConf: Config = ConfigBuilder.getDefaultConfig
+
+  private val waitForRaphtoryService: IO[Unit] =
+    Health.client[IO](ChannelForAddress("localhost", defaultConf.getInt("raphtory.deploy.port"))).use { client =>
+      for {
+        serving <- client.Check(HealthCheckRequest()).map(response => response.status.isServing).handleError(_ => false)
+        _       <- if (serving) IO.unit else IO.sleep(1.seconds) *> waitForRaphtoryService
+      } yield ()
+    }
+
   lazy val remoteProcess =
     Resource.make {
-      def runHealthCheck =
-        IO.delay(Process(Seq("grpc_health_probe", "-addr=:1736", "-connect-timeout=60s")).!).onError {
-          case NonFatal(e) =>
-            IO.raiseError(
-                    new IllegalStateException(
-                            "Please install grpc_health_probe (https://github.com/grpc-ecosystem/grpc-health-probe/tree/v0.4.14)",
-                            e
-                    )
-            )
-        }
-
       for {
 //         get classpath from sbt
         _         <- IO(logger.info("retrieving class path from sbt"))
@@ -108,7 +113,7 @@ class DynamicClassLoaderTest extends CatsEffectSuite {
         _         <- (IO.blocking(process.exitValue()) *> IO(
                                logger.info("Failed to start remote process, a standalone instance is likely already running")
                        )).start
-        _         <- runHealthCheck
+        _         <- waitForRaphtoryService
       } yield process
     }(process =>
       IO {
@@ -144,8 +149,6 @@ class DynamicClassLoaderTest extends CatsEffectSuite {
   case object LocalContext extends Context
 
   case object RemoteContext extends Context
-
-  val defaultConf: Config = ConfigBuilder.getDefaultConfig
 
   lazy val localContextFixture: Fixture[RaphtoryContext] = ResourceSuiteLocalFixture(
           "local",


### PR DESCRIPTION
### What changes were proposed in this pull request?
Replace grpc_health_probe with a direct gRPC call in tests

### Why are the changes needed?
Otherwise, we need to install grpc_health_probe

### Does this PR introduce any user-facing change? If yes is this documented?
No

### How was this patch tested?
The DynamicClassLoaderTest works

### Are there any further changes required?
No
