### PR TITLE
Bug/more python dist fixes

### DIFF
--- a/.github/workflows/test_scala_python_workflow.yml
+++ b/.github/workflows/test_scala_python_workflow.yml
@@ -32,6 +32,10 @@ jobs:
         run: mkdir -p $HOME/.sbt && touch $HOME/.sbt/sonatype_credentials
       - name: Get sbt package
         run: apt-get update && apt-get install unzip make && curl -L "https://github.com/sbt/sbt/releases/download/v1.6.2/sbt-1.6.2.zip" -o sbt-1.6.2.zip && unzip sbt-1.6.2.zip
+      - name: Compile tests
+        run: |
+          export PATH=$(pwd)/sbt/bin:$PATH
+          sbt Test / compile
       - name: Run all scala tests
         run: |
           export PATH=$(pwd)/sbt/bin:$PATH

--- a/.github/workflows/test_scala_python_workflow.yml
+++ b/.github/workflows/test_scala_python_workflow.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Compile tests
         run: |
           export PATH=$(pwd)/sbt/bin:$PATH
-          sbt Test / compile
+          sbt Test/compile
       - name: Run all scala tests
         run: |
           export PATH=$(pwd)/sbt/bin:$PATH

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,4 @@
-include python/src/pyraphtory/lib/*.jar
-prune python/src/pyraphtory/lib/dependencies
+prune python/src/pyraphtory/lib
 prune python/src/pyraphtory/jre
 prune python/src/pyraphtory/ivy
 include python/_custom_build/*.py

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ sbt-thin-build: version clean sbt-build
 
 options?=
 .PHONY: python-build-options
+python-build-options:
 
 
 .PHONY: python-build
@@ -181,13 +182,13 @@ setup-python: gh-sbt-build setup-python-env python-build
 
 
 .PHONY: setup-python-test
-setup-python-test:
-	python -m pip install ".[test]"
+setup-python-test: python-build-options
+	python -m pip install $(options) ".[test]"
 
 
 .PHONY: setup-python-docs
-setup-python-docs:
-	python -m pip install ".[docs]"
+setup-python-docs: python-build-options
+	python -m pip install $(options) ".[docs]"
 
 
 .PHONY: python-test

--- a/examples/nft/src/main/python/.gitignore
+++ b/examples/nft/src/main/python/.gitignore
@@ -1,0 +1,2 @@
+ETH-USD.csv
+results.json

--- a/python/_custom_build/backend.py
+++ b/python/_custom_build/backend.py
@@ -21,7 +21,7 @@ platform = get_platform_tag()
 
 
 def build_sdist(sdist_directory, config_settings=None):
-    make_python_build()
+    make_python_build(rebuild=True)
     return _orig.build_sdist(sdist_directory, config_settings)
 
 
@@ -33,7 +33,7 @@ def setup_wheel_dependencies(rebuild=False):
 
 def build_wheel(wheel_directory, config_settings: dict=None, metadata_directory=None):
     print(sys.path)
-    setup_wheel_dependencies()
+    setup_wheel_dependencies(rebuild=False)
 
     # make wheel platform-specific as the jre downloaded will be different
     if config_settings is not None:

--- a/python/_custom_build/ivysettings.xml
+++ b/python/_custom_build/ivysettings.xml
@@ -1,8 +1,11 @@
 <ivysettings>
+    <caches>
+        <cache name="localcache" basedir="${ivy_tmp_cache}" useOrigin="true" />
+    </caches>
     <settings defaultResolver="default"/>
     <resolvers>
         <chain name="default" returnFirst="true">
-            <filesystem name="local">
+            <filesystem name="local" cache="localcache">
                 <ivy pattern="${ivy_dir}/[module]_ivy.xml" />
                 <artifact pattern="${ivy_dir}/[module].jar" />
             </filesystem>

--- a/python/build_tests/core_2.13_ivy.xml
+++ b/python/build_tests/core_2.13_ivy.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ivy-module version="2.0" xmlns:e="http://ant.apache.org/ivy/extra">
+  <info organisation="com.raphtory" module="core_2.13" revision="test" status="release" publication="20230111124611" e:info.versionScheme="early-semver">
+    <description homepage="https://github.com/Raphtory/Raphtory">A Distributed Temporal Graph Processing System</description>
+  </info>
+  <configurations>
+    <conf name="compile" visibility="public" description=""/>
+    <conf extends="compile" name="runtime" visibility="public" description=""/>
+  </configurations>
+  <publications>
+    <artifact name="core_2.13" type="jar" ext="jar" conf="compile"/>
+  </publications>
+</ivy-module>

--- a/python/build_tests/test_pyraphtory_jvm.py
+++ b/python/build_tests/test_pyraphtory_jvm.py
@@ -137,9 +137,9 @@ class JRETest(unittest.TestCase):
     @mock.patch("ivy.version")
     def test_ivy_cache(self, mock_version):
         mock_version.return_value = "test"
-        old_lib = paths.lib_folder
-        old_ivy = paths.ivy_folder
         import ivy
+        old_lib = ivy.lib_folder
+        old_ivy = ivy.ivy_folder
         with tempfile.TemporaryDirectory() as lib_folder:
             with tempfile.TemporaryDirectory() as ivy_folder:
                 lib_folder = Path(lib_folder)

--- a/python/build_tests/test_pyraphtory_jvm.py
+++ b/python/build_tests/test_pyraphtory_jvm.py
@@ -5,6 +5,7 @@ from unittest import mock
 import platform
 import os
 import tarfile
+import shutil
 print(os.environ.get("PYTHONPATH"))
 import sys
 sys.path.append(str(Path(__file__).parent.parent / "_custom_build"))
@@ -14,6 +15,7 @@ from ivy import *
 from download import *
 from check_platform import *
 from java import *
+import paths
 import java
 
 
@@ -131,3 +133,30 @@ class JRETest(unittest.TestCase):
         mock_unpack_archive.return_value = None
         # Run the function
         self.assertRaises(Exception, unpack_jre, tf, ts)
+
+    @mock.patch("ivy.version")
+    def test_ivy_cache(self, mock_version):
+        mock_version.return_value = "test"
+        old_lib = paths.lib_folder
+        old_ivy = paths.ivy_folder
+        import ivy
+        with tempfile.TemporaryDirectory() as lib_folder:
+            with tempfile.TemporaryDirectory() as ivy_folder:
+                lib_folder = Path(lib_folder)
+                ivy_folder = Path(ivy_folder)
+                try:
+                    ivy.lib_folder = lib_folder
+                    ivy.ivy_folder = ivy_folder
+                    shutil.copyfile(Path(__file__).parent / "core_2.13_ivy.xml", ivy_folder / "core_2.13_ivy.xml")
+                    for revision in ("revision_1", "revision_2"):
+                        with open(ivy_folder / f"core_2.13.jar", "w") as file:
+                            file.write(revision)
+
+                        ivy.get_and_run_ivy(paths.jre_folder / "bin" / "java")
+                        f = next(lib_folder.iterdir())
+                        with open(f) as file:
+                            self.assertEqual(file.read(), revision)
+                finally:
+                    ivy.lib_folder = old_lib
+                    ivy.ivy_folder = old_ivy
+

--- a/python/build_tests/test_pyraphtory_jvm.py
+++ b/python/build_tests/test_pyraphtory_jvm.py
@@ -155,7 +155,8 @@ class JRETest(unittest.TestCase):
                         ivy.get_and_run_ivy(paths.jre_folder / "bin" / "java")
                         f = next(lib_folder.iterdir())
                         with open(f) as file:
-                            self.assertEqual(file.read(), revision)
+                            res = file.read()
+                            self.assertEqual(revision, res)
                 finally:
                     ivy.lib_folder = old_lib
                     ivy.ivy_folder = old_ivy

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ commands =
 [testenv:test]
 description = test environment for python tests
 extras = test
+usedevelop = true
 commands =
     pytest python/tests
     pytest --nbmake -n=auto examples
@@ -22,6 +23,7 @@ commands =
 [testenv:docs]
 description = build environment for docs
 extras = docs
+usedevelop = true
 changedir = {tox_root}/docs
 commands =
     sphinx-build -M html source build

--- a/tox.ini
+++ b/tox.ini
@@ -3,21 +3,25 @@ envlist =
     test
     build_test
 
-[testenv]
-deps =
-    pytest
-    build_test: requests
-    test: nbmake
-    test: pytest-xdist
-
 [testenv:build_test]
 description = test environment for build tests
 skip_install = true
+deps =
+    pytest
+    requests
 commands =
     pytest python/build_tests
 
 [testenv:test]
 description = test environment for python tests
+extras = test
 commands =
     pytest python/tests
     pytest --nbmake -n=auto examples
+
+[testenv:docs]
+description = build environment for docs
+extras = docs
+changedir = {tox_root}/docs
+commands =
+    sphinx-build -M html source build


### PR DESCRIPTION
### What changes were proposed in this pull request?

- always trigger recompile of jars when building sdist
- disable ivy cache for local dependencies
- add options to more make commands
- make tox useful for running tests and building docs, ensuring all dependencies are installed (use `tox` from the project root to run all python tests and `tox -e docs` to build the html docs)

### Why are the changes needed?

Some bugs in the python install process

### Does this PR introduce any user-facing change? If yes is this documented?

no

### How was this patch tested?

added test for the ivy cache problem to confirm that jars are always updated even when revision doesn't change
### Are there any further changes required?

hopefully not
