### PR TITLE
Fix twitter test

### DIFF
--- a/core/src/main/scala/com/raphtory/internals/components/OrchestratorService.scala
+++ b/core/src/main/scala/com/raphtory/internals/components/OrchestratorService.scala
@@ -18,7 +18,8 @@ abstract class OrchestratorService[F[_]: Async, T](graphs: GraphList[F, T]) {
 
   protected val logger: Logger = Logger(LoggerFactory.getLogger(this.getClass))
 
-  private def logError(e: Throwable) = Async[F].delay(logger.error(s"Exception found in Orchestrator service: '$e'"))
+  private def logError(e: Throwable) =
+    Async[F].delay(logger.error(s"Exception found in Orchestrator service: '${e.getMessage}'"))
 
   protected def makeGraphData(graphId: String): F[T]
 

--- a/core/src/main/scala/com/raphtory/internals/components/RaphtoryService.scala
+++ b/core/src/main/scala/com/raphtory/internals/components/RaphtoryService.scala
@@ -237,22 +237,24 @@ object RaphtoryServiceBuilder {
 
   private def localCluster[F[_]: Async](config: Config): Resource[F, ServiceRegistry[F]] =
     for {
+      dispatcher  <- Dispatcher[F]
       topics      <- LocalTopicRepository[F](config, None)
       serviceRepo <- LocalServiceRegistry(topics)
       _           <- IngestionServiceImpl(serviceRepo, config)
       _           <- PartitionServiceImpl.makeN(serviceRepo, config)
-      _           <- QueryOrchestrator[F](config, serviceRepo)
+      _           <- QueryOrchestrator[F](dispatcher, config, serviceRepo)
     } yield serviceRepo
 
   private def localArrowCluster[F[_]: Async, V: VertexSchema, E: EdgeSchema](
       config: Config
   ): Resource[F, ServiceRegistry[F]] =
     for {
+      dispatcher  <- Dispatcher[F]
       topics      <- LocalTopicRepository[F](config, None)
       serviceRepo <- LocalServiceRegistry(topics)
       _           <- IngestionServiceImpl(serviceRepo, config)
       _           <- PartitionServiceImpl.makeNArrow[F, V, E](serviceRepo, config)
-      _           <- QueryOrchestrator[F](config, serviceRepo)
+      _           <- QueryOrchestrator[F](dispatcher, config, serviceRepo)
     } yield serviceRepo
 
   private def remoteCluster[F[_]: Async](config: Config): Resource[F, ServiceRegistry[F]] =

--- a/core/src/main/scala/com/raphtory/internals/components/cluster/OrchestratorComponent.scala
+++ b/core/src/main/scala/com/raphtory/internals/components/cluster/OrchestratorComponent.scala
@@ -28,7 +28,7 @@ import scala.collection.mutable
 
 abstract class OrchestratorComponent[F[_]: Async](
     dispatcher: Dispatcher[F],
-    partitions: Seq[PartitionService[F]],
+    registry: ServiceRegistry[F],
     conf: Config
 ) extends Component[ClusterManagement](conf) {
   private case class Deployment(shutdown: F[Unit], clients: mutable.Set[String])
@@ -87,11 +87,11 @@ abstract class OrchestratorComponent[F[_]: Async](
   protected def deployQueryService(
       graphID: String,
       clientID: String,
-      topics: TopicRepository,
+      repo: TopicRepository,
       conf: Config
   ): Unit =
     deployments.synchronized {
-      val serviceResource = QueryManager[F](graphID, dispatcher, partitions, conf, topics)
+      val serviceResource = QueryManager[F](graphID, dispatcher, registry, conf, repo)
       val (_, shutdown)   = dispatcher.unsafeRunSync(serviceResource.allocated)
       deployments += ((graphID, Deployment(shutdown, clients = mutable.Set(clientID))))
     }

--- a/core/src/main/scala/com/raphtory/internals/components/querymanager/QueryHandler.scala
+++ b/core/src/main/scala/com/raphtory/internals/components/querymanager/QueryHandler.scala
@@ -31,9 +31,9 @@ import scala.collection.mutable
 import scala.concurrent.duration.DurationInt
 import scala.util.Try
 
-private[raphtory] class QueryHandler(
+private[raphtory] class QueryHandler[F[_]](
     graphID: String,
-    queryManager: QueryManager,
+    queryManager: QueryManager[F],
     scheduler: Scheduler,
     jobID: String,
     query: Query,

--- a/core/src/main/scala/com/raphtory/service/Query.scala
+++ b/core/src/main/scala/com/raphtory/service/Query.scala
@@ -3,6 +3,7 @@ package com.raphtory.service
 import cats.effect.IO
 import cats.effect.Resource
 import cats.effect.ResourceApp
+import cats.effect.std.Dispatcher
 import com.raphtory.internals.communication.connectors.AkkaConnector
 import com.raphtory.internals.communication.repositories.DistributedTopicRepository
 import com.raphtory.internals.components.querymanager.QueryOrchestrator
@@ -15,10 +16,11 @@ object Query extends ResourceApp.Forever {
   def run(args: List[String]): Resource[IO, Unit] = {
     val config = ConfigBuilder.getDefaultConfig
     for {
-      _        <- Prometheus[IO](config.getInt("raphtory.prometheus.metrics.port"))
-      topics   <- DistributedTopicRepository[IO](AkkaConnector.ClientMode, config, None)
-      registry <- DistributedServiceRegistry[IO](topics, config)
-      _        <- QueryOrchestrator[IO](config, registry)
+      dispatcher <- Dispatcher[IO]
+      _          <- Prometheus[IO](config.getInt("raphtory.prometheus.metrics.port"))
+      topics     <- DistributedTopicRepository[IO](AkkaConnector.ClientMode, config, None)
+      registry   <- DistributedServiceRegistry[IO](topics, config)
+      _          <- QueryOrchestrator[IO](dispatcher, config, registry)
     } yield ()
   }
 }

--- a/core/src/main/scala/com/raphtory/service/Query.scala
+++ b/core/src/main/scala/com/raphtory/service/Query.scala
@@ -6,6 +6,7 @@ import cats.effect.ResourceApp
 import com.raphtory.internals.communication.connectors.AkkaConnector
 import com.raphtory.internals.communication.repositories.DistributedTopicRepository
 import com.raphtory.internals.components.querymanager.QueryOrchestrator
+import com.raphtory.internals.components.repositories.DistributedServiceRegistry
 import com.raphtory.internals.management.GraphConfig.ConfigBuilder
 import com.raphtory.internals.management.Prometheus
 
@@ -14,9 +15,10 @@ object Query extends ResourceApp.Forever {
   def run(args: List[String]): Resource[IO, Unit] = {
     val config = ConfigBuilder.getDefaultConfig
     for {
-      _    <- Prometheus[IO](config.getInt("raphtory.prometheus.metrics.port"))
-      repo <- DistributedTopicRepository[IO](AkkaConnector.ClientMode, config, None)
-      _    <- QueryOrchestrator[IO](config, repo)
+      _        <- Prometheus[IO](config.getInt("raphtory.prometheus.metrics.port"))
+      topics   <- DistributedTopicRepository[IO](AkkaConnector.ClientMode, config, None)
+      registry <- DistributedServiceRegistry[IO](topics, config)
+      _        <- QueryOrchestrator[IO](config, registry)
     } yield ()
   }
 }

--- a/core/src/test/scala/com/raphtory/twittertest/TwitterTest.scala
+++ b/core/src/test/scala/com/raphtory/twittertest/TwitterTest.scala
@@ -3,7 +3,9 @@ package com.raphtory.twittertest
 import com.raphtory.BaseRaphtoryAlgoTest
 import com.raphtory.algorithms.generic.ConnectedComponents
 import com.raphtory.api.input.sources.CSVEdgeListSource
-import com.raphtory.api.input.{Graph, GraphBuilder, Source}
+import com.raphtory.api.input.Graph
+import com.raphtory.api.input.GraphBuilder
+import com.raphtory.api.input.Source
 import com.raphtory.spouts.StaticGraphSpout
 import munit.IgnoreSuite
 
@@ -33,7 +35,7 @@ import scala.language.postfixOps
  * Reference: https://snap.stanford.edu/data/ego-Twitter.html
  *
  * */
-@IgnoreSuite
+//@IgnoreSuite
 class TwitterTest extends BaseRaphtoryAlgoTest[String] {
   override val outputDirectory: String = "/tmp/raphtoryTwitterTest"
 

--- a/core/src/test/scala/com/raphtory/twittertest/TwitterTest.scala
+++ b/core/src/test/scala/com/raphtory/twittertest/TwitterTest.scala
@@ -35,7 +35,6 @@ import scala.language.postfixOps
  * Reference: https://snap.stanford.edu/data/ego-Twitter.html
  *
  * */
-//@IgnoreSuite
 class TwitterTest extends BaseRaphtoryAlgoTest[String] {
   override val outputDirectory: String = "/tmp/raphtoryTwitterTest"
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Partition services are told to create the query executors at the same time the query handler is created, as it used to be before.

### Why are the changes needed?
Otherwise, if the ingestion takes too much time, query executors fail trying to connect to the query handler

### Does this PR introduce any user-facing change? If yes is this documented?
No

### How was this patch tested?
integration tests

### Are there any further changes required?
No
