### PR TITLE
Fix bug preventing some exceptions from ingestion from bubbling up

### DIFF
--- a/core/src/main/scala/com/raphtory/internals/components/OrchestratorService.scala
+++ b/core/src/main/scala/com/raphtory/internals/components/OrchestratorService.scala
@@ -10,8 +10,12 @@ import com.raphtory.internals.components.OrchestratorService.GraphList
 import com.raphtory.protocol.GraphInfo
 import com.raphtory.protocol.Status
 import com.raphtory.protocol.success
+import com.typesafe.scalalogging.Logger
+import org.slf4j.LoggerFactory
 
 abstract class OrchestratorService[F[_]: Concurrent, T](graphs: GraphList[F, T]) {
+
+  protected val logger: Logger = Logger(LoggerFactory.getLogger(this.getClass))
 
   // Methods to override by instances of this class
   protected def makeGraphData(graphId: String): F[T]

--- a/core/src/main/scala/com/raphtory/internals/components/OrchestratorService.scala
+++ b/core/src/main/scala/com/raphtory/internals/components/OrchestratorService.scala
@@ -1,7 +1,6 @@
 package com.raphtory.internals.components
 
 import cats.effect.Async
-import cats.effect.Concurrent
 import cats.effect.Ref
 import cats.effect.std.Supervisor
 import cats.syntax.all._
@@ -13,14 +12,14 @@ import com.raphtory.protocol.success
 import com.typesafe.scalalogging.Logger
 import org.slf4j.LoggerFactory
 
-abstract class OrchestratorService[F[_]: Concurrent, T](graphs: GraphList[F, T]) {
+abstract class OrchestratorService[F[_]: Async, T](graphs: GraphList[F, T]) {
 
   protected val logger: Logger = Logger(LoggerFactory.getLogger(this.getClass))
 
   // Methods to override by instances of this class
   protected def makeGraphData(graphId: String): F[T]
 
-  protected def graphExecution(graph: Graph[F, T]): F[Unit] = Concurrent[F].unit
+  protected def graphExecution(graph: Graph[F, T]): F[Unit] = Async[F].unit
 
   final def establishGraph(req: GraphInfo): F[Status] =
     for {
@@ -37,8 +36,10 @@ abstract class OrchestratorService[F[_]: Concurrent, T](graphs: GraphList[F, T])
   final protected def attachExecutionToGraph(graphId: String, execution: Graph[F, T] => F[Unit]): F[Unit] =
     for {
       graph <- graphs.get.map(graphs => graphs(graphId))
-      _     <- graph.supervisor.supervise(execution(graph))
+      _     <- graph.supervisor.supervise(execution(graph).onError { case e: Throwable => logError(e) })
     } yield ()
+
+  private def logError(e: Throwable) = Async[F].delay(logger.error(s"Exception found in orchestrator service: '$e'"))
 
   final protected def destroyGraph(graphId: String): F[Unit] =
     for {

--- a/core/src/main/scala/com/raphtory/internals/components/ingestion/IngestionExecutor.scala
+++ b/core/src/main/scala/com/raphtory/internals/components/ingestion/IngestionExecutor.scala
@@ -107,10 +107,9 @@ object IngestionExecutor {
       sourceID: Int,
       config: Config,
       topics: TopicRepository
-  ): F[Unit] = {
+  ): Resource[F, IngestionExecutor[F]] = {
     val createExecutor =
       Async[F].delay(new IngestionExecutor(graphID, source, blocking, sourceID, config, topics))
-    val executor       = Resource.make(createExecutor)(executor => executor.release())
-    executor.use(executor => executor.run())
+    Resource.make(createExecutor)(executor => executor.release())
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
We now allocate the ingestion executor before answering to the client, so any exceptions thrown whilst creating the spout/builder bubble up in the same gRPC call. Additionally, we log any errors appearing when executing the source. 

### Why are the changes needed?
Raphtory was getting stuck if the spout/builder had a problem at creation. This solves the issue and prevent the errors from being ignored.

### Does this PR introduce any user-facing change? If yes is this documented?
This causes `graph.load()` to throw exceptions, but there is no need to document that for the time being

### How was this patch tested?
Integration tests pass.

### Are there any further changes required?
No
