### PR TITLE
Change everything to Long in three node motifs algorithm

### DIFF
--- a/core/src/main/scala/com/raphtory/algorithms/temporal/motif/LocalThreeNodeMotifs.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/temporal/motif/LocalThreeNodeMotifs.scala
@@ -127,7 +127,7 @@ class LocalThreeNodeMotifs(delta:Long=3600, graphWide:Boolean=false, prettyPrint
           // for motif edges with the same timestamp
           mc.execute(v.explodeAllEdges().map(e=> (e.src,e.dst,e.timestamp)).sortBy(x => (x._3, x._1, x._2)),delta)
           val counts : Array[Long] = mc.getCounts
-          var twoNodeCounts = Array.fill(8)(0)
+          var twoNodeCounts = Array.fill(8)(0L)
           v.neighbours.foreach{
             vid =>
               val mc2node = new TwoNodeMotifs(v.ID)
@@ -152,7 +152,7 @@ class LocalThreeNodeMotifs(delta:Long=3600, graphWide:Boolean=false, prettyPrint
       if (prettyPrint)
         graph.select(vertex => Row(vertex.name, getStarCountsPretty(vertex.getState[Array[Long]]("starCounts")), get2NodeCountsWithoutRepeats(vertex.getState[Array[Long]]("twoNodeCounts")), getTriCountsPretty(vertex.getState[Array[Long]]("triCounts"))))
       else
-        graph.select(vertex => Row(vertex.name, (vertex.getState[Array[Long]]("starCounts")++vertex.getState[Array[Int]]("twoNodeCounts")++vertex.getState[Array[Long]]("triCounts")).mkString("(", ";", ")")))
+        graph.select(vertex => Row(vertex.name, (vertex.getState[Array[Long]]("starCounts")++vertex.getState[Array[Long]]("twoNodeCounts")++vertex.getState[Array[Long]]("triCounts")).mkString("(", ";", ")")))
     } else {
       if (prettyPrint)
         graph.globalSelect(state => Row(getStarCountsPretty(state[Array[Long],Array[Long]]("starCounts").value), get2NodeCountsWithoutRepeats(state[Array[Long],Array[Long]]("twoNodeCounts").value), getTriCountsPretty(state[Array[Long],Array[Long]]("triCounts").value)))

--- a/core/src/main/scala/com/raphtory/algorithms/temporal/motif/ThreeNodeMotifs.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/temporal/motif/ThreeNodeMotifs.scala
@@ -90,7 +90,7 @@ class ThreeNodeMotifs(delta: Long = 3600, graphWide: Boolean = false, prettyPrin
         // for motif edges with the same timestamp
         mc.execute(v.explodeAllEdges().map(e => (e.src, e.dst, e.timestamp)).sortBy(x => (x._3, x._1, x._2)), delta)
         val counts: Array[Long] = mc.getCounts
-        var twoNodeCounts      = Array.fill(8)(0)
+        var twoNodeCounts      = Array.fill(8)(0L)
         v.neighbours.filter(_ != v.ID).foreach { vid =>
           val mc2node = new TwoNodeMotifs(v.ID)
           // Here we sort the edges not only by a timestamp but an additional index meaning that we obtain consistent results
@@ -453,9 +453,9 @@ class TwoNodeMotifs(vid: Long) {
   val incoming: Int = 0
   val outgoing: Int = 1
 
-  val count1d: Array[Int] = Array.fill(2)(0)
-  val count2d: Array[Int] = Array.fill(4)(0)
-  val count3d: Array[Int] = Array.fill(8)(0)
+  val count1d: Array[Long] = Array.fill(2)(0)
+  val count2d: Array[Long] = Array.fill(4)(0)
+  val count3d: Array[Long] = Array.fill(8)(0)
 
   def execute(inputEdges: Array[(Long, Long, Long)], delta: Long): Unit = {
     var start = 0
@@ -489,7 +489,7 @@ class TwoNodeMotifs(vid: Long) {
     count1d(dir) += 1
   }
 
-  def getCounts: Array[Int] =
+  def getCounts: Array[Long] =
     count3d
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change all `Int` counters in ThreeNodeMotifs (and its local counterpart) to `Long` counters

### Why are the changes needed?

In large graphs, we were finding some of the counts had ended up experiencing an integer overflow.

### Does this PR introduce any user-facing change? If yes is this documented?

No.

### How was this patch tested?

Checked it passed the usual Three Node Motifs test, i.e. not introducing any new casting runtime errors.

### Are there any further changes required?

No.
