### PR TITLE
only return windows field if a window parameter is supplied in the query

### DIFF
--- a/core/src/main/scala/com/raphtory/formats/JsonFormat.scala
+++ b/core/src/main/scala/com/raphtory/formats/JsonFormat.scala
@@ -29,12 +29,13 @@ import java.io.StringWriter
   *   "jobID" : "EdgeCount",
   *   "partitionID" : 0,
   *   "perspectives" : [ {
-  *     "timestamp" : 10,
-  *     "window" : null,
+  *     "timestamp" : 10
   *     "rows" : [ [ "id1", 12 ], [ "id2", 13 ], [ "id3", 24 ] ]
   *   } ]
   * }
   * }}}
+  *
+  * If the above query is run with a window, then additionally a field `window` with the window size is returned at the same level as `timestamp`.
   *
   * On the other hand, if `level` is not set or is set to `JsonFormat.ROW`, the output might look as follows:
   *
@@ -63,11 +64,14 @@ case class JsonFormat(level: JsonFormat.Level = JsonFormat.ROW) extends Format {
 
   private def printPerspectiveProperties(generator: JsonGenerator, perspective: Perspective): Unit = {
     generator.writeNumberField("timestamp", perspective.timestamp)
-    generator.writeFieldName("window")
     perspective.window match {
-      case Some(DiscreteInterval(interval)) => generator.writeNumber(interval)
-      case Some(TimeInterval(interval))     => generator.writeString(interval.toString)
-      case _                                => generator.writeNull()
+      case Some(DiscreteInterval(interval)) =>
+        generator.writeFieldName("window")
+        generator.writeNumber(interval)
+      case Some(TimeInterval(interval))     =>
+        generator.writeFieldName("window")
+        generator.writeString(interval.toString)
+      case _                                =>
     }
   }
 

--- a/core/src/test/scala/com/raphtory/formats/JsonFormatTest.scala
+++ b/core/src/test/scala/com/raphtory/formats/JsonFormatTest.scala
@@ -35,8 +35,8 @@ class JsonFormatTest extends FunSuite {
   )
 
   private val rowLevelOutput =
-    """{"timestamp":100,"window":null,"row":["id1",34]}
-      |{"timestamp":100,"window":null,"row":["id2",24]}
+    """{"timestamp":100,"row":["id1",34]}
+      |{"timestamp":100,"row":["id2",24]}
       |{"timestamp":200,"window":200,"row":["id1",56]}
       |{"timestamp":200,"window":200,"row":["id2",67]}
       |""".stripMargin
@@ -47,7 +47,6 @@ class JsonFormatTest extends FunSuite {
       |  "partitionID" : 13,
       |  "perspectives" : [ {
       |    "timestamp" : 100,
-      |    "window" : null,
       |    "rows" : [ [ "id1", 34 ], [ "id2", 24 ] ]
       |  }, {
       |    "timestamp" : 200,


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change the JSON format to behave in the same way in the CSV format when it comes to windows -- that is, if no window is given, no window field is returned.

### Why are the changes needed?

Consistency across the JSON and CSV formats and reduces the size of the results generated.

### Does this PR introduce any user-facing change? If yes is this documented?

Only in that the default output behaviour has changed as described above. This default behaviour has been added to the documentation for `JSONFormat`.

### How was this patch tested?

Changed a few lines of the `JsonFormatTest` which compares outputs from queries with and without windows, which works as expected.

### Are there any further changes required?

Not as far as I'm aware.