### PR TITLE
automatically set binder link based on version

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,6 +13,7 @@
 import os
 import sys
 from pathlib import Path
+from pyraphtory import __version__
 sys.path.insert(0, os.path.abspath('exts'))
 
 
@@ -23,7 +24,7 @@ copyright = '2022, Ben Steer'
 author = 'Ben Steer'
 
 # The full version, including alpha/beta/rc tags
-release = '0.1.0'
+release = __version__
 
 
 # -- General configuration ---------------------------------------------------
@@ -97,3 +98,8 @@ html_theme_options = {
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static', 'images', '_scaladoc']
 nbsphinx_kernel_name = 'python3'
+
+rst_prolog = f"""
+.. |binder_link| replace:: Click here to launch the notebook
+.. _binder_link: https://mybinder.org/v2/gh/Raphtory/Raphtory/v{__version__}?labpath=examples%2Fbinder_python%2Findex.ipynb
+"""

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,9 +13,9 @@ Raphtory is an open-source platform for distributed real-time temporal graph ana
 If you would like a brief summary of what it's used for before fully diving into the getting start guide please check out our latest talks and blogs on the `Raphtory website <https://raphtory.com>`_.
 
 You can try PyRaphtory (the python library) right now in a Jupyter notebook within your browser, no install is required.  
-`Click here to launch the notebook <https://mybinder.org/v2/gh/Raphtory/Raphtory/v0.2.0a9?labpath=examples%2Fbinder_python%2Findex.ipynb>`_.
+|binder_link|_.
 
-Alternatively, hit next and lets get Raphtory :doc:`installed <Install/python/pyraphtory>`. If you want to dive headfirst into the API's you can visit the :doc:`PythonDocs <PythonDocs/index>` or :doc:`ScalaDocs <Scaladoc/index>`.
+Alternatively, hit next and lets get Raphtory :doc:`installed <Install/python/pyraphtory>`. If you want to dive headfirst into the API's you can visit the :doc:`PythonDocs <PythonDocs/index>` or :doc:`ScalaDocs <scala/apidocs>`.
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
### What changes were proposed in this pull request?

sets binder link in docs based on the version number

### Why are the changes needed?

binder link needs to always point at the correct version which before required manual changes

### Does this PR introduce any user-facing change? If yes is this documented?

no

### How was this patch tested?

checked that binder link is set correctly

### Are there any further changes required?

no