### PR TITLE
Fix docstrings for overloaded methods

### DIFF
--- a/docs/source/exts/extractScalaAlgoDocs.py
+++ b/docs/source/exts/extractScalaAlgoDocs.py
@@ -5,7 +5,9 @@ from sphinx.util import logging
 from pathlib import Path
 import shutil
 from docutils import nodes
-from docutils.parsers.rst.roles import set_classes, Lexer, utils, LexerError
+from docutils import utils
+from docutils.utils.code_analyzer import Lexer, LexerError
+from docutils.parsers.rst.roles import set_classes
 import subprocess
 import os
 
@@ -236,8 +238,6 @@ def scaladoc_link(role, rawtext, text: str, lineno, inliner, options={}, content
     else:
         target = parts[-1]
         package = "/".join(parts)
-
-
 
     source_dir = Path(inliner.document.settings.env.srcdir)
     current_source = Path(inliner.document.current_source)

--- a/python/pyraphtory/pyraphtory/interop.py
+++ b/python/pyraphtory/pyraphtory/interop.py
@@ -427,9 +427,9 @@ class OverloadedMethod:
     def __init__(self, methods, name):
         self.__name__ = name
         self._methods = methods
-        self.__doc__ = (f"Overloaded method {self.__name__} with alternatives\n\n"
-                        + "\n\n".join(f"{self.__name__}{inspect.signature(m)}" +
-                                      ("\n" + indent(m.__doc__, "    ") if m.__doc__ else "")
+        self.__doc__ = (f"Overloaded method with alternatives\n\n"
+                        + "\n\n".join(f".. method:: {self.__name__}{str(inspect.signature(m.__get__(m)))}\n   :noindex:\n" +  # hack to get signature as if bound method
+                                      ("\n" + indent(m.__doc__, "   ") if m.__doc__ else "")
                                       for m in self._methods))
 
     def __call__(self, *args, **kwargs):


### PR DESCRIPTION
### What changes were proposed in this pull request?

Overloaded method alternatives are now formatted correctly in the docs

### How was this patch tested?

Inspecting documentation output

### Are there any further changes required?

sphinx is still not parsing class/instance methods correctly for wrappers