### PR TITLE
Make algorithm run method public and document it

### DIFF
--- a/core/src/main/scala/com/raphtory/api/analysis/algorithm/BaseAlgorithm.scala
+++ b/core/src/main/scala/com/raphtory/api/analysis/algorithm/BaseAlgorithm.scala
@@ -39,7 +39,8 @@ private[raphtory] trait BaseAlgorithm extends Serializable {
     */
   def tabularise(graph: Out): Table = graph.globalSelect(_ => Row())
 
-  private[raphtory] def run(graph: In): Table = tabularise(apply(graph))
+  /** Apply the algorithm to the graph and return the output as a table using the `tabularise` method */
+  final def run(graph: In): Table = tabularise(apply(graph))
 
   /** The name of the algorithm (returns the simple class name by default) */
   def name: String = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

expose the run method on algorithms as it useful if one doesn't like `transform` and `execute` style

### Why are the changes needed?

nicer api

### Does this PR introduce any user-facing change? If yes is this documented?

added docstring to run

### How was this patch tested?

usual tests pass (this method already existed, I did not add new code)

### Are there any further changes required?

no