### PR TITLE
goodbye tmp dir my old friend

### DIFF
--- a/python/pyraphtory_jvm/pyraphtory_jvm/jre.py
+++ b/python/pyraphtory_jvm/pyraphtory_jvm/jre.py
@@ -193,7 +193,8 @@ def empty_folder(folder):
             continue
 
 
-def unpack_jre(filename, jre_loc, unpack_dir=tempfile.mkdtemp(dir=pathlib.Path().resolve())):
+def unpack_jre(filename, jre_loc):
+    unpack_dir = tempfile.mkdtemp()
     system_os = getOS()
     logging.info(f'Unpacking JRE for {system_os}...')
     shutil.unpack_archive(filename, unpack_dir)

--- a/python/pyraphtory_jvm/tests/test_pyraphtory_jvm.py
+++ b/python/pyraphtory_jvm/tests/test_pyraphtory_jvm.py
@@ -172,13 +172,3 @@ class JRETest(unittest.TestCase):
         mock_unpack_archive.return_value = None
         # Run the function
         self.assertRaises(Exception, jre.unpack_jre, tf, ts)
-
-    @mock.patch('platform.system')
-    def test_unpack_jre(self, mock_machine):
-        mock_machine.return_value = 'Linux'
-        ts = tempfile.mkdtemp()
-        tempfile.mkstemp(dir=ts)
-        unpack_dir = tempfile.mkdtemp()
-        temp_tar = ts + '/tmpfile.tar.gz'
-        make_tarfile(temp_tar, ts)
-        self.assertIsNone(jre.unpack_jre(temp_tar, ts, unpack_dir=unpack_dir))


### PR DESCRIPTION
we will never meet with you again

### What changes were proposed in this pull request?

headers in function were creating tmp folders during initialisation, these have been removed

### Why are the changes needed?

every1 complainz about le temp folders

### Does this PR introduce any user-facing change? If yes is this documented?

no

### How was this patch tested?

in a jupyter lab environment

### Are there any further changes required?

hopefully no