### PR TITLE
Ingestion is not blocking when it needs to

### DIFF
--- a/core/src/main/scala/com/raphtory/internals/components/ingestion/IngestionExecutor.scala
+++ b/core/src/main/scala/com/raphtory/internals/components/ingestion/IngestionExecutor.scala
@@ -85,8 +85,7 @@ private[raphtory] class IngestionExecutor[F[_], T](
                                     queryManager.sendAsync(NonBlocking(sourceID = source.sourceID, graphID = graphID))
                             ) *> iBlocked.set(false)
                     )
-      _        <- source.elements(totalTuplesProcessed).last // process elements here
-      _        <- finaliseIngestion(iBlocked)
+      _        <- source.elements(totalTuplesProcessed).last.onComplete(finaliseIngestion(iBlocked)) // process elements here
     } yield ()
 
     totalTuplesProcessed.inc()

--- a/core/src/main/scala/com/raphtory/internals/components/ingestion/IngestionExecutor.scala
+++ b/core/src/main/scala/com/raphtory/internals/components/ingestion/IngestionExecutor.scala
@@ -72,7 +72,7 @@ private[raphtory] class IngestionExecutor[F[_], T](
   private def executePoll: F[Unit] = {
 
     val s = for {
-      iBlocked <- fs2.Stream.eval(Ref.of(false))
+      iBlocked <- fs2.Stream.eval(Ref.of(blocking))
       _        <- if (blocking)
                     fs2.Stream.eval(
                             F.delay(
@@ -85,7 +85,7 @@ private[raphtory] class IngestionExecutor[F[_], T](
                                     queryManager.sendAsync(NonBlocking(sourceID = source.sourceID, graphID = graphID))
                             ) *> iBlocked.set(false)
                     )
-      _        <- source.elements(totalTuplesProcessed) // process elements here
+      _        <- source.elements(totalTuplesProcessed).last // process elements here
       _        <- finaliseIngestion(iBlocked)
     } yield ()
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix ingestion blocking by only finalizing when the ingestion is done

### Why are the changes needed?
ensure the unblocking message only happens at the end of the stream

### Does this PR introduce any user-facing change? If yes is this documented?
No

### How was this patch tested?
Unit tests
### Are there any further changes required?
No