### PR TITLE
DEV-1453 / Fix disruptor taking different PojoEdge for the same edge

### DIFF
--- a/core/src/main/scala/com/raphtory/internals/storage/pojograph/PojoBasedPartition.scala
+++ b/core/src/main/scala/com/raphtory/internals/storage/pojograph/PojoBasedPartition.scala
@@ -42,8 +42,10 @@ private[raphtory] class PojoBasedPartition(graphID: String, partitionID: Int, co
 
       val edge = new PojoEdge(msgTime, index, srcId, dstId, initialValue = true)
       edge.setType(maybeType.map(_.name))
-      q.addAddEdgeReqToQueue(msgTime, index, srcId, srcId, dstId, properties, maybeType, LocalOutgoingEdge(edge))
-      q.addAddEdgeReqToQueue(msgTime, index, dstId, srcId, dstId, properties, maybeType, LocalIncomingEdge(edge))
+      synchronized { // This is to avoid using different PojoEdge for each of the vertices when this is called in parallel
+        q.addAddEdgeReqToQueue(msgTime, index, srcId, srcId, dstId, properties, maybeType, LocalOutgoingEdge(edge))
+        q.addAddEdgeReqToQueue(msgTime, index, dstId, srcId, dstId, properties, maybeType, LocalIncomingEdge(edge))
+      }
     }
     else
       q.addAddEdgeReqToQueue(msgTime, index, srcId, srcId, dstId, properties, maybeType, SelfLoop)


### PR DESCRIPTION
### What changes were proposed in this pull request?
We now synchronize the adding of the edge events for both vertices

### Why are the changes needed?
This is needed so both vertices take the same PojoEdge for storage. As this function is called in parallel and there is a chance of getting the PojoEdge from one event for the source vertex and a different PojoEdge from another event for the target vertex.

### Does this PR introduce any user-facing change? If yes is this documented?
No

### How was this patch tested?
regular tests and performance test on TwitterTest to confirm that there is no performance downgrade

### Are there any further changes required?
No
