### PR TITLE
easy way to get lib directory for scala extensions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ raphtory-ingestion = "pyraphtory._cli:ingestion"
 raphtory-partition = "pyraphtory._cli:partition"
 raphtory-query = "pyraphtory._cli:query"
 raphtory-classpath = "pyraphtory._cli:classpath"
+raphtory-include = "pyraphtory._cli:include"
 raphtory-version = "pyraphtory._cli:version"
 
 [project.optional-dependencies]

--- a/python/src/pyraphtory/_cli.py
+++ b/python/src/pyraphtory/_cli.py
@@ -1,7 +1,8 @@
-from pyraphtory._config import jars, java, java_args
+from pyraphtory._config import jars, java, java_args, get_local_lib
 from pyraphtory import __version__
 import subprocess
 import sys
+
 
 def standalone():
     if java_args:
@@ -9,11 +10,13 @@ def standalone():
     else:
         subprocess.run([java, "-cp", jars, "com.raphtory.service.Standalone"])
 
+
 def clustermanager():
     if java_args:
         subprocess.run([java, java_args, "-cp", jars, "com.raphtory.service.ClusterManager"])
     else:
         subprocess.run([java, "-cp", jars, "com.raphtory.service.ClusterManager"])
+
 
 def ingestion():
     if java_args:
@@ -21,11 +24,13 @@ def ingestion():
     else:
         subprocess.run([java, "-cp", jars, "com.raphtory.service.Ingestion"])
 
+
 def partition():
     if java_args:
         subprocess.run([java, java_args, "-cp", jars, "com.raphtory.service.Partition"])
     else:
         subprocess.run([java, "-cp", jars, "com.raphtory.service.Partition"])
+
 
 def query():
     if java_args:
@@ -33,12 +38,17 @@ def query():
     else:
         subprocess.run([java, "-cp", jars, "com.raphtory.service.Query"])
 
+
 def classpath():
     sys.stdout.write(jars)
 
 
 def version():
     sys.stdout.write(__version__)
+
+
+def include():
+    sys.stdout.write(str(get_local_lib()))
 
 
 if __name__ == "__main__":

--- a/python/src/pyraphtory/_config.py
+++ b/python/src/pyraphtory/_config.py
@@ -36,11 +36,15 @@ def get_local_jre_loc() -> Path:
         return jre
 
 
-def get_local_jar_path():
+def get_local_lib() -> Path:
     lib = files(pyraphtory) / "lib"
     if not isinstance(lib, Path):
         raise RuntimeError("Pyraphtory is not installed correctly, are you trying to import from a compressed file?")
+    return lib
 
+
+def get_local_jar_path():
+    lib = get_local_lib()
     return str(lib) + "/*"
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

added `raphtory-include` command which can be used to set up unmanaged jars with sbt

### Why are the changes needed?

more convenient than trying to mess with the class path format now that the layout is simplified

### Does this PR introduce any user-facing change? If yes is this documented?

We should document the scala package workflow

### How was this patch tested?

usual tests

### Are there any further changes required?

docs