### PR TITLE
Bug/failed perspective hang

### DIFF
--- a/core/src/main/scala/com/raphtory/api/progresstracker/QueryProgressTrackerWithIterator.scala
+++ b/core/src/main/scala/com/raphtory/api/progresstracker/QueryProgressTrackerWithIterator.scala
@@ -34,8 +34,13 @@ class QueryProgressTrackerWithIterator(
       case PerspectiveCompleted(perspective, rows, _) =>
         logger.debug(s"received message $msg")
         completedResults.add(TableOutput(getJobId, perspective, rows.toArray, conf))
-      case _: QueryCompleted | _: QueryFailed         => // QueryCompleted or QueryFailed
+      case _: QueryCompleted | _: QueryFailed        => // QueryCompleted or QueryFailed
         completedResults.add(msg)
+      case PerspectiveFailed(perspective, reason, _) =>
+        logger.error(s"perspective $perspective failed: $reason")
+        completedResults.add(TableOutput(getJobId, perspective, Array.empty[Row], conf))
+      case _ =>
+        logger.error(s"unknown $msg")
     }
     super.handleQueryUpdate(msg)
   }

--- a/python/pyraphtory/pyraphtory/algorithms/sample.py
+++ b/python/pyraphtory/pyraphtory/algorithms/sample.py
@@ -4,6 +4,7 @@ sample python script.
 
 from pyraphtory.graph import Row
 from pyraphtory.input import *
+from pyraphtory.sources import Source
 from pyraphtory.scala.implicits.numeric import Long
 from pyraphtory.spouts import FileSpout
 from time import perf_counter

--- a/python/pyraphtory/pyraphtory/algorithms/sample.py
+++ b/python/pyraphtory/pyraphtory/algorithms/sample.py
@@ -27,9 +27,9 @@ if __name__ == "__main__":
         target_node = parts[1]
         time_stamp = int(parts[2])
 
-        graph.add_vertex(time_stamp, source_node, type ="Character")
-        graph.add_vertex(time_stamp, target_node, type ="Character")
-        graph.add_edge(time_stamp, source_node, target_node, type ="Character_Co-occurence")
+        graph.add_vertex(time_stamp, source_node, vertex_type="Character")
+        graph.add_vertex(time_stamp, target_node, vertex_type="Character")
+        graph.add_edge(time_stamp, source_node, target_node, edge_type="Character_Co-occurence")
 
 
     with PyRaphtory.local() as ctx:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix handling of failed perspectives so they no longer hang

### Why are the changes needed?

QueryProgressTrackerWithIterator did not handle `PerspectiveFailed` messages which caused a hang

### Does this PR introduce any user-facing change? If yes is this documented?

no
### How was this patch tested?

no more hangs on failure in python

### Are there any further changes required?

no
