### PR TITLE
add command-line interface for raphtory standalone

### DIFF
--- a/python/pyraphtory/pyproject.toml
+++ b/python/pyraphtory/pyproject.toml
@@ -43,6 +43,7 @@ pytest = "^7.1.3"
 
 [tool.poetry.scripts]
 jre_install = 'pyraphtory.jre:check_dl_java_ivy'
+raphtory-standalone = "pyraphtory.cli:standalone"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/python/pyraphtory/pyraphtory/cli.py
+++ b/python/pyraphtory/pyraphtory/cli.py
@@ -1,0 +1,13 @@
+from pyraphtory._config import jars, java, java_args
+import subprocess
+
+
+def standalone():
+    if java_args:
+        subprocess.run([java, java_args, "-cp", jars, "com.raphtory.service.Standalone"])
+    else:
+        subprocess.run([java, "-cp", jars, "com.raphtory.service.Standalone"])
+
+
+if __name__ == "__main__":
+    standalone()


### PR DESCRIPTION
### What changes were proposed in this pull request?
command line script to start raphtory standalone

### Why are the changes needed?
much easier for the user than manually figuring out paths
### Does this PR introduce any user-facing change? If yes is this documented?

### How was this patch tested?
👀 
### Are there any further changes required?
