### PR TITLE
Fix vertex wrapper

### DIFF
--- a/python/pyraphtory/pyraphtory/vertex.py
+++ b/python/pyraphtory/pyraphtory/vertex.py
@@ -10,8 +10,11 @@ class Vertex(GenericScalaProxy):
 
     _classname = "com.raphtory.api.analysis.visitor.Vertex"
 
-    def message_vertex(self, message):
-        super().message_vertex[SchemaProviders.get_schema(message)](message)
+    def message_vertex(self, vertex_id, data):
+        super().message_vertex[SchemaProviders.get_schema(data)](vertex_id, data)
+
+    def message_self(self, data):
+        super().message_self[SchemaProviders.get_schema(data)](data)
 
     def message_out_neighbours(self, message):
         super().message_out_neighbours[SchemaProviders.get_schema(message)](message)

--- a/python/pyraphtory/tests/test_pyraphtory.py
+++ b/python/pyraphtory/tests/test_pyraphtory.py
@@ -1,9 +1,14 @@
 from pathlib import Path
+
+import numpy as np
+
 from pyraphtory.context import PyRaphtory
+from pyraphtory.graph import Row
 import pyraphtory
 from pyraphtory import __version__
 from pyraphtory.builder import *
 import unittest
+from numpy import array_equal
 
 version_file = Path(__file__).parent.parent.parent.parent / "version"
 
@@ -95,3 +100,12 @@ class PyRaphtoryTest(unittest.TestCase):
         self.assertEqual(df.to_csv(), expected_value)
         self.assertEqual(df_time.to_csv(), expected_value_time)
         graph.destroy(force=True)
+
+    def test_message_vertex(self):
+        with self.ctx.new_graph() as graph:
+            graph.add_edge(1, 1, 2)
+            df = (graph.step(lambda vertex: vertex.message_vertex(1, "message"))
+                  .explode_select(lambda vertex: [Row(vertex.name(), message) for message in vertex.message_queue()])).to_df(["id", "message"])
+            assert array_equal(df["id"], ["1", "1"])
+            assert array_equal(df["message"], ["message", "message"])
+


### PR DESCRIPTION
### What changes were proposed in this pull request?

`message_vertex` function overload had the wrong parameters

### Why are the changes needed?

such that the Python API actually works

### Does this PR introduce any user-facing change? If yes is this documented?

no

### How was this patch tested?

added a test that exercises the method

### Are there any further changes required?

no
