### PR TITLE
Source should unblock and graph should not be destroyed when ingestion fails

### DIFF
--- a/core/src/main/scala/com/raphtory/internals/components/ingestion/IngestionExecutor.scala
+++ b/core/src/main/scala/com/raphtory/internals/components/ingestion/IngestionExecutor.scala
@@ -21,8 +21,8 @@ private[raphtory] class IngestionExecutor[F[_], T](
   private val logger: Logger                      = Logger(LoggerFactory.getLogger(this.getClass))
   private val totalTuplesProcessed: Counter.Child = TelemetryReporter.totalTuplesProcessed.labels(s"$sourceID", graphID)
 
-  def run(): F[Unit] =
-    for {
+  def run(): F[Unit] = {
+    val res = for {
       _                <- F.delay(logger.debug("Running ingestion executor"))
       _                <- source.elements(totalTuplesProcessed) // process elements here
       earliestTimeSeen <- source.earliestTimeSeen()
@@ -31,6 +31,11 @@ private[raphtory] class IngestionExecutor[F[_], T](
                                   EndIngestion(graphID, source.sourceID, earliestTimeSeen, highestTimeSeen)
                           )
     } yield totalTuplesProcessed.inc()
+    res.onError(e => queryService.endIngestion(
+      EndIngestion(graphID, source.sourceID, Long.MaxValue, Long.MinValue)
+    ) *> Async[F].unit)
+  }
+
 }
 
 object IngestionExecutor {

--- a/core/src/main/scala/com/raphtory/internals/components/ingestion/IngestionServiceImpl.scala
+++ b/core/src/main/scala/com/raphtory/internals/components/ingestion/IngestionServiceImpl.scala
@@ -35,7 +35,8 @@ class IngestionServiceImpl[F[_]: Async] private (
 
   private def runExecutor(graphId: String, executor: IngestionExecutor[F, _]): F[Unit] = {
     def logError(e: Throwable): Unit = logger.error(s"Exception while executing source: $e")
-    executor.run().handleErrorWith(e => Async[F].delay(logError(e)) *> destroyGraph(graphId))
+    executor.run()
+      .handleErrorWith(e => Async[F].delay(logError(e)))
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Improved error handling when load fails

### Why are the changes needed?

failing load could lead to a hang in python as the graph remained blocked forever

### Does this PR introduce any user-facing change? If yes is this documented?
No

### How was this patch tested?

Hang is resolved

### Are there any further changes required?
