### PR TITLE
make the CSV format use quoted json for printing objects

### DIFF
--- a/core/src/main/scala/com/raphtory/formats/CsvFormat.scala
+++ b/core/src/main/scala/com/raphtory/formats/CsvFormat.scala
@@ -42,10 +42,15 @@ case class CsvFormat(delimiter: String = ",") extends Format {
       private val mapper       = JsonMapper.builder().addModule(DefaultScalaModule).build()
 
       private def csvValue(obj: Any): String = {
-        obj match {
+        obj.asInstanceOf[AnyRef] match {
           case v: java.lang.Number => v.toString
-          case v: Boolean => v.toString
-          case v => "\"" + mapper.writeValueAsString(v) + "\""
+          case v: java.lang.Boolean => v.toString
+          case v =>
+            val value = mapper.writeValueAsString(v)
+            if (value.startsWith("\"") && value.endsWith("\"")) {
+              value
+            } else
+              "\"" + value + "\""
         }
       }
 
@@ -67,10 +72,4 @@ case class CsvFormat(delimiter: String = ",") extends Format {
 
       override def close(): Unit                                    = connector.close()
     }
-}
-
-
-object CsvFormat {
-
-
 }

--- a/core/src/main/scala/com/raphtory/formats/CsvFormat.scala
+++ b/core/src/main/scala/com/raphtory/formats/CsvFormat.scala
@@ -41,16 +41,23 @@ case class CsvFormat(delimiter: String = ",") extends Format {
       var currentPerspective: Perspective = _
       private val mapper       = JsonMapper.builder().addModule(DefaultScalaModule).build()
 
+      private def ensureQuoted(str: String): String = {
+        if ((str.startsWith("\"") && str.endsWith("\""))
+          || (str.startsWith("'") && str.endsWith("'" ))
+          || !str.contains(delimiter)) {
+          str
+        } else {
+          "\"" + str + "\""
+        }
+      }
+
+
+
       private def csvValue(obj: Any): String = {
-        obj.asInstanceOf[AnyRef] match {
-          case v: java.lang.Number => v.toString
-          case v: java.lang.Boolean => v.toString
+        obj match {
+          case v: String => ensureQuoted(v)
           case v =>
-            val value = mapper.writeValueAsString(v)
-            if (value.startsWith("\"") && value.endsWith("\"")) {
-              value
-            } else
-              "\"" + value + "\""
+            ensureQuoted(mapper.writeValueAsString(v))
         }
       }
 

--- a/core/src/main/scala/com/raphtory/formats/CsvFormat.scala
+++ b/core/src/main/scala/com/raphtory/formats/CsvFormat.scala
@@ -5,6 +5,7 @@ import com.raphtory.api.output.format.Format
 import com.raphtory.api.output.sink.SinkConnector
 import com.raphtory.api.output.sink.SinkExecutor
 import com.raphtory.api.time.Perspective
+import com.raphtory.internals.management.PythonInterop.repr
 import com.typesafe.config.Config
 
 /** A `Format` that writes a `Table` in comma-separated value (CSV) format
@@ -43,9 +44,9 @@ case class CsvFormat(delimiter: String = ",") extends Format {
       override protected def writeRow(row: Row): Unit = {
         val value = currentPerspective.window match {
           case Some(w) =>
-            s"${currentPerspective.timestamp}$delimiter$w$delimiter${row.getValues().mkString(delimiter)}"
+            s"${currentPerspective.timestamp}$delimiter$w$delimiter${row.getValues().map(repr).mkString(delimiter)}"
           case None    =>
-            s"${currentPerspective.timestamp}$delimiter${row.getValues().mkString(delimiter)}"
+            s"${currentPerspective.timestamp}$delimiter${row.getValues().map(repr).mkString(delimiter)}"
         }
         connector.write(value)
         connector.closeItem()

--- a/core/src/main/scala/com/raphtory/internals/management/PythonInterop.scala
+++ b/core/src/main/scala/com/raphtory/internals/management/PythonInterop.scala
@@ -64,6 +64,8 @@ object PythonInterop {
             case (name, value) => s"$name=${repr(value)}"
           }
           .mkString(", ") + ")"
+      case v: String                                         =>
+        "\"" + v + "\""
       case v                                                 => v.toString
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Uses the Jackson json writer to print objects 

### Why are the changes needed?
Java `toString` is useless with arrays and other types and breaks civ convention as object strings may contain commas

### Does this PR introduce any user-facing change? If yes is this documented?


### How was this patch tested?

### Are there any further changes required?
