### PR TITLE
delete raphtory jars in ivy cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,7 @@ sbt-build-clean:
 	rm -rf $(PYRAPHTORY_IVYDIR)/
 	rm -rf $(PYRAPHTORY_JREBIN)/
 	rm -rf $(PYRAPHTORY_IVYBIN)/
+	rm -rf ~/.ivy2/cache/com.raphtory/
 
 
 .PHONY: docs


### PR DESCRIPTION
### What changes were proposed in this pull request?

bug  in raphtory not pulling latest build but using cache

### Why are the changes needed?

### Does this PR introduce any user-facing change? If yes is this documented?

### How was this patch tested?

### Are there any further changes required?

Fyi this deletes

> /Users/haaroony/.ivy2/cache/com.raphtory/arrow-core_2.13/ivy-0.1.5.xml                 /Users/haaroony/.ivy2/cache/com.raphtory/arrow-messaging_2.13/ivydata-0.1.5.properties
/Users/haaroony/.ivy2/cache/com.raphtory/arrow-core_2.13/ivy-0.1.5.xml.original        /Users/haaroony/.ivy2/cache/com.raphtory/core_2.13/ivy-0.1.5.xml
/Users/haaroony/.ivy2/cache/com.raphtory/arrow-core_2.13/ivydata-0.1.5.properties      /Users/haaroony/.ivy2/cache/com.raphtory/core_2.13/ivy-0.1.5.xml.original
/Users/haaroony/.ivy2/cache/com.raphtory/arrow-messaging_2.13/ivy-0.1.5.xml            /Users/haaroony/.ivy2/cache/com.raphtory/core_2.13/ivydata-0.1.5.properties

> /Users/haaroony/.ivy2/cache/com.raphtory/arrow-core_2.13/jars:
arrow-core_2.13-0.1.5.jar

> /Users/haaroony/.ivy2/cache/com.raphtory/arrow-messaging_2.13/jars:
arrow-messaging_2.13-0.1.5.jar

> /Users/haaroony/.ivy2/cache/com.raphtory/core_2.13/jars:
core_2.13-0.1.5.jar
