### PR TITLE
fix csv format quote escaping

### DIFF
--- a/core/src/main/scala/com/raphtory/formats/CsvFormat.scala
+++ b/core/src/main/scala/com/raphtory/formats/CsvFormat.scala
@@ -44,15 +44,13 @@ case class CsvFormat(delimiter: String = ",", includeHeader: Boolean = true) ext
       private var currentLinePrefix: String       = _
       private val mapper                          = JsonMapper.builder().addModule(DefaultScalaModule).build()
 
-      private def ensureQuoted(str: String): String =
-        if (
-                (str.startsWith("\"") && str.endsWith("\""))
-                || (str.startsWith("'") && str.endsWith("'"))
-                || !str.contains(delimiter)
-        )
-          str
+      private def ensureQuoted(str: String): String = {
+        val needs_quoting = str.exists(s => delimiter.contains(s) || s == '\n' || s == '\r' || s == '"')
+        if (needs_quoting)
+          "\"" + str.replace("\"", "\"\"") + "\""
         else
-          "\"" + str + "\""
+          str
+      }
 
       private def csvValue(value: Any): String =
         value match {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Properly escape quotes and new lines in csv format

### Why are the changes needed?

Handle arbitrary input strings correctly when outputting to csv (especially important for json formatted data)

### Does this PR introduce any user-facing change? If yes is this documented?

no

### How was this patch tested?


### Are there any further changes required?

no