### PR TITLE
Feature/triangle improvement

### DIFF
--- a/core/src/main/scala/com/raphtory/algorithms/generic/KCore.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/generic/KCore.scala
@@ -82,13 +82,20 @@ class KCore(k: Int, resetStates: Boolean = true) extends Generic {
                   val newlyDeadNeighbours = vertex.messageQueue[Int].length
                   val newEffDegree        = effDegree - newlyDeadNeighbours
 
+                  if (newEffDegree == effDegree)
+                    vertex.voteToHalt()
+
                   vertex.setState(EFFDEGREE, newEffDegree)
-                  if (newEffDegree < k) // this vertex dies
+                  if (newEffDegree < k) { // this vertex dies
                     vertex.messageAllNeighbours(0)
+                    vertex.voteToHalt()
+                  }
+                } else {
+                  vertex.voteToHalt()
                 }
 
               },
-              iterations = 100,
+              iterations = 5000,
               executeMessagedOnly = true
       )
 

--- a/core/src/main/scala/com/raphtory/algorithms/generic/motif/LocalTriangleCount.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/generic/motif/LocalTriangleCount.scala
@@ -1,7 +1,6 @@
 package com.raphtory.algorithms.generic.motif
 
-import com.raphtory.algorithms.generic.NodeList
-import com.raphtory.algorithms.generic.motif
+import com.raphtory.algorithms.generic.{KCore, NodeList, motif}
 import com.raphtory.api.analysis.graphview.GraphPerspective
 import com.raphtory.internals.communication.SchemaProviderInstances._
 
@@ -46,13 +45,18 @@ import com.raphtory.internals.communication.SchemaProviderInstances._
 class LocalTriangleCount extends NodeList(Seq("triangleCount")) {
 
   override def apply(graph: GraphPerspective): graph.Graph =
-    graph
-      .step { (vertex, _) =>
-        vertex.setState("triangleCount", 0)
+    KCore(2).apply(graph)
+      .vertexFilter(v => v.getState[Int]("effectiveDegree")>=2)
+      .step{vertex =>
         val neighbours = vertex.neighbours.toSet
         neighbours.foreach(nb => vertex.messageVertex(nb, neighbours))
-      }
-      .step { (vertex, _) =>
+        }
+//      .step { (vertex, _) =>
+//        vertex.setState("triangleCount", 0)
+//        val neighbours = vertex.neighbours.toSet
+//        neighbours.foreach(nb => vertex.messageVertex(nb, neighbours))
+//      }
+      .step { vertex =>
         val neighbours = vertex.neighbours.toSet
         val queue      = vertex.messageQueue[Set[vertex.IDType]]
         var tri        = 0

--- a/core/src/main/scala/com/raphtory/internals/storage/pojograph/PojoGraphLens.scala
+++ b/core/src/main/scala/com/raphtory/internals/storage/pojograph/PojoGraphLens.scala
@@ -65,7 +65,7 @@ final private[raphtory] case class PojoGraphLens(
   private var fullGraphSize     = 0
   private var exploded: Boolean = false
 
-  val chunkSize = 1
+  val chunkSize = 128
 
   private val needsFiltering: SuperStepFlag = SuperStepFlag()
 

--- a/core/src/main/scala/com/raphtory/internals/storage/pojograph/messaging/VertexMultiQueue.scala
+++ b/core/src/main/scala/com/raphtory/internals/storage/pojograph/messaging/VertexMultiQueue.scala
@@ -14,21 +14,21 @@ final private[raphtory] class VertexMultiQueue {
 
   def getMessageQueue(superStep: Int): Vector[Any] =
     if (superStep % 2 == 0) {
-      logger.debug(s"retreived even message queue at step $superStep")
+      logger.trace(s"retreived even message queue at step $superStep")
       evenMessageQueue.asScala.toVector
     }
     else {
-      logger.debug(s"retreived odd message queue at step $superStep")
+      logger.trace(s"retreived odd message queue at step $superStep")
       oddMessageQueue.asScala.toVector
     }
 
   def clearQueue(superStep: Int): Unit =
     if (superStep % 2 == 0) {
-      logger.debug(s"Clearing even message queue at super step '$superStep'.")
+      logger.trace(s"Clearing even message queue at super step '$superStep'.")
       evenMessageQueue.clear()
     }
     else {
-      logger.debug(s"Clearing odd message queue at super step '$superStep'.")
+      logger.trace(s"Clearing odd message queue at super step '$superStep'.")
       oddMessageQueue.clear()
     }
 
@@ -41,10 +41,10 @@ final private[raphtory] class VertexMultiQueue {
   def receiveMessage(superStep: Int, data: Any): Unit =
     if (superStep % 2 == 0) {
       evenMessageQueue.add(data)
-      logger.debug(s"data $data added to even queue at step $superStep")
+      logger.trace(s"data $data added to even queue at step $superStep")
     }
     else {
-      logger.debug(s"data $data added to odd queue at step $superStep")
+      logger.trace(s"data $data added to odd queue at step $superStep")
       oddMessageQueue.add(data)
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Changes are:
* Mini change to the K-Core algorithm so that it can terminate early via vertices voting to halt
* Triangle Count algorithm now effectively just runs from vertices in the 2-core of the network, vastly reducing the number/size of messages on the network and the number/size set intersections going on in the computation. 
* Changed some logs in the vertex multiqueue from debug level to trace level
* Changed chunk size back to 128

### Why are the changes needed?

* Triangle count was unnecessarily slow especially in scale free networks with huge degree nodes.
* `chunkSize=1` is optimal for some specific algorithms/network sizes but more generally causes explosion in IOFibers so `chunkSize=128` may be more appropriate for more general algorithms. In future this could be changed to a conf variable?

### Does this PR introduce any user-facing change? If yes is this documented?

No

### How was this patch tested?

Performance testing was on a very large graph (33 million edges) -- runtime was reduced from 9hrs to 2.5hrs.
Correctness was checked on the Triangle Test algo. 
NB in smaller graphs the pre-processing (running k-core and synchronising messages for the filter) makes the algorithm actually slightly slower but not noticeably so.

### Are there any further changes required?

No