### PR TITLE
Remove sbt versions and bump docs to 1.7.0 sbt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ sbt-build-clean:
 
 .PHONY: docs
 docs: version python-build
-	pip install -q myst-parser sphinx-rtd-theme sphinx docutils sphinx-tabs
+	pip install -q myst-parser sphinx-rtd-theme sphinx docutils sphinx-tabs nbsphinx
 	cd docs && make html
 
 

--- a/core/project/build.properties
+++ b/core/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.5.5

--- a/docs/project/build.properties
+++ b/docs/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.7.0

--- a/docs/project/build.properties
+++ b/docs/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.7.0

--- a/examples/gab/project/build.properties
+++ b/examples/gab/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.5.2

--- a/examples/lotr/project/build.properties
+++ b/examples/lotr/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.6.2

--- a/examples/lotr/project/plugins.sbt
+++ b/examples/lotr/project/plugins.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.1.0")

--- a/examples/nft/project/build.properties
+++ b/examples/nft/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.6.2

--- a/examples/nft/project/plugins.sbt
+++ b/examples/nft/project/plugins.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.1.0")

--- a/it/project/build.properties
+++ b/it/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.6.2


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove sbt versions from example files 

### Why are the changes needed?
So examples use the same sbt version as core project

### Does this PR introduce any user-facing change? If yes is this documented?
No

### How was this patch tested?
sbt assembly and make python-build

### Are there any further changes required?
No