### PR TITLE
Added jpype to install docs

### DIFF
--- a/docs/source/Install/python/pyraphtory.ipynb
+++ b/docs/source/Install/python/pyraphtory.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "## Install \n",
     "\n",
-    "    pip install requests pandas pemja cloudpickle parsy\n",
+    "    pip install requests pandas pemja cloudpickle parsy jpype1 matplotlib\n",
     "    pip install -i https://test.pypi.org/simple/ pyraphtory_jvm==0.2.0a9\n",
     "    pip install -i https://test.pypi.org/simple/ pyraphtory==0.2.0a9"
    ],


### PR DESCRIPTION
### Why are the changes needed?
Jpype was missing from dependencies in the install page

