### PR TITLE
Changed the command to set the java home to work for older mac versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ DOCKER_RAP:=bin/docker/raphtory
 DOCKER_TMP:=$(DOCKER_RAP)/tmp
 MODE:=batch
 IVY_VERSION:=2.5.1
-export JAVA_HOME:= $(shell readlink -f $$(which java) | sed "s:/bin/java::")
+export JAVA_HOME:= $(shell (readlink -f  $$(which java) 2>/dev/null || echo "$$(which java)")| sed "s:/bin/java::")
 
 # version:
 # 	sbt -Dsbt.supershell=false -error "exit" && \


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fixed the JAVA_HOME settings in the make file
### Why are the changes needed?
Command failed on old Macs like mine
### Does this PR introduce any user-facing change? If yes is this documented?
No
### How was this patch tested?
On my laptop - was already working on CI as command worked on linux
### Are there any further changes required?
No