### PR TITLE
Feature/temporal edge count

### DIFF
--- a/core/src/main/scala/com/raphtory/algorithms/generic/NodeEdgeCount.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/generic/NodeEdgeCount.scala
@@ -23,9 +23,9 @@ import scala.math.Ordering.Implicits._
   *  {s}`undirectedEdges: Long`
   *  : Number of undirected edges in the perspective
   *
-  *  | no nodes          | no directed edges       | no undirected edges       |
-  *  | ----------------- | ----------------------- | ------------------------- |
-  *  | {s}`noNodes: Int` | {s}`directedEdges: Int` | {s}`undirectedEdges: Int` |
+  *  | no nodes          | no directed edges       | no undirected edges       | no temporal edges |
+  *  | ----------------- | ----------------------- | ------------------------- | ----------------- |
+  *  | {s}`noNodes: Int` | {s}`directedEdges: Int` | {s}`undirectedEdges: Int` | {s}`temporalEdges: Int` |
   *
   */
 

--- a/core/src/main/scala/com/raphtory/algorithms/generic/NodeEdgeCount.scala
+++ b/core/src/main/scala/com/raphtory/algorithms/generic/NodeEdgeCount.scala
@@ -12,16 +12,22 @@ import scala.math.Ordering.Implicits._
   *  Stores/returns the number of nodes and edges in the graph.
   *
   *  This counts the number of nodes and edges in the perspective and returns them. We count both the number of "undirected"
-  *  edges, treating the graph as a simple undirected graph, and the number of directed edges, treating the graph as directed
-  *  and simple.
+  *  edges, treating the graph as a simple undirected graph, the number of directed edges, treating the graph as directed
+  *  and simple, and the number of temporal edges which includes duplicate directed edges between the same pair of nodes.
   *
   * ## States
   *
-  *  {s}`directedEdges: Long`
+  *  {s}`directedEdges: Int`
   *  : Number of directed edges in the perspective
   *
-  *  {s}`undirectedEdges: Long`
+  *  {s}`undirectedEdges: Int`
   *  : Number of undirected edges in the perspective
+  *
+  *  {s}`temporalEdges: Int`
+  *  : Number of directed edges with multiplicity in the perspective
+  *
+  *
+  *  ## Returns
   *
   *  | no nodes          | no directed edges       | no undirected edges       | no temporal edges |
   *  | ----------------- | ----------------------- | ------------------------- | ----------------- |
@@ -53,4 +59,3 @@ object NodeEdgeCount extends GenericReduction {
         Row(state.nodeCount, state("directedEdges").value, state[Int,Int]("undirectedEdges").value/2, state[Int,Int]("temporalEdges").value)
     }
 }
-


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add the temporal edges (directed edges with multiplicity) into the `NodeEdgeCount` algorithm.

### Why are the changes needed?

As a feature to be able to count the total interactions in a perspective not just the number of edges.

### Does this PR introduce any user-facing change? If yes is this documented?

Just an extra state and return for the algorithm. Documentation has been edited to reflect this.

### How was this patch tested?

Produces the expected number of edges (with and without windows) on the LOTR data.

### Are there any further changes required?

No.
