### PR TITLE
Bug/inline breaks python

### DIFF
--- a/core/src/main/scala/com/raphtory/api/input/Graph.scala
+++ b/core/src/main/scala/com/raphtory/api/input/Graph.scala
@@ -42,17 +42,13 @@ trait Graph {
   def index: Long
   protected def graphID: String
 
-  @inline
-  private def vertexAddCounter    = TelemetryReporter.vertexAddCounter.labels(s"$sourceID", graphID)
+  private def vertexAddCounter = TelemetryReporter.vertexAddCounter.labels(s"$sourceID", graphID)
 
-  @inline
   private def vertexDeleteCounter = TelemetryReporter.vertexDeleteCounter.labels(s"$sourceID", graphID)
 
-  @inline
-  private def edgeAddCounter      = TelemetryReporter.edgeAddCounter.labels(s"$sourceID", graphID)
+  private def edgeAddCounter = TelemetryReporter.edgeAddCounter.labels(s"$sourceID", graphID)
 
-  @inline
-  private def edgeDeleteCounter   = TelemetryReporter.edgeDeleteCounter.labels(s"$sourceID", graphID)
+  private def edgeDeleteCounter = TelemetryReporter.edgeDeleteCounter.labels(s"$sourceID", graphID)
 
   /** Adds a new vertex to the graph or updates an existing vertex
     *

--- a/core/src/main/scala/com/raphtory/internals/management/PythonEncoder.scala
+++ b/core/src/main/scala/com/raphtory/internals/management/PythonEncoder.scala
@@ -120,19 +120,18 @@ object PythonEncoder {
     for (i <- 0 until length) {
       var c = input.charAt(i)
       if (c == '$') c = '_'
-      if (i > 0 || c != '_') { // skip first starting underscore
-        if (Character.isUpperCase(c)) {
-          if (!wasPrevTranslated && resultLength > 0 && result.charAt(resultLength - 1) != '_') {
-            result.append('_')
-            resultLength += 1
-          }
-          c = Character.toLowerCase(c)
-          wasPrevTranslated = true
+      if (Character.isUpperCase(c)) {
+        if (!wasPrevTranslated && resultLength > 0 && result.charAt(resultLength - 1) != '_') {
+          result.append('_')
+          resultLength += 1
         }
-        else wasPrevTranslated = false
-        result.append(c)
-        resultLength += 1
+        c = Character.toLowerCase(c)
+        wasPrevTranslated = true
       }
+      else wasPrevTranslated = false
+      result.append(c)
+      resultLength += 1
+
     }
     if (resultLength > 0) result.toString
     else input

--- a/core/src/main/scala/com/raphtory/internals/storage/pojograph/PojoGraphLens.scala
+++ b/core/src/main/scala/com/raphtory/internals/storage/pojograph/PojoGraphLens.scala
@@ -235,7 +235,6 @@ final private[raphtory] case class PojoGraphLens(
     scheduler.executeInParallel(tasks, onComplete, errorHandler)
   }
 
-  @inline
   def prepareRun[V <: Vertex](vs: Iterator[V], chunkSize: Int, includeAllVs: Boolean)(
       f: V => Unit
   ): (Int, List[IO[Unit]]) =

--- a/core/src/main/scala/com/raphtory/internals/storage/pojograph/entities/internal/PojoVertex.scala
+++ b/core/src/main/scala/com/raphtory/internals/storage/pojograph/entities/internal/PojoVertex.scala
@@ -39,7 +39,6 @@ private[raphtory] class PojoVertex(msgTime: Long, index: Long, val vertexId: Lon
             lens
     )
 
-  @inline
   def edgeView(
       startTime: Long,
       endTime: Long,


### PR DESCRIPTION
### What changes were proposed in this pull request?

Removed all `@inline` annotations
Fixed method name translation to not remove leading underscores

### Why are the changes needed?

- some `@inline` annotations were breaking Scala reflection and thus python wrappers
- `1` is not a valid method name
- 
### Does this PR introduce any user-facing change? If yes is this documented?

No

### How was this patch tested?

python tests still work 

### Are there any further changes required?

no
