### PR TITLE
Add python commands for each component

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,10 @@ documentation = "https://docs.raphtory.com/"
 
 [project.scripts]
 raphtory-standalone = "pyraphtory.cli:standalone"
+raphtory-clustermanager = "pyraphtory.cli:clustermanager"
+raphtory-ingestion = "pyraphtory.cli:ingestion"
+raphtory-partition = "pyraphtory.cli:partition"
+raphtory-query = "pyraphtory.cli:query"
 raphtory-classpath = "pyraphtory.cli:classpath"
 raphtory-version = "pyraphtory.cli:version"
 

--- a/python/src/pyraphtory/cli.py
+++ b/python/src/pyraphtory/cli.py
@@ -3,13 +3,35 @@ from pyraphtory import __version__
 import subprocess
 import sys
 
-
 def standalone():
     if java_args:
         subprocess.run([java, java_args, "-cp", jars, "com.raphtory.service.Standalone"])
     else:
         subprocess.run([java, "-cp", jars, "com.raphtory.service.Standalone"])
 
+def clustermanager():
+    if java_args:
+        subprocess.run([java, java_args, "-cp", jars, "com.raphtory.service.ClusterManager"])
+    else:
+        subprocess.run([java, "-cp", jars, "com.raphtory.service.ClusterManager"])
+
+def ingestion():
+    if java_args:
+        subprocess.run([java, java_args, "-cp", jars, "com.raphtory.service.Ingestion"])
+    else:
+        subprocess.run([java, "-cp", jars, "com.raphtory.service.Ingestion"])
+
+def partition():
+    if java_args:
+        subprocess.run([java, java_args, "-cp", jars, "com.raphtory.service.Partition"])
+    else:
+        subprocess.run([java, "-cp", jars, "com.raphtory.service.Partition"])
+
+def query():
+    if java_args:
+        subprocess.run([java, java_args, "-cp", jars, "com.raphtory.service.Query"])
+    else:
+        subprocess.run([java, "-cp", jars, "com.raphtory.service.Query"])
 
 def classpath():
     sys.stdout.write(jars)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Added python commands to start Raphtory services when doing a remote deployment

### Why are the changes needed?
To start Raphtory services when doing a remote deployment

### Does this PR introduce any user-facing change? If yes is this documented?
Yes, documentation for full distributed deployment to follow

### How was this patch tested?
Build on distributed servers and commands used to start some services that were then connected to 

### Are there any further changes required?
How to deploy distributed serviced doc to follow