### PR TITLE
Fix error reporting when submitting to a destroyed graph

### DIFF
--- a/core/src/main/scala/com/raphtory/internals/components/RaphtoryService.scala
+++ b/core/src/main/scala/com/raphtory/internals/components/RaphtoryService.scala
@@ -114,12 +114,19 @@ class DefaultRaphtoryService[F[_]](
     req match {
       case protocol.Query(TryQuery(Success(query)), _) =>
         for {
-          _         <- partitions.map(partition => partition.establishExecutor(req)).sequence // TODO: in parallel?
-          responses <- submitDeserializedQuery(query)
+          graphRunning <- runningGraphs.get.map(graphs => graphs.isDefinedAt(query.graphID))
+          responses    <- if (graphRunning) establishExecutors(req) *> submitDeserializedQuery(query)
+                          else Stream[F, protocol.QueryManagement](graphNotRunningMessage(query.graphID)).pure[F]
         } yield responses
       case protocol.Query(TryQuery(Failure(error)), _) =>
         Stream[F, protocol.QueryManagement](protocol.QueryManagement(JobFailed(error))).pure[F]
     }
+
+  private def graphNotRunningMessage(graphId: String) =
+    protocol.QueryManagement(JobFailed(new IllegalStateException(s"Graph $graphId is not running")))
+
+  private def establishExecutors(query: protocol.Query) =
+    partitions.map(partition => partition.establishExecutor(query)).sequence // TODO: in parallel?
 
   private def submitDeserializedQuery(query: Query): F[Stream[F, protocol.QueryManagement]] =
     (for {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Made Raphtory correctly throw an error if you make a request on a already destroyed graph
### Why are the changes needed?
This would previously throw an Akka error and just hang
### Does this PR introduce any user-facing change? If yes is this documented?
No
### How was this patch tested?
With the usual tests
### Are there any further changes required?
This was a hot fix and is all being improved as part of @ricopinazo's Writer updates