### PR TITLE
Feature/JPype

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ gh-sbt-build: version
 
 .PHONY sbt-build:
 sbt-build: version
+	rm -r -f ~/.ivy2/local/com.raphtory/arrow-core_2.13/$$(cat version)
+	rm -r -f ~/.ivy2/local/com.raphtory/arrow-messaging_2.13/$$(cat version)
+	rm -r -f ~/.ivy2/local/com.raphtory/core_2.13/$$(cat version)
 	sbt publishLocal
 	cp ~/.ivy2/local/com.raphtory/arrow-core_2.13/$$(cat version)/ivys/ivy.xml python/pyraphtory_jvm/pyraphtory_jvm/data/ivys/arrow_core_ivy.xml
 	cp ~/.ivy2/local/com.raphtory/arrow-messaging_2.13/$$(cat version)/ivys/ivy.xml python/pyraphtory_jvm/pyraphtory_jvm/data/ivys/arrow_messaging_ivy.xml

--- a/core/src/main/scala/com/raphtory/internals/context/RaphtoryContext.scala
+++ b/core/src/main/scala/com/raphtory/internals/context/RaphtoryContext.scala
@@ -70,7 +70,7 @@ object PyRaphtoryContext {
 
   def local(): PyRaphtoryContext = new PyRaphtoryContext(Resource.pure(standalone), defaultConf, shutdown)
 
-  def remote(host: String, port: Int): PyRaphtoryContext = {
+  def remote(host: String = deployInterface, port: Int = deployPort): PyRaphtoryContext = {
     val config =
       ConfigBuilder()
         .addConfig("raphtory.deploy.address", host)

--- a/core/src/main/scala/com/raphtory/internals/management/PythonInterop.scala
+++ b/core/src/main/scala/com/raphtory/internals/management/PythonInterop.scala
@@ -73,6 +73,9 @@ object PythonInterop {
   def decode[T](obj: java.util.Collection[_]): T =
     obj.asScala.asInstanceOf[T]
 
+  def decode[T](obj: java.util.Map[_, _]): T =
+    obj.asScala.asInstanceOf[T]
+
   /** Look up name of python wrapper based on input type
     * (used to provide specialised wrappers for categories of types rather than specific classes)
     */

--- a/core/src/main/scala/com/raphtory/internals/management/python/EmbeddedPython.scala
+++ b/core/src/main/scala/com/raphtory/internals/management/python/EmbeddedPython.scala
@@ -16,6 +16,9 @@ trait EmbeddedPython[IO[_]] {
 }
 
 object EmbeddedPython {
+  private var globalInterpreter: Option[EmbeddedPython[Id]] = None
+  def injectInterpreter(interpreter: EmbeddedPython[Id]) =
+    globalInterpreter = Some(interpreter)
   private val interpreters       = ThreadLocal.withInitial[EmbeddedPython[Id]](() => UnsafeEmbeddedPython.apply())
-  def global: EmbeddedPython[Id] = interpreters.get()
+  def global: EmbeddedPython[Id] = globalInterpreter.getOrElse(interpreters.get())
 }

--- a/core/src/main/scala/com/raphtory/internals/management/python/JPypeEmbeddedPython.scala
+++ b/core/src/main/scala/com/raphtory/internals/management/python/JPypeEmbeddedPython.scala
@@ -1,0 +1,16 @@
+package com.raphtory.internals.management.python
+
+import cats.Id
+import com.raphtory.internals.management.{PyRef, PythonEncoder}
+import pemja.core.Interpreter
+
+case class JPypeEmbeddedPython(interpreter: Interpreter) extends EmbeddedPython[Id] {
+  override def invoke(ref: PyRef, methodName: String, args: Vector[Object]): Id[Object] =
+    interpreter.invokeMethod(ref.name, methodName, args: _*)
+
+  override def eval[T](expr: String)(implicit PE: PythonEncoder[T]): Id[T] = ???
+
+  override def run(script: String): Id[Unit] = interpreter.exec(script)
+
+  override def set(name: String, obj: Any): Id[Unit] = interpreter.set(name, obj)
+}

--- a/core/src/main/scala/com/raphtory/internals/management/python/UnsafeEmbeddedPython.scala
+++ b/core/src/main/scala/com/raphtory/internals/management/python/UnsafeEmbeddedPython.scala
@@ -76,7 +76,7 @@ object UnsafeEmbeddedPython {
         PythonInterpreterConfig
           .newBuilder()
           .setPythonExec(pythonExec)
-          .setExcType(PythonInterpreterConfig.ExecType.SUB_INTERPRETER)
+          .setExcType(PythonInterpreterConfig.ExecType.MULTI_THREAD)
 
       val config      = (pythonPaths ++ sitePackages)
         .foldLeft(builder) { (b, path) =>

--- a/core/src/main/scala/com/raphtory/internals/management/python/UnsafeEmbeddedPython.scala
+++ b/core/src/main/scala/com/raphtory/internals/management/python/UnsafeEmbeddedPython.scala
@@ -76,7 +76,7 @@ object UnsafeEmbeddedPython {
         PythonInterpreterConfig
           .newBuilder()
           .setPythonExec(pythonExec)
-          .setExcType(PythonInterpreterConfig.ExecType.MULTI_THREAD)
+          .setExcType(PythonInterpreterConfig.ExecType.SUB_INTERPRETER)
 
       val config      = (pythonPaths ++ sitePackages)
         .foldLeft(builder) { (b, path) =>

--- a/python/pyraphtory/poetry.lock
+++ b/python/pyraphtory/poetry.lock
@@ -7,10 +7,10 @@ optional = false
 python-versions = ">=3.5"
 
 [package.extras]
-tests_no_zope = ["cloudpickle", "pytest-mypy-plugins", "mypy (>=0.900,!=0.940)", "pytest (>=4.3.0)", "pympler", "hypothesis", "coverage[toml] (>=5.0.2)"]
-tests = ["cloudpickle", "zope.interface", "pytest-mypy-plugins", "mypy (>=0.900,!=0.940)", "pytest (>=4.3.0)", "pympler", "hypothesis", "coverage[toml] (>=5.0.2)"]
-docs = ["sphinx-notfound-page", "zope.interface", "sphinx", "furo"]
-dev = ["cloudpickle", "pre-commit", "sphinx-notfound-page", "sphinx", "furo", "zope.interface", "pytest-mypy-plugins", "mypy (>=0.900,!=0.940)", "pytest (>=4.3.0)", "pympler", "hypothesis", "coverage[toml] (>=5.0.2)"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
+docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
 name = "certifi"
@@ -49,7 +49,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7
 
 [[package]]
 name = "exceptiongroup"
-version = "1.0.0"
+version = "1.0.4"
 description = "Backport of PEP 654 (exception groups)"
 category = "dev"
 optional = false
@@ -60,7 +60,7 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "find-libpython"
-version = "0.2.0"
+version = "0.3.0"
 description = "Finds the libpython associated with your environment, wherever it may be hiding"
 category = "main"
 optional = false
@@ -83,6 +83,21 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "jpype1"
+version = "1.4.1"
+description = "A Python to Java bridge."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+packaging = "*"
+
+[package.extras]
+docs = ["readthedocs-sphinx-ext", "sphinx", "sphinx-rtd-theme"]
+tests = ["pytest"]
+
+[[package]]
 name = "numpy"
 version = "1.21.4"
 description = "NumPy is the fundamental package for array computing with Python."
@@ -94,7 +109,7 @@ python-versions = ">=3.7,<3.11"
 name = "packaging"
 version = "21.3"
 description = "Core utilities for Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -103,7 +118,7 @@ pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "pandas"
-version = "1.5.1"
+version = "1.5.2"
 description = "Powerful data structures for data analysis, time series, and statistics"
 category = "main"
 optional = false
@@ -111,14 +126,14 @@ python-versions = ">=3.8"
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.21.0", markers = "python_version >= \"3.10\""},
     {version = ">=1.20.3", markers = "python_version < \"3.10\""},
+    {version = ">=1.21.0", markers = "python_version >= \"3.10\""},
 ]
 python-dateutil = ">=2.8.1"
 pytz = ">=2020.1"
 
 [package.extras]
-test = ["pytest-xdist (>=1.31)", "pytest (>=6.0)", "hypothesis (>=5.5.3)"]
+test = ["hypothesis (>=5.5.3)", "pytest (>=6.0)", "pytest-xdist (>=1.31)"]
 
 [[package]]
 name = "parsy"
@@ -164,12 +179,12 @@ python-versions = "*"
 name = "pyparsing"
 version = "3.0.9"
 description = "pyparsing module - Classes and methods to define and execute parsing grammars"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6.8"
 
 [package.extras]
-diagrams = ["jinja2", "railroad-diagrams"]
+diagrams = ["railroad-diagrams", "jinja2"]
 
 [[package]]
 name = "pyraphtory-jvm"
@@ -276,7 +291,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.9.13,<3.11"
-content-hash = "72d394751c2b6aa1698d7fc6d81d9f5a4505caa6919917e9306550f187e7ab2d"
+content-hash = "c3153bc9159c5cd1879611930c0faa3c9368776e5d22a4c915d6e57f26f780a6"
 
 [metadata.files]
 attrs = [
@@ -300,12 +315,12 @@ colorama = [
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
 exceptiongroup = [
-    {file = "exceptiongroup-1.0.0-py3-none-any.whl", hash = "sha256:2ac84b496be68464a2da60da518af3785fff8b7ec0d090a581604bc870bdee41"},
-    {file = "exceptiongroup-1.0.0.tar.gz", hash = "sha256:affbabf13fb6e98988c38d9c5650e701569fe3c1de3233cfb61c5f33774690ad"},
+    {file = "exceptiongroup-1.0.4-py3-none-any.whl", hash = "sha256:542adf9dea4055530d6e1279602fa5cb11dab2395fa650b8674eaec35fc4a828"},
+    {file = "exceptiongroup-1.0.4.tar.gz", hash = "sha256:bd14967b79cd9bdb54d97323216f8fdf533e278df937aa2a90089e7d6e06e5ec"},
 ]
 find-libpython = [
-    {file = "find_libpython-0.2.0-py3-none-any.whl", hash = "sha256:857e7207d6b5aabd8e05419a67a2003efc43f2986fb02766932bd91a50a76ea8"},
-    {file = "find_libpython-0.2.0.tar.gz", hash = "sha256:aba5d41aa4c3e245a536d397a5f0e0c12c20e7ab2ada398c4ab07ff685f91ff9"},
+    {file = "find_libpython-0.3.0-py3-none-any.whl", hash = "sha256:93fa14c8d007a7f9e6b650a486e249b49f01fd8d45b83ecf080a78b1a7011214"},
+    {file = "find_libpython-0.3.0.tar.gz", hash = "sha256:6e7fe5d9af7fad6dc066cb5515a0e9c90a71f1feb2bb2f8e4cdbb4f83276e9e5"},
 ]
 idna = [
     {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
@@ -314,6 +329,29 @@ idna = [
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
+]
+jpype1 = [
+    {file = "JPype1-1.4.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:233a6a1a9c7f3633e7d74c14039f7ea35df81e138241f1acc8f94f65a8bd086e"},
+    {file = "JPype1-1.4.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0099e77c6e99af13089b1c89cd99681b485fbf74daa492ee38e35d90d6349ffc"},
+    {file = "JPype1-1.4.1-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:213f7154a7cc859dead7143cfee255bd3ce57938e0a5f2250b6768af0cef62c8"},
+    {file = "JPype1-1.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:8d94013dfed3d1c7ee193e86393b2aea756a9910d222b7167ed493f9a0b1b3d5"},
+    {file = "JPype1-1.4.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:34373696c3457f1d686639d928ef53b6a121203d9c0e651ed44dd3adf78bedb3"},
+    {file = "JPype1-1.4.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7622d07408e6d9a89e9eb70d4a9a675e51d5411657ac434ccec23cc94b828d9c"},
+    {file = "JPype1-1.4.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d960ce12c3913242f9e4a11e55afa9c38e1a5410d0a38cc5a21086415c38a02"},
+    {file = "JPype1-1.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5473a89d2cab327e38382fd69d1209517bad44158fb3ee9e699ebfeb5bc1cd51"},
+    {file = "JPype1-1.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:d85489a27c58b1b21feb8601406319b6a51d233ae9fa27de9b24c4dfea560b22"},
+    {file = "JPype1-1.4.1-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:9ce364d26ccbf7a21e35737f62663ce8d3aeb4e4b0f05d7e71f6126a6eb81059"},
+    {file = "JPype1-1.4.1-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:b9e29a0ea763c16d0fb05528785d4ed0fa56a421d600eca87e43398b569d2dea"},
+    {file = "JPype1-1.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:8c2fef2d0c298c8e69b2880ff866fa5db5f477ddd78ef310a357d697362c9f89"},
+    {file = "JPype1-1.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6089cd28067d77e5b4a09e272525ecd70f838b92a7c08d91d4fa7d192ec3f3bb"},
+    {file = "JPype1-1.4.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:24e601a31fb3b44decd5389ea87cbc39aaa0c61980c39b060561f9dc604f4cc5"},
+    {file = "JPype1-1.4.1-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:000556d5839ffbe61c12f1fa41cbfd4e9a0abe103e0100febacc069d75defa8f"},
+    {file = "JPype1-1.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:7039db1a522af55cf89f6a4a72120f8b074abcde2535543da34616640ecbb3c1"},
+    {file = "JPype1-1.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:bd8bd76bf8741fa20d44ded776e6a3ea7fe103bcab7156f53ba7a72c50b7dd2f"},
+    {file = "JPype1-1.4.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:d483a6c3e6cb19065e71d322c4742efcfafc44bf1a67ef8ef75f78626158c3d9"},
+    {file = "JPype1-1.4.1-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:04ea4be3e9471bf62ccdeccc2417ad6b9a300effcc0e5f6af9534eafa14e3978"},
+    {file = "JPype1-1.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:8692a7b14e807b224673010a648ab12415d3bc32323e351f03e6c64814ee319b"},
+    {file = "JPype1-1.4.1.tar.gz", hash = "sha256:dc8ee854073474ad79ae168d90c2f6893854f58936cfa18f3587cadae0d3696d"},
 ]
 numpy = [
     {file = "numpy-1.21.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:8890b3360f345e8360133bc078d2dacc2843b6ee6059b568781b15b97acbe39f"},
@@ -352,33 +390,33 @@ packaging = [
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
 pandas = [
-    {file = "pandas-1.5.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:0a78e05ec09731c5b3bd7a9805927ea631fe6f6cb06f0e7c63191a9a778d52b4"},
-    {file = "pandas-1.5.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5b0c970e2215572197b42f1cff58a908d734503ea54b326412c70d4692256391"},
-    {file = "pandas-1.5.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f340331a3f411910adfb4bbe46c2ed5872d9e473a783d7f14ecf49bc0869c594"},
-    {file = "pandas-1.5.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8c709f4700573deb2036d240d140934df7e852520f4a584b2a8d5443b71f54d"},
-    {file = "pandas-1.5.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:32e3d9f65606b3f6e76555bfd1d0b68d94aff0929d82010b791b6254bf5a4b96"},
-    {file = "pandas-1.5.1-cp310-cp310-win_amd64.whl", hash = "sha256:a52419d9ba5906db516109660b114faf791136c94c1a636ed6b29cbfff9187ee"},
-    {file = "pandas-1.5.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:66a1ad667b56e679e06ba73bb88c7309b3f48a4c279bd3afea29f65a766e9036"},
-    {file = "pandas-1.5.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:36aa1f8f680d7584e9b572c3203b20d22d697c31b71189322f16811d4ecfecd3"},
-    {file = "pandas-1.5.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bcf1a82b770b8f8c1e495b19a20d8296f875a796c4fe6e91da5ef107f18c5ecb"},
-    {file = "pandas-1.5.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c25e5c16ee5c0feb6cf9d982b869eec94a22ddfda9aa2fbed00842cbb697624"},
-    {file = "pandas-1.5.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:932d2d7d3cab44cfa275601c982f30c2d874722ef6396bb539e41e4dc4618ed4"},
-    {file = "pandas-1.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:eb7e8cf2cf11a2580088009b43de84cabbf6f5dae94ceb489f28dba01a17cb77"},
-    {file = "pandas-1.5.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:cb2a9cf1150302d69bb99861c5cddc9c25aceacb0a4ef5299785d0f5389a3209"},
-    {file = "pandas-1.5.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:81f0674fa50b38b6793cd84fae5d67f58f74c2d974d2cb4e476d26eee33343d0"},
-    {file = "pandas-1.5.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:17da7035d9e6f9ea9cdc3a513161f8739b8f8489d31dc932bc5a29a27243f93d"},
-    {file = "pandas-1.5.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:669c8605dba6c798c1863157aefde959c1796671ffb342b80fcb80a4c0bc4c26"},
-    {file = "pandas-1.5.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:683779e5728ac9138406c59a11e09cd98c7d2c12f0a5fc2b9c5eecdbb4a00075"},
-    {file = "pandas-1.5.1-cp38-cp38-win32.whl", hash = "sha256:ddf46b940ef815af4e542697eaf071f0531449407a7607dd731bf23d156e20a7"},
-    {file = "pandas-1.5.1-cp38-cp38-win_amd64.whl", hash = "sha256:db45b94885000981522fb92349e6b76f5aee0924cc5315881239c7859883117d"},
-    {file = "pandas-1.5.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:927e59c694e039c75d7023465d311277a1fc29ed7236b5746e9dddf180393113"},
-    {file = "pandas-1.5.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:e675f8fe9aa6c418dc8d3aac0087b5294c1a4527f1eacf9fe5ea671685285454"},
-    {file = "pandas-1.5.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:04e51b01d5192499390c0015630975f57836cc95c7411415b499b599b05c0c96"},
-    {file = "pandas-1.5.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5cee0c74e93ed4f9d39007e439debcaadc519d7ea5c0afc3d590a3a7b2edf060"},
-    {file = "pandas-1.5.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b156a971bc451c68c9e1f97567c94fd44155f073e3bceb1b0d195fd98ed12048"},
-    {file = "pandas-1.5.1-cp39-cp39-win32.whl", hash = "sha256:05c527c64ee02a47a24031c880ee0ded05af0623163494173204c5b72ddce658"},
-    {file = "pandas-1.5.1-cp39-cp39-win_amd64.whl", hash = "sha256:6bb391659a747cf4f181a227c3e64b6d197100d53da98dcd766cc158bdd9ec68"},
-    {file = "pandas-1.5.1.tar.gz", hash = "sha256:249cec5f2a5b22096440bd85c33106b6102e0672204abd2d5c014106459804ee"},
+    {file = "pandas-1.5.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e9dbacd22555c2d47f262ef96bb4e30880e5956169741400af8b306bbb24a273"},
+    {file = "pandas-1.5.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e2b83abd292194f350bb04e188f9379d36b8dfac24dd445d5c87575f3beaf789"},
+    {file = "pandas-1.5.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2552bffc808641c6eb471e55aa6899fa002ac94e4eebfa9ec058649122db5824"},
+    {file = "pandas-1.5.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fc87eac0541a7d24648a001d553406f4256e744d92df1df8ebe41829a915028"},
+    {file = "pandas-1.5.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d0d8fd58df5d17ddb8c72a5075d87cd80d71b542571b5f78178fb067fa4e9c72"},
+    {file = "pandas-1.5.2-cp310-cp310-win_amd64.whl", hash = "sha256:4aed257c7484d01c9a194d9a94758b37d3d751849c05a0050c087a358c41ad1f"},
+    {file = "pandas-1.5.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:375262829c8c700c3e7cbb336810b94367b9c4889818bbd910d0ecb4e45dc261"},
+    {file = "pandas-1.5.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc3cd122bea268998b79adebbb8343b735a5511ec14efb70a39e7acbc11ccbdc"},
+    {file = "pandas-1.5.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b4f5a82afa4f1ff482ab8ded2ae8a453a2cdfde2001567b3ca24a4c5c5ca0db3"},
+    {file = "pandas-1.5.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8092a368d3eb7116e270525329a3e5c15ae796ccdf7ccb17839a73b4f5084a39"},
+    {file = "pandas-1.5.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f6257b314fc14958f8122779e5a1557517b0f8e500cfb2bd53fa1f75a8ad0af2"},
+    {file = "pandas-1.5.2-cp311-cp311-win_amd64.whl", hash = "sha256:82ae615826da838a8e5d4d630eb70c993ab8636f0eff13cb28aafc4291b632b5"},
+    {file = "pandas-1.5.2-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:457d8c3d42314ff47cc2d6c54f8fc0d23954b47977b2caed09cd9635cb75388b"},
+    {file = "pandas-1.5.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:c009a92e81ce836212ce7aa98b219db7961a8b95999b97af566b8dc8c33e9519"},
+    {file = "pandas-1.5.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:71f510b0efe1629bf2f7c0eadb1ff0b9cf611e87b73cd017e6b7d6adb40e2b3a"},
+    {file = "pandas-1.5.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a40dd1e9f22e01e66ed534d6a965eb99546b41d4d52dbdb66565608fde48203f"},
+    {file = "pandas-1.5.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5ae7e989f12628f41e804847a8cc2943d362440132919a69429d4dea1f164da0"},
+    {file = "pandas-1.5.2-cp38-cp38-win32.whl", hash = "sha256:530948945e7b6c95e6fa7aa4be2be25764af53fba93fe76d912e35d1c9ee46f5"},
+    {file = "pandas-1.5.2-cp38-cp38-win_amd64.whl", hash = "sha256:73f219fdc1777cf3c45fde7f0708732ec6950dfc598afc50588d0d285fddaefc"},
+    {file = "pandas-1.5.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:9608000a5a45f663be6af5c70c3cbe634fa19243e720eb380c0d378666bc7702"},
+    {file = "pandas-1.5.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:315e19a3e5c2ab47a67467fc0362cb36c7c60a93b6457f675d7d9615edad2ebe"},
+    {file = "pandas-1.5.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e18bc3764cbb5e118be139b3b611bc3fbc5d3be42a7e827d1096f46087b395eb"},
+    {file = "pandas-1.5.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0183cb04a057cc38fde5244909fca9826d5d57c4a5b7390c0cc3fa7acd9fa883"},
+    {file = "pandas-1.5.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:344021ed3e639e017b452aa8f5f6bf38a8806f5852e217a7594417fb9bbfa00e"},
+    {file = "pandas-1.5.2-cp39-cp39-win32.whl", hash = "sha256:e7469271497960b6a781eaa930cba8af400dd59b62ec9ca2f4d31a19f2f91090"},
+    {file = "pandas-1.5.2-cp39-cp39-win_amd64.whl", hash = "sha256:c218796d59d5abd8780170c937b812c9637e84c32f8271bbf9845970f8c1351f"},
+    {file = "pandas-1.5.2.tar.gz", hash = "sha256:220b98d15cee0b2cd839a6358bd1f273d0356bf964c1a1aeb32d47db0215488b"},
 ]
 parsy = [
     {file = "parsy-2.0-py2.py3-none-any.whl", hash = "sha256:214a0b3f2cdaf671e73654e50193c3bdf23b0c93a6a192d3f95bc6c9f67a38f3"},

--- a/python/pyraphtory/pyproject.toml
+++ b/python/pyraphtory/pyproject.toml
@@ -36,7 +36,7 @@ requests = "^2.28.1"
 parsy = ">=2.0,<3"
 #pyraphtory_jvm = { path = '../pyraphtory_jvm'}
 pyraphtory_jvm = ">=0.2.0a7"
-jpype = ">=1.4.0"
+jpype1 = ">=1.4.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.3"

--- a/python/pyraphtory/pyproject.toml
+++ b/python/pyraphtory/pyproject.toml
@@ -36,6 +36,7 @@ requests = "^2.28.1"
 parsy = ">=2.0,<3"
 #pyraphtory_jvm = { path = '../pyraphtory_jvm'}
 pyraphtory_jvm = ">=0.2.0a7"
+jpype = ">=1.4.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.3"

--- a/python/pyraphtory/pyraphtory/_codegen.py
+++ b/python/pyraphtory/pyraphtory/_codegen.py
@@ -4,9 +4,9 @@ from pyraphtory._docstring import convert_docstring
 
 def clean_identifier(name: str):
     if iskeyword(name):
-        return name + "_"
+        return str(name + "_")
     else:
-        return name
+        return str(name)
 
 
 def build_method(name, method):

--- a/python/pyraphtory/pyraphtory/_codegen.py
+++ b/python/pyraphtory/pyraphtory/_codegen.py
@@ -9,9 +9,10 @@ def clean_identifier(name: str):
         return str(name)
 
 
-def build_method(name, method):
+def build_method(name, method, jpype=False):
     params = [clean_identifier(name) for name in method.parameters()]
     name = clean_identifier(name)
+    java_name = clean_identifier(method.name()) if jpype else method.name()
     implicits = [clean_identifier(name) for name in method.implicits()]
     nargs = method.n()
     varargs = method.varargs()
@@ -43,7 +44,7 @@ def build_method(name, method):
     lines.extend(f"    {p} = _check_default(self._jvm_object, {p})" if i in defaults else
                  f"    {p} = to_jvm({p})" for i, p in enumerate(params))
     if varargs:
-        lines.append(f"    {varparam} = make_varargs(to_jvm({varparam}))")
+        lines.append(f"    {varparam} = make_varargs(to_jvm(list({varparam})))")
         params.append(varparam)
-    lines.append(f"    return to_python(getattr(self._jvm_object, '{method.name()}')({', '.join(p for p in params + implicits)}))")
+    lines.append(f"    return to_python(getattr(self._jvm_object, '{java_name}')({', '.join(p for p in params + implicits)}))")
     return "\n".join(lines)

--- a/python/pyraphtory/pyraphtory/_config.py
+++ b/python/pyraphtory/pyraphtory/_config.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from pyraphtory_jvm.jre import ivy_folder
+from pyraphtory_jvm.jre import ivy_folder, get_local_java_loc
 
 
 def get_ivy_jars_from_local_lib():
@@ -29,3 +29,4 @@ def setup_raphtory_jars():
 
 
 jars, java_args = setup_raphtory_jars()
+java = get_local_java_loc()

--- a/python/pyraphtory/pyraphtory/_docstring.py
+++ b/python/pyraphtory/pyraphtory/_docstring.py
@@ -237,6 +237,7 @@ doc_converter = alt(tparam, directive("note"), directive("see", "seealso"),
 
 
 def convert_docstring(docs):
+    docs = str(docs)
     if docs:
         try:
             cleaned = doc_converter.parse(docs)

--- a/python/pyraphtory/pyraphtory/_jpypeinterpreter.py
+++ b/python/pyraphtory/pyraphtory/_jpypeinterpreter.py
@@ -1,0 +1,67 @@
+import jpype.imports
+from jpype import JImplements, JOverride, JString, JObject, JClass
+import pydevd
+
+Interpreter = JClass("pemja.core.Interpreter")
+from java.util import Map
+from java.lang import Object
+
+
+@JImplements(Interpreter)
+class JPypeInterpreter:
+    _locals = {}
+
+    @JOverride
+    def set(self, name: JString, value: JObject):
+        pydevd.connected = True
+        pydevd.settrace(suspend=False)
+        self._locals[name] = value
+
+    @JOverride
+    def get(self, *args):
+        pydevd.connected = True
+        pydevd.settrace(suspend=False)
+        obj = self._locals[args[0]]
+        if len(args) == 1:
+            return obj
+        else:
+            return JObject(obj, args[1])
+
+    @JOverride
+    def invoke(self, *args):
+        pydevd.connected = True
+        pydevd.settrace(suspend=False)
+        fun = self._locals[args[0]]
+        if isinstance(args[1], Map):
+            return fun(**args[1])
+        else:
+            if len(args) > 2:
+                return fun(*args[1], **args[2])
+            else:
+                return fun(*args[1])
+
+    @JOverride
+    def invokeMethod(self, obj: JString, method: JString, args):
+        pydevd.connected = True
+        pydevd.settrace(suspend=False)
+        obj = self._locals[obj]
+        method = getattr(obj, str(method))
+        result = method(*args)
+        return result
+
+    @JOverride
+    def exec(self, code: JString):
+        pydevd.connected = True
+        pydevd.settrace(suspend=False)
+        try:
+            exec(str(code), globals(), self._locals)
+        except Exception as e:
+            print(e)
+            raise e
+        return
+
+    @JOverride
+    def close(self):
+        pydevd.connected = True
+        pydevd.settrace(suspend=False)
+        self._locals = {}

--- a/python/pyraphtory/pyraphtory/_jpypeinterpreter.py
+++ b/python/pyraphtory/pyraphtory/_jpypeinterpreter.py
@@ -1,6 +1,7 @@
 import jpype.imports
 from jpype import JImplements, JOverride, JString, JObject, JClass
 import pydevd
+from traceback import print_exc
 
 Interpreter = JClass("pemja.core.Interpreter")
 from java.util import Map
@@ -13,55 +14,71 @@ class JPypeInterpreter:
 
     @JOverride
     def set(self, name: JString, value: JObject):
-        pydevd.connected = True
-        pydevd.settrace(suspend=False)
-        self._locals[name] = value
+        # pydevd.connected = True
+        # pydevd.settrace(suspend=False)
+        try:
+            self._locals[name] = value
+        except Exception as e:
+            print_exc()
+            raise e
 
     @JOverride
     def get(self, *args):
-        pydevd.connected = True
-        pydevd.settrace(suspend=False)
-        obj = self._locals[args[0]]
-        if len(args) == 1:
-            return obj
-        else:
-            return JObject(obj, args[1])
+        # pydevd.connected = True
+        # pydevd.settrace(suspend=False)
+        try:
+            obj = self._locals[args[0]]
+            if len(args) == 1:
+                return obj
+            else:
+                return JObject(obj, args[1])
+        except Exception as e:
+            print_exc()
+            raise e
 
     @JOverride
     def invoke(self, *args):
-        pydevd.connected = True
-        pydevd.settrace(suspend=False)
-        fun = self._locals[args[0]]
-        if isinstance(args[1], Map):
-            return fun(**args[1])
-        else:
-            if len(args) > 2:
-                return fun(*args[1], **args[2])
+        # pydevd.connected = True
+        # pydevd.settrace(suspend=False)
+        try:
+            fun = self._locals[args[0]]
+            if isinstance(args[1], Map):
+                return fun(**args[1])
             else:
-                return fun(*args[1])
+                if len(args) > 2:
+                    return fun(*args[1], **args[2])
+                else:
+                    return fun(*args[1])
+        except Exception as e:
+            print_exc()
+            raise e
 
     @JOverride
     def invokeMethod(self, obj: JString, method: JString, args):
-        pydevd.connected = True
-        pydevd.settrace(suspend=False)
-        obj = self._locals[obj]
-        method = getattr(obj, str(method))
-        result = method(*args)
+        # pydevd.connected = True
+        # pydevd.settrace(suspend=False)
+        try:
+            obj = self._locals[obj]
+            method = getattr(obj, str(method))
+            result = method(*args)
+        except Exception as e:
+            print_exc()
+            raise e
         return result
 
     @JOverride
     def exec(self, code: JString):
-        pydevd.connected = True
-        pydevd.settrace(suspend=False)
+        # pydevd.connected = True
+        # pydevd.settrace(suspend=False)
         try:
             exec(str(code), globals(), self._locals)
         except Exception as e:
-            print(e)
+            print_exc()
             raise e
         return
 
     @JOverride
     def close(self):
-        pydevd.connected = True
-        pydevd.settrace(suspend=False)
+        # pydevd.connected = True
+        # pydevd.settrace(suspend=False)
         self._locals = {}

--- a/python/pyraphtory/pyraphtory/_jpypeinterpreter.py
+++ b/python/pyraphtory/pyraphtory/_jpypeinterpreter.py
@@ -1,11 +1,10 @@
 import jpype.imports
 from jpype import JImplements, JOverride, JString, JObject, JClass
-import pydevd
+# import pydevd
 from traceback import print_exc
 
 Interpreter = JClass("pemja.core.Interpreter")
 from java.util import Map
-from java.lang import Object
 
 
 @JImplements(Interpreter)

--- a/python/pyraphtory/pyraphtory/_jpypeinterpreter.py
+++ b/python/pyraphtory/pyraphtory/_jpypeinterpreter.py
@@ -1,32 +1,30 @@
 import jpype.imports
 from jpype import JImplements, JOverride, JString, JObject, JClass
-# import pydevd
+from pyraphtory.debug import enable_pydev_debug
 from traceback import print_exc
 
 Interpreter = JClass("pemja.core.Interpreter")
 from java.util import Map
 
+_globals = globals()
 
 @JImplements(Interpreter)
 class JPypeInterpreter:
-    _locals = {}
 
     @JOverride
     def set(self, name: JString, value: JObject):
-        # pydevd.connected = True
-        # pydevd.settrace(suspend=False)
+        enable_pydev_debug()
         try:
-            self._locals[name] = value
+            globals()[name] = value
         except Exception as e:
             print_exc()
             raise e
 
     @JOverride
     def get(self, *args):
-        # pydevd.connected = True
-        # pydevd.settrace(suspend=False)
+        enable_pydev_debug()
         try:
-            obj = self._locals[args[0]]
+            obj = globals()[args[0]]
             if len(args) == 1:
                 return obj
             else:
@@ -37,10 +35,9 @@ class JPypeInterpreter:
 
     @JOverride
     def invoke(self, *args):
-        # pydevd.connected = True
-        # pydevd.settrace(suspend=False)
+        enable_pydev_debug()
         try:
-            fun = self._locals[args[0]]
+            fun = globals()[args[0]]
             if isinstance(args[1], Map):
                 return fun(**args[1])
             else:
@@ -54,10 +51,9 @@ class JPypeInterpreter:
 
     @JOverride
     def invokeMethod(self, obj: JString, method: JString, args):
-        # pydevd.connected = True
-        # pydevd.settrace(suspend=False)
+        enable_pydev_debug()
         try:
-            obj = self._locals[obj]
+            obj = globals()[obj]
             method = getattr(obj, str(method))
             result = method(*args)
         except Exception as e:
@@ -67,10 +63,9 @@ class JPypeInterpreter:
 
     @JOverride
     def exec(self, code: JString):
-        # pydevd.connected = True
-        # pydevd.settrace(suspend=False)
+        enable_pydev_debug()
         try:
-            exec(str(code), globals(), self._locals)
+            exec(str(code), globals(), globals())
         except Exception as e:
             print_exc()
             raise e
@@ -78,6 +73,4 @@ class JPypeInterpreter:
 
     @JOverride
     def close(self):
-        # pydevd.connected = True
-        # pydevd.settrace(suspend=False)
-        self._locals = {}
+        pass

--- a/python/pyraphtory/pyraphtory/_py4jgateway.py
+++ b/python/pyraphtory/pyraphtory/_py4jgateway.py
@@ -8,6 +8,9 @@ from weakref import finalize
 
 import pyraphtory_jvm.jre
 from py4j.java_gateway import JavaGateway, GatewayParameters
+import jpype
+import jpype.imports
+
 from typing.io import IO
 
 import pyraphtory._config

--- a/python/pyraphtory/pyraphtory/algorithms/trianglecount.py
+++ b/python/pyraphtory/pyraphtory/algorithms/trianglecount.py
@@ -28,7 +28,7 @@ class LocalTriangleCount(PyAlgorithm):
 class GlobalTriangleCount(LocalTriangleCount):
     def __call__(self, graph: TemporalGraph) -> TemporalGraph:
         return (super().__call__(graph)
-                .set_global_state(lambda s: s.new_adder[Long](name="triangles", retain_state=True))
+                .set_global_state(lambda s: s.new_adder[Long](name="triangles", initial_value=0, retain_state=True))
                 .step(lambda v, s: s["triangles"].add(v["triangleCount"])))
 
     def tabularise(self, graph: TemporalGraph):

--- a/python/pyraphtory/pyraphtory/debug.py
+++ b/python/pyraphtory/pyraphtory/debug.py
@@ -1,19 +1,22 @@
-try:
-    import pydevd
-    pydevd.connected = True
-    pydevd.settrace(suspend=False)
-    def enable_pydev_debug():
-        """
-        Use this function to ensure the pydevd debugger (used by e.g. Pycharm)
-        works for python code called from a thread created by the jvm.
+import sys
 
-        """
+
+def enable_pydev_debug():
+    pass
+
+
+if hasattr(sys, "gettrace") and sys.gettrace() is not None:
+    try:
+        import pydevd
         pydevd.connected = True
         pydevd.settrace(suspend=False)
-except Exception as e:
-    def enable_pydev_debug():
+        def enable_pydev_debug():
+            """
+            Use this function to ensure the pydevd debugger (used by e.g. Pycharm)
+            works for python code called from a thread created by the jvm.
+
+            """
+            pydevd.connected = True
+            pydevd.settrace(suspend=False)
+    except Exception:
         pass
-
-
-
-

--- a/python/pyraphtory/pyraphtory/debug.py
+++ b/python/pyraphtory/pyraphtory/debug.py
@@ -1,0 +1,19 @@
+try:
+    import pydevd
+    pydevd.connected = True
+    pydevd.settrace(suspend=False)
+    def enable_pydev_debug():
+        """
+        Use this function to ensure the pydevd debugger (used by e.g. Pycharm)
+        works for python code called from a thread created by the jvm.
+
+        """
+        pydevd.connected = True
+        pydevd.settrace(suspend=False)
+except Exception as e:
+    def enable_pydev_debug():
+        pass
+
+
+
+

--- a/python/pyraphtory/pyraphtory/graph.py
+++ b/python/pyraphtory/pyraphtory/graph.py
@@ -66,5 +66,5 @@ class Accumulator(GenericScalaProxy):
     _classname = "com.raphtory.api.analysis.graphstate.Accumulator"
 
     def __iadd__(self, other):
-        self.plus_eq(other)
+        self._plus_eq(other)
         return self

--- a/python/pyraphtory/pyraphtory/interop.py
+++ b/python/pyraphtory/pyraphtory/interop.py
@@ -16,7 +16,18 @@ from jpype import JObject, JBoolean, JByte, JShort, JInt, JLong, JFloat, JDouble
 from pyraphtory._py4jgateway import Py4JConnection
 
 _wrapper_lock = Lock()
-_wrappers = {}
+
+def no_wrapper(jvm_object):
+    return jvm_object
+
+
+_wrappers = {
+    "java.lang.Integer": no_wrapper,
+    "java.lang.Short": no_wrapper,
+    "java.lang.Long": no_wrapper,
+    "java.lang.Float": no_wrapper,
+    "java.lang.Double": no_wrapper,
+}
 
 
 def repr(obj):
@@ -448,11 +459,15 @@ class OverloadedMethod:
                                       for m in self._methods))
 
     def __call__(self, *args, **kwargs):
+        errors = []
         for method in self._methods:
             try:
                 return method(*args, **kwargs)
             except Exception as e:
                 logger.trace("call failed for {name} with exception {e}", e=e, name=self.__name__)
+                errors.append(e)
+        for e in errors:
+            print(e)
         raise RuntimeError(f"No overloaded implementations matched for {self.__name__} with {args=} and {kwargs=}")
 
     def __get__(self, instance, owner):

--- a/python/pyraphtory/pyraphtory/interop.py
+++ b/python/pyraphtory/pyraphtory/interop.py
@@ -35,8 +35,12 @@ try:
 
     _scala = findClass('com.raphtory.internals.management.PythonInterop')
 except ImportError:
-    _py4j = Py4JConnection()
-    _scala = _py4j.j_gateway.entry_point
+    import jpype
+    import jpype.imports
+    from pyraphtory import _config
+
+    jpype.startJVM(*_config.java_args, classpath=_config.jars.split(":"))
+    from com.raphtory.internals.management import PythonInterop as _scala
 
 
 def test_scala_reflection(obj):

--- a/python/pyraphtory/pyraphtory/scala/collection.py
+++ b/python/pyraphtory/pyraphtory/scala/collection.py
@@ -1,6 +1,4 @@
-from abc import abstractmethod
 from collections import abc
-from typing import overload
 
 from pyraphtory.interop import register, GenericScalaProxy, ScalaClassProxy, to_python, to_jvm
 

--- a/python/pyraphtory/pyraphtory/scala/collection.py
+++ b/python/pyraphtory/pyraphtory/scala/collection.py
@@ -1,5 +1,4 @@
 from collections import abc
-
 from pyraphtory.interop import register, GenericScalaProxy, ScalaClassProxy, to_python, to_jvm
 
 
@@ -63,6 +62,23 @@ class SequenceScalaProxy(IterableScalaProxy, abc.Sequence):
             return self.indexOf(value)
 
 
+@register(name="Map")
+class Map(ScalaClassProxy, abc.Mapping):
+    _classname = "scala.collection.Map"
+
+    def __len__(self) -> int:
+        self.size()
+
+    def __iter__(self):
+        return self.keys_iterator()
+
+    def __getitem__(self, key):
+        try:
+            return self.apply(key)
+        except Exception:
+            raise KeyError(f"missing key {key}")
+
+
 class List(ScalaClassProxy, SequenceScalaProxy):
     _classname = "scala.collection.immutable.List"
 
@@ -97,3 +113,11 @@ class ScalaNone(ScalaClassProxy):
 
     def __new__(cls, jvm_object=None):
         return None
+
+
+class ScalaSome(ScalaClassProxy):
+    _classname = "scala.Some"
+
+    @classmethod
+    def _from_jvm(cls, jvm_object):
+        return to_python(jvm_object.get())


### PR DESCRIPTION
### What changes were proposed in this pull request?

Changes the Scala interop to use JPype instead of Py4j when running locally. 

Advantages: 
 - improved performance due to avoiding inter-process communication
 - debuggable algorithm execution (needs some hacks to work with threads spawned from the jvm)

### Why are the changes needed?

Py4j is slow 

### Does this PR introduce any user-facing change? If yes is this documented?

Changes are transparent to the user, everything should work as before.

### How was this patch tested?

Sample script runs, existing python tests pass, manually tested remote connection to standalone instance still works

### Are there any further changes required?

Figure out if it is possible to fix the overload bug in JPype